### PR TITLE
ci: build connectivity + coordination before running harness tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,26 @@ jobs:
         working-directory: packages/surfaces
         run: npx vitest run
 
-      # harness pulls @agent-assistant/connectivity and @agent-assistant/coordination
-      # via workspace file: links. Their dists are not committed, so vitest fails
-      # to resolve the entry point until we build them here. Dependency order:
-      # connectivity (leaf) → coordination (needs connectivity) → harness tests.
+      # Harness depends on traits, connectivity, coordination, and turn-context via
+      # workspace file: links. None of those dists (except turn-context's, which is
+      # stale and references a `memory-retriever.js` that isn't in the committed
+      # dist) are ready for vitest on a fresh checkout. Build them in dependency
+      # order before running harness tests.
+      #
+      # Chain:
+      #   traits        — leaf (no workspace deps)
+      #   memory        — leaf (no workspace deps); needed by turn-context type imports
+      #   connectivity  — leaf (no workspace deps)
+      #   coordination  — needs connectivity
+      #   turn-context  — needs memory + traits (type-only); rebuilt to refresh stale dist
+      - name: Build — traits (harness dep)
+        working-directory: packages/traits
+        run: npm run build
+
+      - name: Build — memory (turn-context dep)
+        working-directory: packages/memory
+        run: npm run build
+
       - name: Build — connectivity (harness dep)
         working-directory: packages/connectivity
         run: npm run build
@@ -52,6 +68,12 @@ jobs:
       - name: Build — coordination (harness dep)
         working-directory: packages/coordination
         run: npm run build
+
+      - name: Rebuild — turn-context (committed dist is stale)
+        working-directory: packages/turn-context
+        run: |
+          rm -rf dist
+          npm run build
 
       - name: Run tests — harness
         working-directory: packages/harness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,22 @@ jobs:
         working-directory: packages/surfaces
         run: npx vitest run
 
+      # harness pulls @agent-assistant/connectivity and @agent-assistant/coordination
+      # via workspace file: links. Their dists are not committed, so vitest fails
+      # to resolve the entry point until we build them here. Dependency order:
+      # connectivity (leaf) → coordination (needs connectivity) → harness tests.
+      - name: Build — connectivity (harness dep)
+        working-directory: packages/connectivity
+        run: npm run build
+
+      - name: Build — coordination (harness dep)
+        working-directory: packages/coordination
+        run: npm run build
+
+      - name: Run tests — harness
+        working-directory: packages/harness
+        run: npx vitest run
+
       # Build/typecheck in dependency order so downstream workspace imports resolve
       - name: Build — traits
         working-directory: packages/traits


### PR DESCRIPTION
## Summary
Fixes the failing harness test run and adds harness to CI so this regression is caught in the future.

## Root cause
\`packages/harness\` imports \`@agent-assistant/connectivity\` and \`@agent-assistant/coordination\` via workspace \`file:\` links. Neither package has a committed \`dist/\`, and CI never builds them before running harness tests, so a fresh checkout hits:

\`\`\`
Failed to resolve entry for package "@agent-assistant/connectivity".
The package may have incorrect main/module/exports specified in its package.json.
\`\`\`

This was masked locally because prior builds leave \`dist/\` populated. It only surfaces on fresh CI runners.

## Reproduction (local)
\`\`\`bash
git worktree add -b repro .claude/worktrees/repro origin/main
cd .claude/worktrees/repro
npm ci
cd packages/harness
npx vitest run
# → Failed to resolve entry for package "@agent-assistant/connectivity"
\`\`\`

## Fix
In \`.github/workflows/ci.yml\`, after the existing \`Run tests — surfaces\` step:
1. Build \`connectivity\` (leaf — no agent-assistant workspace deps)
2. Build \`coordination\` (depends on connectivity)
3. Run \`harness\` tests

Dependency order is explicit in the job so a future reader understands why this block exists.

## Verification
Reproduced the failure on a fresh worktree, applied the fix, re-ran:
\`\`\`
Test Files  3 passed (3)
     Tests  32 passed (32)
\`\`\`
(9 claude-code-adapter + 14 harness + 9 byoh-local-proof)

## Follow-ups (not in this PR)
- Consider committing \`packages/connectivity/dist\` and \`packages/coordination/dist\` to match harness/turn-context (which are committed), OR removing the committed dists from harness/turn-context for consistency. Picking one convention would eliminate this class of bug entirely.

## Test plan
- [x] Reproduce failure on fresh checkout of origin/main
- [x] Apply fix, re-run harness tests → all 32 pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
