### PR TITLE
feat(harness): add OpenRouter execution adapter slice

### DIFF
--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -87,12 +87,112 @@ const result = await harness.runTurn({
 });
 ```
 
+## OpenRouter execution adapter
+
+The harness package now also exposes a bounded hosted execution adapter for OpenRouter-backed turns.
+
+### What it is
+
+The `OpenRouterExecutionAdapter` is a direct hosted backend behind the existing `ExecutionAdapter` seam.
+
+This means Agent Assistant still owns:
+- assistant identity
+- turn-context assembly
+- policy
+- continuation semantics
+- Relay-native collaboration
+
+The adapter only owns:
+- request translation
+- backend invocation
+- output normalization
+- truthful capability/degradation reporting
+
+### Current scope
+
+This adapter is intentionally narrow in the current slice:
+- backend id: `openrouter-api`
+- direct hosted API execution
+- no-tool turns only
+- minimal trace facts
+- truthful `unsupported` / degraded negotiation
+
+### Current non-goals
+
+This adapter does **not** currently support:
+- tool-bearing execution
+- structured tool calls
+- attachments
+- structured continuation support
+- approval interrupts
+
+### Example
+
+```ts
+import {
+  OpenRouterExecutionAdapter,
+  type ExecutionRequest,
+} from '@agent-assistant/harness';
+
+const adapter = new OpenRouterExecutionAdapter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  model: 'openai/gpt-5-mini',
+});
+
+const request: ExecutionRequest = {
+  assistantId: 'sage',
+  turnId: 'turn-456',
+  message: {
+    id: 'msg-2',
+    text: 'Summarize the current PR status.',
+    receivedAt: new Date().toISOString(),
+  },
+  instructions: {
+    systemPrompt: 'You are Sage. Be concise and truthful.',
+    developerPrompt: 'Do not invent missing GitHub state.',
+  },
+  context: {
+    blocks: [
+      {
+        id: 'ctx-1',
+        label: 'Scope',
+        text: 'Only summarize what is present in the supplied context.',
+      },
+    ],
+  },
+};
+
+const negotiation = adapter.negotiate(request);
+if (!negotiation.supported) {
+  throw new Error(negotiation.reasons.map((reason) => reason.message).join(' '));
+}
+
+const result = await adapter.execute(request);
+```
+
+### Honest usage guidance
+
+Use this adapter when you want:
+- a hosted API backend
+- one bounded no-tool turn
+- normalized `ExecutionResult` output through the same execution seam as other backends
+
+Do **not** treat it as a replacement for:
+- the local CLI harness BYOH path
+- Relay-native collaboration
+- future tool-capable hosted execution work
+
 ## Public API
 
 ```ts
 import {
   HarnessConfigError,
+  OpenRouterExecutionAdapter,
   createHarness,
+  createOpenRouterAdapter,
+  type ExecutionAdapter,
+  type ExecutionRequest,
+  type ExecutionResult,
   type HarnessConfig,
   type HarnessContinuation,
   type HarnessModelAdapter,
@@ -129,5 +229,6 @@ Current package validation includes a non-trivial test suite covering:
 - retryable vs unrecoverable tool errors
 - deferred outcomes for iteration and budget ceilings
 - runtime error surfacing
+- focused OpenRouter adapter coverage for bounded no-tool hosted execution
 
 HARNESS_PACKAGE_IMPLEMENTED

--- a/packages/harness/src/adapter/index.ts
+++ b/packages/harness/src/adapter/index.ts
@@ -1,4 +1,5 @@
 export { ClaudeCodeExecutionAdapter, createClaudeCodeAdapter } from './claude-code-adapter.js';
+export { OpenRouterExecutionAdapter, createOpenRouterAdapter } from './openrouter-adapter.js';
 export { createAgentRelayProofTransport, runByohLocalProof } from './proof/byoh-local-proof.js';
 export { createValidationSpecialist } from './proof/validation-specialist.js';
 

--- a/packages/harness/src/adapter/openrouter-adapter.test.ts
+++ b/packages/harness/src/adapter/openrouter-adapter.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { OpenRouterExecutionAdapter } from './openrouter-adapter.js';
+import type { ExecutionRequest } from './types.js';
+
+function baseRequest(): ExecutionRequest {
+  return {
+    assistantId: 'assistant-1',
+    turnId: 'turn-1',
+    threadId: 'thread-1',
+    message: {
+      id: 'msg-1',
+      text: 'Summarize the current direction.',
+      receivedAt: '2026-04-17T12:00:00.000Z',
+    },
+    instructions: {
+      systemPrompt: 'You are Sage.',
+      developerPrompt: 'Be direct.',
+    },
+    context: {
+      blocks: [
+        {
+          id: 'ctx-1',
+          label: 'Scope',
+          text: 'Only direct OpenRouter proof is in scope.',
+          category: 'workspace',
+        },
+      ],
+    },
+  };
+}
+
+describe('OpenRouterExecutionAdapter', () => {
+  it('describes the expected bounded capabilities', () => {
+    const adapter = new OpenRouterExecutionAdapter({ apiKey: 'test-key' });
+
+    expect(adapter.describeCapabilities()).toMatchObject({
+      toolUse: 'none',
+      structuredToolCalls: false,
+      continuationSupport: 'none',
+      approvalInterrupts: 'none',
+      traceDepth: 'minimal',
+      attachments: false,
+      maxContextStrategy: 'large',
+    });
+  });
+
+  it('rejects tool-bearing requests during negotiation', () => {
+    const adapter = new OpenRouterExecutionAdapter({ apiKey: 'test-key' });
+    const negotiation = adapter.negotiate({
+      ...baseRequest(),
+      tools: [{ name: 'lookup_repo', description: 'Lookup repo metadata' }],
+    });
+
+    expect(negotiation.supported).toBe(false);
+    expect(negotiation.reasons[0]?.code).toBe('tool_use_unsupported');
+  });
+
+  it('marks preferred trace depth as degraded', () => {
+    const adapter = new OpenRouterExecutionAdapter({ apiKey: 'test-key' });
+    const negotiation = adapter.negotiate({
+      ...baseRequest(),
+      requirements: { traceDepth: 'standard' },
+    });
+
+    expect(negotiation.supported).toBe(true);
+    expect(negotiation.degraded).toBe(true);
+    expect(negotiation.reasons[0]?.code).toBe('trace_depth_reduced');
+  });
+
+  it('maps a completed hosted response without tools', async () => {
+    const adapter = new OpenRouterExecutionAdapter({
+      apiKey: 'test-key',
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            id: 'resp_123',
+            choices: [
+              {
+                message: { content: 'The direction is now explicit.' },
+                finish_reason: 'stop',
+              },
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('completed');
+    expect(result.output?.text).toBe('The direction is now explicit.');
+    expect(result.backendId).toBe('openrouter-api');
+    expect(result.trace?.summary.toolCallCount).toBe(0);
+    expect(result.metadata).toEqual({ responseId: 'resp_123' });
+  });
+
+  it('maps backend HTTP failure to failed result', async () => {
+    const adapter = new OpenRouterExecutionAdapter({
+      apiKey: 'test-key',
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({ error: { message: 'Rate limit hit', code: 429 } }),
+          { status: 429, headers: { 'Content-Type': 'application/json' } },
+        ),
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('backend_execution_error');
+    expect(result.error?.metadata).toEqual({ status: 429, code: 429 });
+  });
+
+  it('maps missing assistant text to invalid_backend_output', async () => {
+    const adapter = new OpenRouterExecutionAdapter({
+      apiKey: 'test-key',
+      fetchImpl: async () =>
+        new Response(JSON.stringify({ choices: [{ message: {} }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('invalid_backend_output');
+  });
+
+  it('returns unsupported for tool-bearing execution requests', async () => {
+    const adapter = new OpenRouterExecutionAdapter({ apiKey: 'test-key' });
+
+    const result = await adapter.execute({
+      ...baseRequest(),
+      tools: [{ name: 'lookup_repo', description: 'Lookup repo metadata' }],
+    });
+
+    expect(result.status).toBe('unsupported');
+    expect(result.error?.code).toBe('unsupported_capability');
+  });
+});

--- a/packages/harness/src/adapter/openrouter-adapter.ts
+++ b/packages/harness/src/adapter/openrouter-adapter.ts
@@ -1,0 +1,393 @@
+import type {
+  ExecutionAdapter,
+  ExecutionCapabilities,
+  ExecutionNegotiation,
+  ExecutionNegotiationReason,
+  ExecutionRequest,
+  ExecutionResult,
+  ExecutionTrace,
+  ExecutionTraceEvent,
+} from './types.js';
+
+const OPENROUTER_CAPABILITIES: ExecutionCapabilities = {
+  toolUse: 'none',
+  structuredToolCalls: false,
+  continuationSupport: 'none',
+  approvalInterrupts: 'none',
+  traceDepth: 'minimal',
+  attachments: false,
+  maxContextStrategy: 'large',
+  notes: ['Direct hosted API adapter', 'Bounded no-tool proof slice only'],
+};
+
+export interface OpenRouterMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface OpenRouterRequestBody {
+  model: string;
+  messages: OpenRouterMessage[];
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface OpenRouterResponseBody {
+  id?: string;
+  choices?: Array<{
+    message?: {
+      content?: string;
+    };
+    finish_reason?: string;
+  }>;
+  error?: {
+    message?: string;
+    code?: string | number;
+  };
+}
+
+export interface OpenRouterAdapterConfig {
+  apiKey?: string;
+  model?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  timeoutMs?: number;
+}
+
+function toIso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function buildTrace(
+  startedAt: number,
+  completedAt: number,
+  degraded: boolean,
+  events?: ExecutionTraceEvent[],
+): ExecutionTrace {
+  return {
+    summary: {
+      startedAt: toIso(startedAt),
+      completedAt: toIso(completedAt),
+      stepCount: 1,
+      toolCallCount: 0,
+      degraded,
+    },
+    ...(events && events.length > 0 ? { events } : {}),
+  };
+}
+
+function requiredUnsupported(
+  code: ExecutionNegotiationReason['code'],
+  message: string,
+): ExecutionNegotiationReason {
+  return { code, message, severity: 'blocking' };
+}
+
+function preferredDegradation(
+  code: ExecutionNegotiationReason['code'],
+  message: string,
+): ExecutionNegotiationReason {
+  return { code, message, severity: 'warning' };
+}
+
+function buildUserPrompt(request: ExecutionRequest): string {
+  const sections: string[] = [];
+
+  if (request.instructions.developerPrompt?.trim()) {
+    sections.push(`Developer instructions:\n${request.instructions.developerPrompt}`);
+  }
+
+  const blocks = request.context?.blocks ?? [];
+  if (blocks.length > 0) {
+    sections.push(
+      `Context:\n${blocks.map((block) => `- [${block.label}] ${block.text}`).join('\n')}`,
+    );
+  }
+
+  if (request.context?.structured && Object.keys(request.context.structured).length > 0) {
+    sections.push(`Structured context:\n${JSON.stringify(request.context.structured, null, 2)}`);
+  }
+
+  sections.push(`User message:\n${request.message.text}`);
+
+  return sections.join('\n\n');
+}
+
+function buildRequestBody(request: ExecutionRequest, model: string): OpenRouterRequestBody {
+  return {
+    model,
+    messages: [
+      {
+        role: 'system',
+        content: request.instructions.systemPrompt,
+      },
+      {
+        role: 'user',
+        content: buildUserPrompt(request),
+      },
+    ],
+  };
+}
+
+function parseResponseText(body: OpenRouterResponseBody): string | undefined {
+  return body.choices?.[0]?.message?.content?.trim() || undefined;
+}
+
+function negotiateRequest(request: ExecutionRequest): ExecutionNegotiation {
+  const reasons: ExecutionNegotiationReason[] = [];
+  const requirements = request.requirements;
+
+  if ((request.tools?.length ?? 0) > 0) {
+    reasons.push(
+      requiredUnsupported(
+        'tool_use_unsupported',
+        'OpenRouter proof adapter does not support tool-bearing requests in this slice.',
+      ),
+    );
+  }
+
+  if (requirements?.toolUse === 'required') {
+    reasons.push(requiredUnsupported('tool_use_unsupported', 'Backend does not support tool use.'));
+  }
+
+  if (requirements?.structuredToolCalls === 'required') {
+    reasons.push(
+      requiredUnsupported(
+        'structured_tool_calls_unsupported',
+        'Structured tool calls are required but unsupported by this adapter.',
+      ),
+    );
+  }
+
+  if (requirements?.continuationSupport === 'required') {
+    reasons.push(
+      requiredUnsupported(
+        'continuation_unsupported',
+        'Structured continuation support is unavailable in this OpenRouter proof slice.',
+      ),
+    );
+  } else if (requirements?.continuationSupport === 'preferred') {
+    reasons.push(
+      preferredDegradation(
+        'continuation_unsupported',
+        'Continuation support is preferred but unavailable in this OpenRouter proof slice.',
+      ),
+    );
+  }
+
+  if (requirements?.approvalInterrupts === 'required') {
+    reasons.push(
+      requiredUnsupported(
+        'approval_interrupt_unsupported',
+        'Approval interrupts are required but unsupported by this adapter.',
+      ),
+    );
+  } else if (requirements?.approvalInterrupts === 'preferred') {
+    reasons.push(
+      preferredDegradation(
+        'approval_interrupt_unsupported',
+        'Approval interrupts are preferred but unavailable in this OpenRouter proof slice.',
+      ),
+    );
+  }
+
+  if ((request.message.attachments?.length ?? 0) > 0 || requirements?.attachments === 'required') {
+    reasons.push(
+      requiredUnsupported(
+        'attachments_unsupported',
+        'Attachments are unsupported by this OpenRouter proof adapter.',
+      ),
+    );
+  }
+
+  if (requirements?.traceDepth === 'standard' || requirements?.traceDepth === 'detailed') {
+    reasons.push(
+      preferredDegradation(
+        'trace_depth_reduced',
+        'Only minimal execution trace facts are available in this OpenRouter proof slice.',
+      ),
+    );
+  }
+
+  const supported = !reasons.some((reason) => reason.severity === 'blocking');
+  const degraded = reasons.some((reason) => reason.severity !== 'blocking');
+
+  return {
+    supported,
+    degraded,
+    reasons,
+    effectiveCapabilities: OPENROUTER_CAPABILITIES,
+  };
+}
+
+export class OpenRouterExecutionAdapter implements ExecutionAdapter {
+  readonly backendId = 'openrouter-api';
+
+  private readonly apiKey?: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: NonNullable<OpenRouterAdapterConfig['now']>;
+  private readonly timeoutMs: number;
+
+  constructor(config: OpenRouterAdapterConfig = {}) {
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? 'openai/gpt-5-mini';
+    this.baseUrl = config.baseUrl ?? 'https://openrouter.ai/api/v1/chat/completions';
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.now = config.now ?? Date.now;
+    this.timeoutMs = config.timeoutMs ?? 30_000;
+  }
+
+  describeCapabilities(): ExecutionCapabilities {
+    return {
+      ...OPENROUTER_CAPABILITIES,
+      ...(OPENROUTER_CAPABILITIES.notes ? { notes: [...OPENROUTER_CAPABILITIES.notes] } : {}),
+    };
+  }
+
+  negotiate(request: ExecutionRequest): ExecutionNegotiation {
+    return negotiateRequest(request);
+  }
+
+  async execute(request: ExecutionRequest): Promise<ExecutionResult> {
+    const negotiation = this.negotiate(request);
+    if (!negotiation.supported) {
+      return {
+        backendId: this.backendId,
+        status: 'unsupported',
+        error: {
+          code: 'unsupported_capability',
+          message: negotiation.reasons.map((reason) => reason.message).join(' '),
+        },
+        degradation: negotiation.reasons,
+        trace: {
+          summary: {
+            degraded: false,
+          },
+        },
+      };
+    }
+
+    if (!this.apiKey) {
+      return {
+        backendId: this.backendId,
+        status: 'failed',
+        error: {
+          code: 'backend_execution_error',
+          message: 'OpenRouter API key is not configured.',
+        },
+        degradation: negotiation.degraded ? negotiation.reasons : undefined,
+      };
+    }
+
+    const startedAt = this.now();
+    const abortController = new AbortController();
+    const timeout = setTimeout(() => abortController.abort(), this.timeoutMs);
+
+    try {
+      const response = await this.fetchImpl(this.baseUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(buildRequestBody(request, this.model)),
+        signal: abortController.signal,
+      });
+
+      const body = (await response.json()) as OpenRouterResponseBody;
+      const completedAt = this.now();
+
+      if (!response.ok) {
+        return {
+          backendId: this.backendId,
+          status: 'failed',
+          error: {
+            code: 'backend_execution_error',
+            message: body.error?.message || `OpenRouter request failed with status ${response.status}.`,
+            retryable: response.status >= 500,
+            metadata: {
+              status: response.status,
+              code: body.error?.code,
+            },
+          },
+          trace: buildTrace(startedAt, completedAt, negotiation.degraded, [
+            {
+              type: 'failure',
+              at: toIso(completedAt),
+              data: { status: response.status, error: body.error?.message },
+            },
+          ]),
+          degradation: negotiation.degraded ? negotiation.reasons : undefined,
+        };
+      }
+
+      const text = parseResponseText(body);
+      if (!text) {
+        return {
+          backendId: this.backendId,
+          status: 'failed',
+          error: {
+            code: 'invalid_backend_output',
+            message: 'OpenRouter response did not contain assistant text.',
+            metadata: { body },
+          },
+          trace: buildTrace(startedAt, completedAt, negotiation.degraded, [
+            {
+              type: 'failure',
+              at: toIso(completedAt),
+              data: { reason: 'missing_text' },
+            },
+          ]),
+          degradation: negotiation.degraded ? negotiation.reasons : undefined,
+        };
+      }
+
+      return {
+        backendId: this.backendId,
+        status: 'completed',
+        output: { text },
+        trace: buildTrace(startedAt, completedAt, negotiation.degraded, [
+          { type: 'model_started', at: toIso(startedAt) },
+          { type: 'model_completed', at: toIso(completedAt), data: { finishReason: body.choices?.[0]?.finish_reason } },
+        ]),
+        degradation: negotiation.degraded ? negotiation.reasons : undefined,
+        metadata: body.id ? { responseId: body.id } : undefined,
+      };
+    } catch (error) {
+      const completedAt = this.now();
+      const isAbort = error instanceof Error && error.name === 'AbortError';
+      return {
+        backendId: this.backendId,
+        status: 'failed',
+        error: {
+          code: isAbort ? 'timeout' : 'backend_execution_error',
+          message: isAbort
+            ? `OpenRouter request timed out after ${this.timeoutMs}ms.`
+            : error instanceof Error
+              ? error.message
+              : 'Unknown OpenRouter execution error.',
+          retryable: true,
+        },
+        trace: buildTrace(startedAt, completedAt, negotiation.degraded, [
+          {
+            type: 'failure',
+            at: toIso(completedAt),
+            data: { timeoutMs: this.timeoutMs, error: error instanceof Error ? error.message : String(error) },
+          },
+        ]),
+        degradation: negotiation.degraded ? negotiation.reasons : undefined,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function createOpenRouterAdapter(
+  config: OpenRouterAdapterConfig = {},
+): ExecutionAdapter {
+  return new OpenRouterExecutionAdapter(config);
+}


### PR DESCRIPTION
## Summary
- add a bounded `openrouter-api` execution adapter behind the existing `ExecutionAdapter` seam
- cover the first no-tool hosted execution path with focused adapter tests
- export the new adapter from the harness adapter entrypoint

## Validation
- npm test -w @agent-assistant/harness -- openrouter-adapter.test.ts
- npm run build -w @agent-assistant/routing
- npm run build -w @agent-assistant/coordination
- npm run build -w @agent-assistant/traits
- npm run build -w @agent-assistant/harness

## Notes
- this slice is intentionally bounded to direct hosted no-tool execution
- tool-bearing hosted execution remains out of scope for this PR
- local temp-worktree `package-lock.json` churn from install was not committed
