### PR TITLE
ci: build vfs before publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
         working-directory: packages/surfaces
         run: npx vitest run
 
+      - name: Run tests — vfs
+        working-directory: packages/vfs
+        run: npx vitest run
+
       # Harness depends on traits, connectivity, coordination, and turn-context via
       # workspace file: links. None of those dists (except turn-context's, which is
       # stale and references a `memory-retriever.js` that isn't in the committed
@@ -112,10 +116,18 @@ jobs:
         working-directory: packages/surfaces
         run: npx tsc --noEmit -p tsconfig.json
 
+      - name: Build — vfs
+        working-directory: packages/vfs
+        run: npm run build
+
+      - name: Typecheck — vfs
+        working-directory: packages/vfs
+        run: npx tsc --noEmit -p tsconfig.json
+
       - name: Verify no test artifacts in dist
         run: |
           FAIL=0
-          for pkg in traits core sessions surfaces; do
+          for pkg in traits core sessions surfaces vfs; do
             if find "packages/$pkg/dist" -name '*.test.*' 2>/dev/null | grep -q .; then
               echo "ERROR: test artifacts found in packages/$pkg/dist/"
               find "packages/$pkg/dist" -name '*.test.*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           case "${{ github.event.inputs.package_group }}" in
             runtime-core)
-              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk", "vfs"]'
+              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk","vfs"]'
               FIRST='traits'
               ;;
             *)
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk)
+          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs)
           for pkg in "${ORDER[@]}"; do
             if echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -e --arg pkg "$pkg" '.[] | select(. == $pkg)' >/dev/null; then
               echo "==> Building $pkg"

--- a/.trajectories/completed/2026-04/traj_z976eyovjwme.json
+++ b/.trajectories/completed/2026-04/traj_z976eyovjwme.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_z976eyovjwme",
+  "version": 1,
+  "task": {
+    "title": "Fix agent-assistant VFS publish build"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-17T12:11:46.926Z",
+  "completedAt": "2026-04-17T12:12:54.010Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-17T12:12:06.154Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ig9zigln1cs2",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-17T12:12:06.154Z",
+      "endedAt": "2026-04-17T12:12:54.010Z",
+      "events": [
+        {
+          "ts": 1776427926155,
+          "type": "decision",
+          "content": "Build VFS in publish workflow: Build VFS in publish workflow",
+          "raw": {
+            "question": "Build VFS in publish workflow",
+            "chosen": "Build VFS in publish workflow",
+            "alternatives": [],
+            "reasoning": "The runtime-core publish matrix included vfs, but the dependency-aware build order omitted it, so artifact upload tried to copy packages/vfs/dist before it existed."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed agent-assistant publish workflow so the VFS package is built before publish artifacts are copied, and added VFS to CI validation.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": [],
+  "_trace": {
+    "startRef": "b20ee7d600a68f943f60d86863a07b64c5004e37",
+    "endRef": "b20ee7d600a68f943f60d86863a07b64c5004e37"
+  }
+}

--- a/.trajectories/completed/2026-04/traj_z976eyovjwme.md
+++ b/.trajectories/completed/2026-04/traj_z976eyovjwme.md
@@ -1,0 +1,31 @@
+# Trajectory: Fix agent-assistant VFS publish build
+
+> **Status:** ✅ Completed
+> **Confidence:** 93%
+> **Started:** April 17, 2026 at 02:11 PM
+> **Completed:** April 17, 2026 at 02:12 PM
+
+---
+
+## Summary
+
+Fixed agent-assistant publish workflow so the VFS package is built before publish artifacts are copied, and added VFS to CI validation.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Build VFS in publish workflow
+- **Chose:** Build VFS in publish workflow
+- **Reasoning:** The runtime-core publish matrix included vfs, but the dependency-aware build order omitted it, so artifact upload tried to copy packages/vfs/dist before it existed.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Build VFS in publish workflow: Build VFS in publish workflow

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-17T11:34:41.242Z",
+  "lastUpdated": "2026-04-17T12:12:54.115Z",
   "trajectories": {
     "traj_1775887868833_95cb9380": {
       "title": "relay-agent-assistant-connectivity-spike-workflow",
@@ -267,6 +267,13 @@
       "startedAt": "2026-04-17T11:24:14.375Z",
       "completedAt": "2026-04-17T11:34:41.147Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/completed/2026-04/traj_5vovw7tpi074.json"
+    },
+    "traj_z976eyovjwme": {
+      "title": "Fix agent-assistant VFS publish build",
+      "status": "completed",
+      "startedAt": "2026-04-17T12:11:46.926Z",
+      "completedAt": "2026-04-17T12:12:54.010Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/completed/2026-04/traj_z976eyovjwme.json"
     }
   }
 }


### PR DESCRIPTION
## Summary
- include `vfs` in the publish workflow dependency-aware build order
- normalize the runtime-core matrix entry for `vfs`
- add VFS package tests/build/typecheck/dist-artifact validation to CI

## Validation
- `npm test -w @agent-assistant/vfs`
- `npm run typecheck -w @agent-assistant/vfs`
- `rm -rf packages/vfs/dist && npm run build -w @agent-assistant/vfs && test -d packages/vfs/dist && test -f packages/vfs/dist/index.js`
- simulated runtime-core publish build order and copied `packages/vfs/dist` to `/tmp/agent-assistant-publish-artifacts-test/dist-vfs`

Fixes the publish failure:
```
cp: cannot stat 'packages/vfs/dist': No such file or directory\n```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
