### PR TITLE
fix(surfaces): scope SlackThreadGate by workspace+channel composite key

### DIFF
--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -26,6 +26,7 @@ export type {
 export { SlackThreadGate } from "./slack-thread-gate.js";
 export type {
   ActiveThreadContext,
+  ActiveThreadKey,
   ActiveThreadStore,
   SlackThreadGateOptions,
   ThreadGateDecision,

--- a/packages/surfaces/src/slack-thread-gate.test.ts
+++ b/packages/surfaces/src/slack-thread-gate.test.ts
@@ -2,18 +2,22 @@ import { describe, it, expect } from "vitest";
 
 import {
   SlackThreadGate,
+  type ActiveThreadKey,
   type ActiveThreadStore,
-  type ActiveThreadContext,
 } from "./slack-thread-gate.js";
 
+function keyString(key: ActiveThreadKey): string {
+  return `${key.workspaceId}:${key.channel}:${key.threadTs}`;
+}
+
 function createFakeStore() {
-  const entries = new Map<string, { ctx: ActiveThreadContext; ttl: number }>();
+  const entries = new Map<string, { key: ActiveThreadKey; ttl: number }>();
   const store: ActiveThreadStore = {
-    async isActive(ts) {
-      return entries.has(ts);
+    async isActive(key) {
+      return entries.has(keyString(key));
     },
-    async markActive(ts, ctx, ttl) {
-      entries.set(ts, { ctx, ttl });
+    async markActive(key, ttl) {
+      entries.set(keyString(key), { key, ttl });
     },
   };
   return { store, entries };
@@ -23,11 +27,10 @@ describe("SlackThreadGate.shouldProcess", () => {
   it("allows mention events regardless of store state", async () => {
     const { store } = createFakeStore();
     const gate = new SlackThreadGate({ store });
-    const decision = await gate.shouldProcess({
-      type: "mention",
-      channel: "C1",
-      ts: "100.1",
-    });
+    const decision = await gate.shouldProcess(
+      { type: "mention", channel: "C1", ts: "100.1" },
+      "W1",
+    );
     expect(decision.proceed).toBe(true);
     expect(decision.reason).toBeUndefined();
   });
@@ -35,27 +38,26 @@ describe("SlackThreadGate.shouldProcess", () => {
   it("drops message events with threadTs when the thread is inactive", async () => {
     const { store } = createFakeStore();
     const gate = new SlackThreadGate({ store });
-    const decision = await gate.shouldProcess({
-      type: "message",
-      channel: "C1",
-      threadTs: "100.1",
-      ts: "100.2",
-    });
+    const decision = await gate.shouldProcess(
+      { type: "message", channel: "C1", threadTs: "100.1", ts: "100.2" },
+      "W1",
+    );
     expect(decision.proceed).toBe(false);
     expect(decision.reason).toBe("inactive-thread");
   });
 
   it("allows message events with threadTs when the thread is active", async () => {
     const { store, entries } = createFakeStore();
-    await store.markActive("100.1", { workspaceId: "W1", channel: "C1" }, 60);
-    expect(entries.has("100.1")).toBe(true);
+    await store.markActive(
+      { workspaceId: "W1", channel: "C1", threadTs: "100.1" },
+      60,
+    );
+    expect(entries.size).toBe(1);
     const gate = new SlackThreadGate({ store });
-    const decision = await gate.shouldProcess({
-      type: "message",
-      channel: "C1",
-      threadTs: "100.1",
-      ts: "100.2",
-    });
+    const decision = await gate.shouldProcess(
+      { type: "message", channel: "C1", threadTs: "100.1", ts: "100.2" },
+      "W1",
+    );
     expect(decision.proceed).toBe(true);
   });
 
@@ -63,20 +65,51 @@ describe("SlackThreadGate.shouldProcess", () => {
     const { store } = createFakeStore();
     let reads = 0;
     const trackingStore: ActiveThreadStore = {
-      async isActive(ts) {
+      async isActive(key) {
         reads += 1;
-        return store.isActive(ts);
+        return store.isActive(key);
       },
       markActive: store.markActive.bind(store),
     };
     const gate = new SlackThreadGate({ store: trackingStore });
-    const decision = await gate.shouldProcess({
-      type: "message",
-      channel: "C1",
-      ts: "100.1",
-    });
+    const decision = await gate.shouldProcess(
+      { type: "message", channel: "C1", ts: "100.1" },
+      "W1",
+    );
     expect(decision.proceed).toBe(true);
     expect(reads).toBe(0);
+  });
+
+  it("scopes active threads by workspaceId (regression: cross-workspace ts collision)", async () => {
+    const { store } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    // W1 engages a thread at ts 100.1
+    await gate.onEngaged(
+      { type: "mention", channel: "C1", ts: "100.1" },
+      "W1",
+    );
+    // W2 sees a reply on a thread with the same ts 100.1 in the same-named channel
+    const decision = await gate.shouldProcess(
+      { type: "message", channel: "C1", threadTs: "100.1", ts: "100.2" },
+      "W2",
+    );
+    expect(decision.proceed).toBe(false);
+    expect(decision.reason).toBe("inactive-thread");
+  });
+
+  it("scopes active threads by channel (regression: cross-channel ts collision)", async () => {
+    const { store } = createFakeStore();
+    const gate = new SlackThreadGate({ store });
+    await gate.onEngaged(
+      { type: "mention", channel: "C1", ts: "100.1" },
+      "W1",
+    );
+    const decision = await gate.shouldProcess(
+      { type: "message", channel: "C2", threadTs: "100.1", ts: "100.2" },
+      "W1",
+    );
+    expect(decision.proceed).toBe(false);
+    expect(decision.reason).toBe("inactive-thread");
   });
 });
 
@@ -88,8 +121,8 @@ describe("SlackThreadGate.onEngaged", () => {
       { type: "mention", channel: "C1", threadTs: "t-parent", ts: "t-new" },
       "W1",
     );
-    expect(entries.has("t-parent")).toBe(true);
-    expect(entries.has("t-new")).toBe(false);
+    expect(entries.has("W1:C1:t-parent")).toBe(true);
+    expect(entries.has("W1:C1:t-new")).toBe(false);
   });
 
   it("marks event.ts active when mention occurs at top level (no threadTs)", async () => {
@@ -99,7 +132,7 @@ describe("SlackThreadGate.onEngaged", () => {
       { type: "mention", channel: "C1", ts: "t-top" },
       "W1",
     );
-    expect(entries.has("t-top")).toBe(true);
+    expect(entries.has("W1:C1:t-top")).toBe(true);
   });
 
   it("is a no-op for message events", async () => {
@@ -121,13 +154,17 @@ describe("SlackThreadGate.onEngaged", () => {
 });
 
 describe("SlackThreadGate.refresh", () => {
-  it("calls markActive with the caller-provided context and configured ttlSeconds", async () => {
+  it("calls markActive with the full composite key and configured ttlSeconds", async () => {
     const { store, entries } = createFakeStore();
     const gate = new SlackThreadGate({ store, ttlSeconds: 3600 });
-    const ctx: ActiveThreadContext = { workspaceId: "W1", channel: "C1" };
-    await gate.refresh("t1", ctx);
-    const entry = entries.get("t1");
+    const key: ActiveThreadKey = {
+      workspaceId: "W1",
+      channel: "C1",
+      threadTs: "t1",
+    };
+    await gate.refresh(key);
+    const entry = entries.get("W1:C1:t1");
     expect(entry?.ttl).toBe(3600);
-    expect(entry?.ctx).toEqual(ctx);
+    expect(entry?.key).toEqual(key);
   });
 });

--- a/packages/surfaces/src/slack-thread-gate.ts
+++ b/packages/surfaces/src/slack-thread-gate.ts
@@ -8,9 +8,12 @@
  *      the thread was previously engaged by a mention. Otherwise they are dropped.
  *   3. Non-thread message events (no thread_ts) proceed — callers may gate further.
  *
- * The store is caller-supplied (Cloudflare KV, Redis, in-memory, etc.) so the gate is
- * runtime-agnostic. Every Slack-surfaced agent should use this instead of inlining the
- * same KV reads/writes in its webhook handler.
+ * Active-thread state is keyed by the composite {workspaceId, channel, threadTs}.
+ * Slack's `thread_ts` is only unique within a channel — across workspaces or channels
+ * a bare-ts lookup would let a mention in one channel unlock unrelated threads in
+ * another. The store is caller-supplied (Cloudflare KV, Redis, in-memory, etc.) so
+ * the gate is runtime-agnostic; callers join the key fields into their native key
+ * format (e.g. `${workspaceId}:${channel}:${threadTs}`).
  */
 
 export interface ActiveThreadContext {
@@ -18,9 +21,13 @@ export interface ActiveThreadContext {
   channel: string;
 }
 
+export interface ActiveThreadKey extends ActiveThreadContext {
+  threadTs: string;
+}
+
 export interface ActiveThreadStore {
-  isActive(threadTs: string): Promise<boolean>;
-  markActive(threadTs: string, ctx: ActiveThreadContext, ttlSeconds: number): Promise<void>;
+  isActive(key: ActiveThreadKey): Promise<boolean>;
+  markActive(key: ActiveThreadKey, ttlSeconds: number): Promise<void>;
 }
 
 export interface ThreadGateEvent {
@@ -52,9 +59,16 @@ export class SlackThreadGate {
     this.ttlSeconds = options.ttlSeconds ?? 86_400;
   }
 
-  async shouldProcess(event: ThreadGateEvent): Promise<ThreadGateDecision> {
+  async shouldProcess(
+    event: ThreadGateEvent,
+    workspaceId: string,
+  ): Promise<ThreadGateDecision> {
     if (event.type === "message" && event.threadTs) {
-      const active = await this.store.isActive(event.threadTs);
+      const active = await this.store.isActive({
+        workspaceId,
+        channel: event.channel,
+        threadTs: event.threadTs,
+      });
       if (!active) {
         return { proceed: false, reason: "inactive-thread" };
       }
@@ -67,13 +81,12 @@ export class SlackThreadGate {
     const threadTs = event.threadTs ?? event.ts;
     if (!threadTs) return;
     await this.store.markActive(
-      threadTs,
-      { workspaceId, channel: event.channel },
+      { workspaceId, channel: event.channel, threadTs },
       this.ttlSeconds,
     );
   }
 
-  async refresh(threadTs: string, ctx: ActiveThreadContext): Promise<void> {
-    await this.store.markActive(threadTs, ctx, this.ttlSeconds);
+  async refresh(key: ActiveThreadKey): Promise<void> {
+    await this.store.markActive(key, this.ttlSeconds);
   }
 }


### PR DESCRIPTION
## Summary
Follow-up to #3 (merged). Addresses Codex's P2 review finding on that PR: `SlackThreadGate.shouldProcess` was keying active-thread state on `threadTs` alone, so a mention in one Slack workspace/channel could unintentionally unlock processing for an unrelated thread in another workspace/channel that happened to have the same timestamp string. Slack's `thread_ts` is only unique within a channel.

## Changes
- New `ActiveThreadKey` type: `{ workspaceId, channel, threadTs }`.
- `ActiveThreadStore.isActive` / `markActive` now take the composite key. Callers join the fields into their native key format (e.g. `` `${workspaceId}:${channel}:${threadTs}` `` for Cloudflare KV).
- `shouldProcess(event, workspaceId)` — workspaceId is now a required second argument so the lookup is scoped.
- `refresh(key)` — takes the full composite key instead of a bare threadTs + context.
- `onEngaged` signature unchanged (it already received workspaceId).
- Exported `ActiveThreadKey` from `packages/surfaces/src/index.ts`.

## Regression tests
Added two explicit regression tests:
- **cross-workspace ts collision** — W1 engages ts `100.1` in C1; a reply arriving in W2's C1 with the same thread_ts must NOT proceed.
- **cross-channel ts collision** — W1 engages ts `100.1` in C1; a reply in W1's C2 with the same thread_ts must NOT proceed.

Full suite: 11 `slack-thread-gate.test.ts` tests passing (up from 9 on #3).

## Breaking change
This is a breaking change to the `@agent-assistant/surfaces` public API — `shouldProcess` requires workspaceId and the store interface takes a composite key. No published callers exist yet; the sage-side refactor (still a draft) will adopt the new shape.

## Test plan
- [x] `npx vitest run` in `packages/surfaces` — 39 tests pass (28 existing + 11 gate)
- [x] `npm run build` in `packages/surfaces` — clean tsc
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
