### PR TITLE
ci(publish): add @agent-assistant/inbox to publish matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           case "${{ github.event.inputs.package_group }}" in
             runtime-core)
-              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","continuation","sdk"]'
+              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk"]'
               FIRST='traits'
               ;;
             *)
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context continuation sdk)
+          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk)
           for pkg in "${ORDER[@]}"; do
             if echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -e --arg pkg "$pkg" '.[] | select(. == $pkg)' >/dev/null; then
               echo "==> Building $pkg"


### PR DESCRIPTION
## Summary
- `@agent-assistant/sdk` imports from `@agent-assistant/inbox`, but inbox was never added to the `runtime-core` publish matrix or the dependency-aware build ORDER. On a fresh publish run, sdk's `tsc` build fails:
  ```
  src/index.ts(104,8): error TS2307: Cannot find module '@agent-assistant/inbox'
  ```
- Add `inbox` to both:
  - the `runtime-core` matrix (so it gets built, versioned, and published alongside the other runtime-core packages)
  - the `ORDER` array, positioned between `turn-context` and `continuation` (inbox depends on turn-context; sdk depends on inbox)

## Test plan
- [x] Ran the full build chain locally in dependency order — all 12 packages build clean including `sdk`
- [ ] Trigger the `Publish Packages` workflow (dry-run first) to confirm end-to-end

## Version note
`@agent-assistant/inbox` is currently `0.1.0`. The publish workflow syncs every matrix package to the new version, so this PR will cause inbox to bump alongside the rest of runtime-core on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
