### PR TITLE
feat(surfaces): add SlackThreadGate for agent-in-Slack gating

### DIFF
--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/surfaces",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Surface connection registry, inbound normalization, and outbound dispatch for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/surfaces",
-  "version": "0.2.0",
+  "version": "0.1.5",
   "description": "Surface connection registry, inbound normalization, and outbound dispatch for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -22,3 +22,13 @@ export type {
   SurfaceState,
   SurfaceType,
 } from './types.js';
+
+export { SlackThreadGate } from "./slack-thread-gate.js";
+export type {
+  ActiveThreadContext,
+  ActiveThreadStore,
+  SlackThreadGateOptions,
+  ThreadGateDecision,
+  ThreadGateDropReason,
+  ThreadGateEvent,
+} from "./slack-thread-gate.js";

--- a/packages/surfaces/src/slack-thread-gate.test.ts
+++ b/packages/surfaces/src/slack-thread-gate.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  SlackThreadGate,
+  type ActiveThreadStore,
+  type ActiveThreadContext,
+} from "./slack-thread-gate.js";
+
+function createFakeStore() {
+  const entries = new Map<string, { ctx: ActiveThreadContext; ttl: number }>();
+  const store: ActiveThreadStore = {
+    async isActive(ts) {
+      return entries.has(ts);
+    },
+    async markActive(ts, ctx, ttl) {
+      entries.set(ts, { ctx, ttl });
+    },
+  };
+  return { store, entries };
+}
+
+describe("SlackThreadGate.shouldProcess", () => {
+  it("allows mention events regardless of store state", async () => {
+    const { store } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    const decision = await gate.shouldProcess({
+      type: "mention",
+      channel: "C1",
+      ts: "100.1",
+    });
+    expect(decision.proceed).toBe(true);
+    expect(decision.reason).toBeUndefined();
+  });
+
+  it("drops message events with threadTs when the thread is inactive", async () => {
+    const { store } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    const decision = await gate.shouldProcess({
+      type: "message",
+      channel: "C1",
+      threadTs: "100.1",
+      ts: "100.2",
+    });
+    expect(decision.proceed).toBe(false);
+    expect(decision.reason).toBe("inactive-thread");
+  });
+
+  it("allows message events with threadTs when the thread is active", async () => {
+    const { store, entries } = createFakeStore();
+    await store.markActive("100.1", { workspaceId: "W1", channel: "C1" }, 60);
+    expect(entries.has("100.1")).toBe(true);
+    const gate = new SlackThreadGate({ store });
+    const decision = await gate.shouldProcess({
+      type: "message",
+      channel: "C1",
+      threadTs: "100.1",
+      ts: "100.2",
+    });
+    expect(decision.proceed).toBe(true);
+  });
+
+  it("allows message events without threadTs (top-level channel messages)", async () => {
+    const { store } = createFakeStore();
+    let reads = 0;
+    const trackingStore: ActiveThreadStore = {
+      async isActive(ts) {
+        reads += 1;
+        return store.isActive(ts);
+      },
+      markActive: store.markActive.bind(store),
+    };
+    const gate = new SlackThreadGate({ store: trackingStore });
+    const decision = await gate.shouldProcess({
+      type: "message",
+      channel: "C1",
+      ts: "100.1",
+    });
+    expect(decision.proceed).toBe(true);
+    expect(reads).toBe(0);
+  });
+});
+
+describe("SlackThreadGate.onEngaged", () => {
+  it("marks event.threadTs active when mention occurs inside an existing thread", async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    await gate.onEngaged(
+      { type: "mention", channel: "C1", threadTs: "t-parent", ts: "t-new" },
+      "W1",
+    );
+    expect(entries.has("t-parent")).toBe(true);
+    expect(entries.has("t-new")).toBe(false);
+  });
+
+  it("marks event.ts active when mention occurs at top level (no threadTs)", async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    await gate.onEngaged(
+      { type: "mention", channel: "C1", ts: "t-top" },
+      "W1",
+    );
+    expect(entries.has("t-top")).toBe(true);
+  });
+
+  it("is a no-op for message events", async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    await gate.onEngaged(
+      { type: "message", channel: "C1", threadTs: "t1", ts: "t2" },
+      "W1",
+    );
+    expect(entries.size).toBe(0);
+  });
+
+  it("is a no-op when a mention has neither threadTs nor ts", async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    await gate.onEngaged({ type: "mention", channel: "C1" }, "W1");
+    expect(entries.size).toBe(0);
+  });
+});
+
+describe("SlackThreadGate.refresh", () => {
+  it("calls markActive with the caller-provided context and configured ttlSeconds", async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackThreadGate({ store, ttlSeconds: 3600 });
+    const ctx: ActiveThreadContext = { workspaceId: "W1", channel: "C1" };
+    await gate.refresh("t1", ctx);
+    const entry = entries.get("t1");
+    expect(entry?.ttl).toBe(3600);
+    expect(entry?.ctx).toEqual(ctx);
+  });
+});

