### PR TITLE
ci(publish): build harness deps before running tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,6 +125,24 @@ jobs:
           echo "Publishing Agent Assistant package group: ${{ github.event.inputs.package_group }}"
           echo "Packages: ${{ needs.resolve-packages.outputs.package_list }}"
 
+      # Harness tests import from @agent-assistant/{traits,connectivity,
+      # coordination,turn-context}, several of which are file: workspace deps
+      # with stale or missing committed dists. Build the chain before running
+      # vitest so its resolver can find each package's dist/. Mirrors
+      # .github/workflows/ci.yml. Note: connectivity + coordination are not
+      # in the publish matrix, so the dependency-aware Build step below does
+      # not cover them.
+      - name: Prepare harness test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run build -w @agent-assistant/traits
+          npm run build -w @agent-assistant/memory
+          npm run build -w @agent-assistant/connectivity
+          npm run build -w @agent-assistant/coordination
+          rm -rf packages/turn-context/dist
+          npm run build -w @agent-assistant/turn-context
+
       - name: Run tests
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- The publish workflow runs `npm test -w @agent-assistant/harness` before its dependency-aware build step, so harness's vitest can't resolve its workspace deps and `@agent-assistant/surfaces@0.2.0` is blocked from publishing.
- Adds a "Prepare harness test dependencies" step that mirrors `.github/workflows/ci.yml`: builds traits, memory, connectivity, coordination, and rebuilds turn-context (stale committed dist).
- Connectivity and coordination are not in the publish matrix at all, so the later dependency-aware build step does not cover them.

## Test plan
- [x] Ran the exact prep chain locally in a fresh worktree
- [x] `npm test -w @agent-assistant/harness` passes (32/32)
- [ ] CI on this PR stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