--- a/packages/surfaces/src/slack-thread-gate.ts
+++ b/packages/surfaces/src/slack-thread-gate.ts
@@ -1,0 +1,79 @@
+/**
+ * SlackThreadGate — decides whether an agent should respond to an inbound Slack event.
+ *
+ * Rules:
+ *   1. @-mentions always proceed, and the thread is marked active so follow-up replies
+ *      in the same thread are also processed.
+ *   2. Thread replies (non-mention message events with a thread_ts) only proceed if
+ *      the thread was previously engaged by a mention. Otherwise they are dropped.
+ *   3. Non-thread message events (no thread_ts) proceed — callers may gate further.
+ *
+ * The store is caller-supplied (Cloudflare KV, Redis, in-memory, etc.) so the gate is
+ * runtime-agnostic. Every Slack-surfaced agent should use this instead of inlining the
+ * same KV reads/writes in its webhook handler.
+ */
+
+export interface ActiveThreadContext {
+  workspaceId: string;
+  channel: string;
+}
+
+export interface ActiveThreadStore {
+  isActive(threadTs: string): Promise<boolean>;
+  markActive(threadTs: string, ctx: ActiveThreadContext, ttlSeconds: number): Promise<void>;
+}
+
+export interface ThreadGateEvent {
+  type: "mention" | "message" | string;
+  channel: string;
+  threadTs?: string;
+  ts?: string;
+}
+
+export type ThreadGateDropReason = "inactive-thread";
+
+export interface ThreadGateDecision {
+  proceed: boolean;
+  reason?: ThreadGateDropReason;
+}
+
+export interface SlackThreadGateOptions {
+  store: ActiveThreadStore;
+  /** Active-thread TTL. Defaults to 86_400 (24h). */
+  ttlSeconds?: number;
+}
+
+export class SlackThreadGate {
+  private readonly store: ActiveThreadStore;
+  private readonly ttlSeconds: number;
+
+  constructor(options: SlackThreadGateOptions) {
+    this.store = options.store;
+    this.ttlSeconds = options.ttlSeconds ?? 86_400;
+  }
+
+  async shouldProcess(event: ThreadGateEvent): Promise<ThreadGateDecision> {
+    if (event.type === "message" && event.threadTs) {
+      const active = await this.store.isActive(event.threadTs);
+      if (!active) {
+        return { proceed: false, reason: "inactive-thread" };
+      }
+    }
+    return { proceed: true };
+  }
+
+  async onEngaged(event: ThreadGateEvent, workspaceId: string): Promise<void> {
+    if (event.type !== "mention") return;
+    const threadTs = event.threadTs ?? event.ts;
+    if (!threadTs) return;
+    await this.store.markActive(
+      threadTs,
+      { workspaceId, channel: event.channel },
+      this.ttlSeconds,
+    );
+  }
+
+  async refresh(threadTs: string, ctx: ActiveThreadContext): Promise<void> {
+    await this.store.markActive(threadTs, ctx, this.ttlSeconds);
+  }
+}


### PR DESCRIPTION
## Summary
Adds a reusable `SlackThreadGate` class to `@agent-assistant/surfaces` that encapsulates the "should this agent respond to this Slack event?" decision. Replaces inline KV reads/writes that every Sage-like assistant in Slack will otherwise re-implement.

### Rules enforced
1. `@`-mentions always proceed, and the thread is marked active so follow-up replies in the same thread are also processed.
2. Thread replies (non-mention message events with `thread_ts`) only proceed if the thread was previously engaged by a mention. Otherwise dropped.
3. Non-thread message events proceed — callers may gate further on their own surface.

### API
- `new SlackThreadGate({ store, ttlSeconds? })`
- `gate.shouldProcess(event)` → `{ proceed, reason? }`
- `gate.onEngaged(event, workspaceId)` — call on mention events before dispatch
- `gate.refresh(threadTs, ctx)` — call after posting a reply to refresh TTL

The store is caller-supplied, so the gate is runtime-agnostic (Cloudflare KV, Redis, in-memory, etc.).

Bumps `@agent-assistant/surfaces` to **0.2.0**.

## Why this package
The thread-gate is agent-communication policy, not Slack data ingestion. `@agent-assistant/surfaces` already owns `SurfaceAdapter` / `NormalizedInboundMessage` — the agent-side abstraction for how agents talk on Slack/Discord/CLI. `@relayfile/adapter-slack` is the wrong layer because it's about normalizing Slack data into Relayfile objects, not agent response policy.

## Follow-up
Sage side refactor (draft PR opened by the same workflow run) is blocked on this merging and publishing `@agent-assistant/surfaces@0.2.0`.

## Test plan
- [x] `npx vitest run` in `packages/surfaces` — new tests cover 9 cases
- [x] `npm run build` in `packages/surfaces`

🤖 Generated by sage workflow `v2/50-abstract-slack-thread-gate.ts`
PRBODY && gh pr view feat/slack-thread-gate --json url --jq .url > /tmp/aa-pr-url.txt && cat /tmp/aa-pr-url.txt

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
