### PR TITLE
feat(specialists): GitHub investigator + librarian package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           case "${{ github.event.inputs.package_group }}" in
             runtime-core)
-              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk","vfs"]'
+              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk","vfs","specialists"]'
               FIRST='traits'
               ;;
             *)

--- a/docs/specs/v1-specialists-spec.md
+++ b/docs/specs/v1-specialists-spec.md
@@ -1,0 +1,154 @@
+# v1 Specialists Spec — `@agent-assistant/specialists`
+
+**Status:** IMPLEMENTATION_READY
+**Date:** 2026-04-17
+**Package:** `@agent-assistant/specialists`
+**Version target:** v0.1.0 (pre-1.0, provisional)
+**Adoption posture:** direct-import / wave-2 once GitHub investigator + librarian land
+
+---
+
+## 1. Responsibilities
+
+`@agent-assistant/specialists` ships concrete, deterministic specialist implementations that products can register into any `@agent-assistant/coordination` registry. Specialists here are code, not prompts: they read structured data (currently via `VfsProvider`) and return structured findings. An LLM is not in the inner loop.
+
+The package is the home for **integration-domain** specialists — agents that operate against synced workspace data (GitHub, and later Linear / Slack / Notion). It complements — it does not replace — persona-driven LLM agents (which live in the `workforce` repo) and the SDK contract packages (`@agent-assistant/coordination`, `@agent-assistant/vfs`).
+
+**Owns:**
+- `createGitHubInvestigator({ vfs, apiFallback? })` — single-PR deep dive. Returns `SpecialistFindings` with structured `pr-meta` + `pr-diff` evidence.
+- `createGitHubLibrarian({ vfs, apiFallback? })` — enumeration over PRs / issues / repos. Filters by `state`, `repo`, `label`, `type` parsed from a natural-language or key:value instruction.
+- Shared contract: `DelegationRequest`, `SpecialistFindings`, `DelegationTransport`, `DelegationTimeoutError`, `parseQuery` filter-syntax parser, `matchesFilters` VFS adapter helper.
+- Typed capability discriminators: `GitHubInvestigationParams` (`pr_investigation` | `github.investigate`) and `GitHubEnumerationParams` (`github.enumerate`).
+- Pure evidence shapes compatible with `SpecialistResult.metadata.findings` — consumers read rich structured fields without breaking the `coordination` `SpecialistResult` contract.
+
+**Does NOT own:**
+- The `Specialist` / `Coordinator` / `SpecialistRegistry` contracts (→ `@agent-assistant/coordination`).
+- VFS contracts or providers (→ `@agent-assistant/vfs`). Specialists consume a `VfsProvider`; they do not implement one.
+- GitHub API access (→ consumer-provided `apiFallback`; specialists only read the VFS by default).
+- Persona prompts, model selection, or tier routing (→ `workforce` personas + `@agent-assistant/routing`).
+- Relay transport. Transport lives with the consumer (e.g. Sage's `RelayDelegationTransport`). The package defines the `DelegationTransport` interface only.
+- Durable evidence storage. Specialists accept an optional `EvidenceWriter` and call it when evidence exceeds a threshold; the concrete writer is consumer-owned.
+
+---
+
+## 2. Non-Goals
+
+- No LLM prompt catalog. Persona prompts belong in `workforce/personas/*.json`. If a capability needs an LLM, it should live there and call into these specialists as tools.
+- No data syncing. The VFS is populated by other adapters (e.g. `@relayfile/adapter-github`); specialists only read.
+- No cross-integration synthesis. A specialist owns one integration at a time. Cross-cutting analysis is the coordinator's job.
+- No retry / timeout / circuit-breaker policy. The transport / coordinator owns those. Specialists raise errors truthfully and let upstream decide.
+- No capability invention. Capability literals must match `types.ts` discriminators; specialists never emit ad-hoc strings.
+
+---
+
+## 3. GitHub VFS contract
+
+The GitHub specialists read from the canonical VFS layout defined by `@relayfile/adapter-github/path-mapper`:
+
+| Object | Path |
+|---|---|
+| PR metadata | `/github/repos/{owner}/{repo}/pulls/{n}/metadata.json` |
+| Issue metadata | `/github/repos/{owner}/{repo}/issues/{n}/metadata.json` |
+| Repository metadata | `/github/repos/{owner}/{repo}/metadata.json` |
+
+Investigator falls back to legacy paths (`meta.json`, `pr.md`, `pr.txt`, `summary.md`, `diff.patch`) so pre-adapter VFS data still works, but the adapter-canonical path is always tried first.
+
+Properties on VFS entries (used for librarian filter matching) are expected to follow the adapter's `mapPRProperties` / `mapIssueProperties` schema — `state`, `repo`, `label`/`labels`, `number`, `title`, `url`, `updated_at`.
+
+---
+
+## 4. Interfaces and contracts
+
+### 4.1 Capability discriminators
+
+```typescript
+export type GitHubInvestigationCapability = 'pr_investigation' | 'github.investigate';
+export type GitHubEnumerationCapability = 'github.enumerate';
+```
+
+Capability literals round-trip cleanly between request (`params.capability`), specialist registration (`Specialist.capabilities`), and findings (`SpecialistFindings.capability`) so delegation routers can correlate by string.
+
+### 4.2 `createGitHubInvestigator`
+
+```typescript
+function createGitHubInvestigator(deps: {
+  vfs: VfsProvider;
+  apiFallback?: GitHubApiFallback | null;
+  evidenceWriter?: EvidenceWriter | null;
+  now?: () => number;
+}): Specialist;
+```
+
+Returns a `Specialist` that reads a PR's metadata + diff from the VFS, extracts structured fields, and emits two evidence items (`pr-meta`, `pr-diff`). Diffs exceeding 4 KB are written to the optional `EvidenceWriter` and replaced inline with a durable reference.
+
+### 4.3 `createGitHubLibrarian`
+
+```typescript
+function createGitHubLibrarian(options: {
+  vfs: { list?: ...; search?: ... };
+  apiFallback?: (request) => Promise<readonly VfsEntry[]> | { list?; search? };
+}): GitHubLibrarianSpecialist;
+```
+
+Handler parses the instruction with `parseQuery`, infers filter values from natural-language cues (`"open"`, `"labeled security"`) and explicit `key:value` tokens, lists or searches the VFS under the adapter-canonical paths, optionally falls back to the caller-supplied API, and returns `evidence[]` where each entry summarizes a match (repo, title, state, labels, snippet).
+
+### 4.4 Functional exports
+
+`investigateGitHub(params, deps)` and `enumerateGitHub(params, options)` are functional entry points that mirror the `create*` specialists for callers that don't want to instantiate a `Specialist`. Both return fully-typed findings and do not throw on known failure modes — they return `failed` findings with gaps instead.
+
+### 4.5 `parseQuery`
+
+```typescript
+function parseQuery(input: string): {
+  text: string;
+  filters: Record<string, string[]>;
+};
+```
+
+Recognizes `state:`, `repo:`, `label:`, `type:` prefixes. Unknown keys pass through as text so grammar evolves without breaking callers.
+
+---
+
+## 5. Evidence shape
+
+Findings conform to `SpecialistFindings` in `shared/findings.ts`. Each `SpecialistFinding.metadata` carries a stable id (`pr-meta`, `pr-diff`, or an enumeration hit id), a `kind`, optional structured fields, optional `confidence`, and an `EvidenceSource` describing where the data came from (`vfs` vs `github_api` with provenance path/revision). Consumers project findings into `SpecialistResult.metadata.findings` so the `@agent-assistant/coordination` contract is preserved.
+
+---
+
+## 6. Error handling
+
+- VFS read failures are swallowed into an `errors[]` array; the handler returns `partial` or `failed` with a truthful status — it does not throw.
+- `apiFallback` calls are wrapped in the same try/catch envelope; a crashing fallback never propagates as an unhandled rejection.
+- Structurally invalid requests (missing owner/repo/number for investigation) return `failed` findings with a `invalid_request` gap, never throw.
+
+---
+
+## 7. Dependencies
+
+- `@agent-assistant/coordination@^0.1.0` — `Specialist`, `SpecialistResult`, `SpecialistContext` contracts.
+- `@agent-assistant/vfs@^0.2.2` — `VfsProvider`, `VfsEntry`, `VfsReadResult`.
+- `@relayfile/adapter-github@^0.1.6` (subpath `path-mapper` only) — canonical GitHub VFS paths. Zero-dep subpath; no SDK pulled at runtime.
+
+No other runtime dependencies. `@relayfile/sdk` is a peer of the adapter but not invoked from the specialists package.
+
+---
+
+## 8. Testing strategy
+
+- Unit tests use inline fake `VfsProvider` implementations; no network, no filesystem, no mocks of third-party modules.
+- `query-syntax.test.ts` covers the filter-syntax grammar (bare text, mixed tokens, repeated keys, unknown keys).
+- `investigator.test.ts` covers VFS-hit and VFS-miss paths for single-PR investigation.
+- `librarian.test.ts` covers filter matching (`state:open`, `state:open label:security`, `type:pr repo:foo/bar`).
+- Consumer E2E (owned by the consumer, not this package): Sage spawns the specialist process over `@agent-relay/sdk/communicate`, posts a `DelegationRequest`, asserts `SpecialistFindings` arrive with ≥1 evidence item.
+
+---
+
+## 9. Roadmap
+
+**v0.1.x — current**: GitHub investigator + librarian.
+
+**v0.2 — Linear specialists**: `linearIssueInvestigator` (single-issue deep dive), `linearLibrarian` (enumerate issues/projects/roadmaps). Reuses `parseQuery`, adds Linear path-mapper once `@relayfile/adapter-linear` exposes one.
+
+**v0.3 — Slack + Notion**: `slackChannelInvestigator`, `notionPageLibrarian`. Both share the capability-discriminator + findings shape.
+
+**v1.0**: Stabilize the capability literal union and evidence schema once at least three integrations are implemented, so downstream coordinators can pin against a stable contract.

--- a/packages/specialists/package-lock.json
+++ b/packages/specialists/package-lock.json
@@ -8,8 +8,9 @@
       "name": "@agent-assistant/specialists",
       "version": "0.1.0",
       "dependencies": {
-        "@agent-assistant/coordination": "file:../coordination",
-        "@agent-assistant/vfs": "file:../vfs"
+        "@agent-assistant/coordination": "^0.1.0",
+        "@agent-assistant/vfs": "^0.2.2",
+        "@relayfile/adapter-github": "^0.1.6"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -496,6 +497,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@relayfile/adapter-core": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-core/-/adapter-core-0.1.6.tgz",
+      "integrity": "sha512-YHzNfkx/G/ZeeVqGzh4+keRHKBgdCCu+srAfTMxYciuyfhnR5iSUUulggC7DWuZGNQMFY9Wdjhham4XFRVGkQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/postman-to-openapi": "^0.6.0",
+        "cheerio": "^1.2.0",
+        "minimatch": "^10.0.3",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "adapter-core": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": "^0.1.7"
+      }
+    },
+    "node_modules/@relayfile/adapter-github": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-github/-/adapter-github-0.1.6.tgz",
+      "integrity": "sha512-nN9C+tyUhnKfEbrONjFms+rXDt/xHQD1jh5kSAIo6OdZ1J0oRvGE/v/mC+PMnuGOsCDX5b6BKLM8e8uiiunyEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@relayfile/adapter-core": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": "^0.1.7"
+      }
+    },
+    "node_modules/@relayfile/sdk": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.1.12.tgz",
+      "integrity": "sha512-tgGkIV2vWt068g2rQtSrUSksYC5QnQ2QL8s6rgpQZkM8u/+UxK77YYJ5YQUTQ8BWusa3cgvKdk4STpquS3wXEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -846,6 +893,37 @@
         "win32"
       ]
     },
+    "node_modules/@scalar/helpers": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.0.tgz",
+      "integrity": "sha512-S7m46UWqngUmDXuihUerNKS58vlUqF/qaXle3QREfc8Xh9wperAKxFmmxrnulAayrcCQ/fTJyGu5oSM2STlxkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
+      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/postman-to-openapi": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.6.2.tgz",
+      "integrity": "sha512-b8XcDqeVOXTdvBqj0JK72HiZDelhAC6ysuToHJnyP4a57O5D2szuHBOfsoAWHG98AOi3bcJzKnnQpWzPIapbmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.5.0",
+        "@scalar/openapi-types": "0.7.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -996,6 +1074,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1033,6 +1138,76 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1059,6 +1234,86 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1163,6 +1418,49 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1185,6 +1483,21 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1211,6 +1524,67 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1323,6 +1697,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -1441,6 +1821,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/vite": {
@@ -1614,6 +2003,28 @@
         }
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1629,6 +2040,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/packages/specialists/package-lock.json
+++ b/packages/specialists/package-lock.json
@@ -1,0 +1,1635 @@
+{
+  "name": "@agent-assistant/specialists",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agent-assistant/specialists",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agent-assistant/coordination": "file:../coordination",
+        "@agent-assistant/vfs": "file:../vfs"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "../coordination": {
+      "name": "@agent-assistant/coordination",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agent-assistant/connectivity": "file:../connectivity",
+        "nanoid": "^5.1.6"
+      },
+      "devDependencies": {
+        "@agent-assistant/routing": "file:../routing",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "../vfs": {
+      "name": "@agent-assistant/vfs",
+      "version": "0.2.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@agent-assistant/coordination": {
+      "resolved": "../coordination",
+      "link": true
+    },
+    "node_modules/@agent-assistant/vfs": {
+      "resolved": "../vfs",
+      "link": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@agent-assistant/specialists",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agent-assistant/coordination": "file:../coordination",
+    "@agent-assistant/vfs": "file:../vfs"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -18,8 +18,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agent-assistant/coordination": "file:../coordination",
-    "@agent-assistant/vfs": "file:../vfs"
+    "@agent-assistant/coordination": "^0.1.0",
+    "@agent-assistant/vfs": "^0.2.2",
+    "@relayfile/adapter-github": "^0.1.6"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/specialists/src/github/external-module-types.d.ts
+++ b/packages/specialists/src/github/external-module-types.d.ts
@@ -1,0 +1,97 @@
+declare module '@agent-assistant/coordination' {
+  export type SpecialistExecutionStatus = 'complete' | 'partial' | 'failed';
+
+  export interface SpecialistDefinition {
+    name: string;
+    description: string;
+    capabilities: string[];
+  }
+
+  export interface SpecialistResult {
+    specialistName: string;
+    output: string;
+    confidence?: number;
+    status: SpecialistExecutionStatus;
+    metadata?: Record<string, unknown>;
+  }
+
+  export interface SpecialistContext {
+    turnId: string;
+    threadId: string;
+    stepIndex: number;
+    plan: {
+      intent: string;
+      steps: Array<{
+        specialistName: string;
+        instruction: string;
+        optional?: boolean;
+      }>;
+    };
+    priorResults: SpecialistResult[];
+    connectivity: unknown;
+    routingDecision?: {
+      mode: string;
+      tier: string;
+      hints: Record<string, unknown>;
+      reason: string;
+      escalated: boolean;
+      overridden: boolean;
+    };
+  }
+
+  export interface SpecialistHandler {
+    execute(instruction: string, context: SpecialistContext): Promise<SpecialistResult>;
+  }
+
+  export interface Specialist extends SpecialistDefinition {
+    handler: SpecialistHandler;
+  }
+}
+
+declare module '@agent-assistant/vfs' {
+  export type VfsNodeType = 'file' | 'dir' | 'unknown';
+
+  export interface VfsEntry {
+    path: string;
+    type: VfsNodeType;
+    provider?: string;
+    title?: string;
+    revision?: string;
+    updatedAt?: string;
+    size?: number;
+    properties?: Record<string, string>;
+  }
+
+  export interface VfsSearchResult extends VfsEntry {
+    snippet?: string;
+  }
+
+  export interface VfsReadResult {
+    path: string;
+    content: string;
+    contentType?: string;
+    encoding?: 'utf-8' | 'base64';
+    provider?: string;
+    title?: string;
+    revision?: string;
+    updatedAt?: string;
+    properties?: Record<string, string>;
+  }
+
+  export interface VfsListOptions {
+    depth?: number;
+    limit?: number;
+  }
+
+  export interface VfsSearchOptions {
+    provider?: string;
+    limit?: number;
+  }
+
+  export interface VfsProvider {
+    list(path: string, options?: VfsListOptions): Promise<VfsEntry[]>;
+    read(path: string): Promise<VfsReadResult | null>;
+    search(query: string, options?: VfsSearchOptions): Promise<VfsSearchResult[]>;
+    stat?(path: string): Promise<VfsEntry | null>;
+  }
+}

--- a/packages/specialists/src/github/index.ts
+++ b/packages/specialists/src/github/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './investigator.js';
+export * from './librarian.js';

--- a/packages/specialists/src/github/investigator.test.ts
+++ b/packages/specialists/src/github/investigator.test.ts
@@ -1,0 +1,249 @@
+import type { VfsEntry, VfsProvider, VfsReadResult, VfsSearchResult } from '@agent-assistant/vfs';
+import { describe, expect, it } from 'vitest';
+
+import {
+  investigatePullRequest,
+  type GitHubApiFallback,
+  type GitHubApiPullRequest,
+  type PrInvestigationRequest,
+} from './investigator.js';
+
+type VfsFile = {
+  content: string;
+  provider?: string;
+  revision?: string;
+};
+
+class InMemoryVfsProvider implements VfsProvider {
+  readonly reads: string[] = [];
+
+  constructor(private readonly files: Record<string, VfsFile>) {}
+
+  async read(filePath: string): Promise<VfsReadResult | null> {
+    this.reads.push(filePath);
+    const file = this.files[filePath];
+    if (!file) {
+      return null;
+    }
+
+    return {
+      path: filePath,
+      content: file.content,
+      provider: file.provider ?? 'github',
+      revision: file.revision ?? 'rev-vfs',
+    };
+  }
+
+  async list(): Promise<VfsEntry[]> {
+    return [];
+  }
+
+  async search(): Promise<VfsSearchResult[]> {
+    return [];
+  }
+}
+
+class InlineGitHubApiFallback implements GitHubApiFallback {
+  readonly calls: Array<{ owner: string; repo: string; number: number }> = [];
+
+  constructor(private readonly pullRequest: GitHubApiPullRequest | null) {}
+
+  async readPRDiff(owner: string, repo: string, number: number): Promise<GitHubApiPullRequest | null> {
+    this.calls.push({ owner, repo, number });
+    return this.pullRequest;
+  }
+}
+
+function createRequest(): PrInvestigationRequest {
+  return {
+    requestId: 'req-investigator',
+    repo: { owner: 'foo', repo: 'bar' },
+    pr: { number: 47 },
+    allowDurableEvidence: true,
+  };
+}
+
+const metadataPath = '/github/repos/foo/bar/pulls/47/meta.json';
+const diffPath = '/github/repos/foo/bar/pulls/47/diff.patch';
+const producedAt = '2026-04-17T00:00:00.000Z';
+
+describe('investigatePullRequest VFS evidence', () => {
+  it('returns pr-meta and pr-diff evidence when VFS metadata and diff are present', async () => {
+    const vfs = new InMemoryVfsProvider({
+      [metadataPath]: {
+        revision: 'rev-meta',
+        content: JSON.stringify({
+          title: 'Tighten token checks',
+          html_url: 'https://github.com/foo/bar/pull/47',
+          state: 'open',
+          body: 'Adds stricter token validation.',
+          user: { login: 'security-lead' },
+          base: { ref: 'main' },
+          head: { ref: 'feature/token-checks' },
+          labels: [{ name: 'security' }, { name: 'backend' }],
+          reviewStatus: 'approved',
+        }),
+      },
+      [diffPath]: {
+        revision: 'rev-diff',
+        content: [
+          'diff --git a/src/auth.ts b/src/auth.ts',
+          '--- a/src/auth.ts',
+          '+++ b/src/auth.ts',
+          '+validateTokenScope();',
+          'diff --git a/src/auth.test.ts b/src/auth.test.ts',
+          '--- a/src/auth.test.ts',
+          '+++ b/src/auth.test.ts',
+          '+expect(scopeCheck).toBe(true);',
+        ].join('\n'),
+      },
+    });
+
+    const findings = await investigatePullRequest(createRequest(), {
+      vfs,
+      now: () => Date.parse(producedAt),
+    });
+
+    expect(findings.status).toBe('complete');
+    expect(findings.capability).toBe('pr_investigation');
+    expect(findings.findings).toHaveLength(2);
+    expect(findings.findings.map((finding) => finding.metadata?.id)).toEqual(['pr-meta', 'pr-diff']);
+    expect(findings.metadata).toEqual(
+      expect.objectContaining({
+        durableEvidenceCount: 0,
+        producedAt,
+      }),
+    );
+
+    const [metadataEvidence, diffEvidence] = findings.findings;
+    expect(metadataEvidence).toEqual(
+      expect.objectContaining({
+        title: 'PR #47 metadata',
+        url: 'https://github.com/foo/bar/pull/47',
+        metadata: expect.objectContaining({
+          id: 'pr-meta',
+          kind: 'pr_summary',
+          confidence: 0.72,
+          source: expect.objectContaining({
+            provider: 'vfs',
+            ref: '/github/repos/foo/bar/pulls/47',
+            path: metadataPath,
+            revision: 'rev-meta',
+            asOf: producedAt,
+          }),
+          structured: expect.objectContaining({
+            number: 47,
+            title: 'Tighten token checks',
+            state: 'open',
+            author: 'security-lead',
+            baseBranch: 'main',
+            headBranch: 'feature/token-checks',
+            labels: ['security', 'backend'],
+            reviewStatus: 'approved',
+            additions: 2,
+            deletions: 0,
+            url: 'https://github.com/foo/bar/pull/47',
+          }),
+        }),
+      }),
+    );
+
+    expect(diffEvidence).toEqual(
+      expect.objectContaining({
+        title: 'PR #47 diff analysis',
+        body: expect.stringContaining('src/auth.ts'),
+        metadata: expect.objectContaining({
+          id: 'pr-diff',
+          kind: 'diff_analysis',
+          confidence: 0.88,
+          source: expect.objectContaining({
+            provider: 'vfs',
+            ref: '/github/repos/foo/bar/pulls/47',
+            path: metadataPath,
+            revision: 'rev-meta',
+            asOf: producedAt,
+          }),
+          structured: expect.objectContaining({
+            filesChanged: ['src/auth.ts', 'src/auth.test.ts'],
+            changeCategories: ['feature', 'test'],
+            riskAreas: expect.arrayContaining([
+              expect.objectContaining({
+                file: 'src/auth.ts',
+                severity: 'high',
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+    expect(diffEvidence?.metadata).not.toHaveProperty('durableRef');
+    expect(vfs.reads).toEqual(expect.arrayContaining([metadataPath, diffPath]));
+  });
+
+  it('uses inline GitHub fallback when VFS misses and preserves evidence shape', async () => {
+    const vfs = new InMemoryVfsProvider({});
+    const apiFallback = new InlineGitHubApiFallback({
+      title: 'Load PR from fallback',
+      body: 'Fallback metadata body.',
+      state: 'open',
+      url: 'https://github.com/foo/bar/pull/47',
+      author: 'api-user',
+      baseBranch: 'main',
+      headBranch: 'feature/api-fallback',
+      labels: ['fallback', 'security'],
+      reviewStatus: 'pending',
+      diff: [
+        'diff --git a/src/fallback.ts b/src/fallback.ts',
+        '--- a/src/fallback.ts',
+        '+++ b/src/fallback.ts',
+        '+export const loaded = true;',
+      ].join('\n'),
+    });
+
+    const findings = await investigatePullRequest(createRequest(), {
+      vfs,
+      apiFallback,
+      now: () => Date.parse(producedAt),
+    });
+
+    expect(apiFallback.calls).toEqual([{ owner: 'foo', repo: 'bar', number: 47 }]);
+    expect(findings.status).toBe('complete');
+    expect(findings.findings.map((finding) => finding.metadata?.id)).toEqual(['pr-meta', 'pr-diff']);
+
+    const [metadataEvidence, diffEvidence] = findings.findings;
+    expect(metadataEvidence?.metadata).toEqual(
+      expect.objectContaining({
+        id: 'pr-meta',
+        kind: 'pr_summary',
+        source: expect.objectContaining({
+          provider: 'github_api',
+          ref: '/github/repos/foo/bar/pulls/47',
+          asOf: producedAt,
+        }),
+        structured: expect.objectContaining({
+          number: 47,
+          title: 'Load PR from fallback',
+          author: 'api-user',
+          labels: ['fallback', 'security'],
+          reviewStatus: 'pending',
+        }),
+      }),
+    );
+    expect(diffEvidence?.metadata).toEqual(
+      expect.objectContaining({
+        id: 'pr-diff',
+        kind: 'diff_analysis',
+        source: expect.objectContaining({
+          provider: 'github_api',
+          ref: '/github/repos/foo/bar/pulls/47',
+          asOf: producedAt,
+        }),
+        structured: expect.objectContaining({
+          filesChanged: ['src/fallback.ts'],
+          changeCategories: ['feature'],
+        }),
+      }),
+    );
+    expect(diffEvidence?.body).toContain('src/fallback.ts');
+  });
+});

--- a/packages/specialists/src/github/investigator.ts
+++ b/packages/specialists/src/github/investigator.ts
@@ -1,0 +1,1072 @@
+import type { Specialist, SpecialistContext, SpecialistResult } from '@agent-assistant/coordination';
+import type { VfsProvider, VfsReadResult } from '@agent-assistant/vfs';
+
+import type { SpecialistFinding, SpecialistFindings } from '../shared/findings.js';
+import type { GitHubInvestigationParams, GitHubPullRequestRef, GitHubQueryFilterSet } from './types.js';
+
+const SPECIALIST_NAME = 'github-investigator';
+const SPECIALIST_VERSION = '1.0.0';
+const PR_INVESTIGATION_CAPABILITY = 'pr_investigation';
+const DURABLE_EVIDENCE_THRESHOLD_BYTES = 4_096;
+
+type ReviewStatus = 'approved' | 'changes_requested' | 'pending' | 'none';
+type EvidenceSourceProvider = 'vfs' | 'github_api';
+
+interface GitHubRepoRef {
+  owner: string;
+  repo: string;
+}
+
+export interface PrInvestigationRequest {
+  requestId: string;
+  repo: GitHubRepoRef;
+  pr: {
+    number: number;
+  };
+  query?: string;
+  allowDurableEvidence?: boolean;
+}
+
+export interface GitHubApiPullRequest {
+  number?: number;
+  title?: string;
+  body?: string | null;
+  state?: string;
+  diff?: string | null;
+  url?: string;
+  html_url?: string;
+  author?: string | { login?: string; name?: string };
+  user?: { login?: string; name?: string };
+  base?: { ref?: string };
+  head?: { ref?: string };
+  baseBranch?: string;
+  headBranch?: string;
+  base_branch?: string;
+  head_branch?: string;
+  labels?: Array<string | { name?: string }> | string;
+  reviewStatus?: string;
+  review_status?: string;
+}
+
+export interface GitHubApiFallback {
+  readPRDiff(
+    owner: string,
+    repo: string,
+    number: number,
+  ): Promise<{ data: GitHubApiPullRequest } | GitHubApiPullRequest | null>;
+}
+
+export interface DurableEvidenceRef {
+  path: string;
+  revision?: string;
+  workspaceId?: string;
+  [key: string]: unknown;
+}
+
+export interface EvidenceWriteInput {
+  requestId: string;
+  evidenceId: string;
+  kind: string;
+  title: string;
+  content: string;
+  contentType: string;
+  confidence?: number;
+}
+
+export interface EvidenceWriter {
+  writeEvidence(input: EvidenceWriteInput): Promise<DurableEvidenceRef>;
+  finalize?(): Promise<void> | void;
+}
+
+export interface GitHubInvestigatorDeps {
+  vfs: VfsProvider;
+  apiFallback?: GitHubApiFallback | null;
+  github?: GitHubApiFallback | null;
+  evidenceWriter?: EvidenceWriter | null;
+  now?: () => number;
+}
+
+interface ParsedPrSections {
+  title: string;
+  url: string;
+  body: string;
+  diff: string;
+  state: string;
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+  labels: string[];
+  reviewStatus: ReviewStatus;
+}
+
+interface StructuredPr {
+  title: string;
+  body: string;
+  url: string;
+  state: string;
+  author: string;
+  baseBranch: string;
+  headBranch: string;
+  labels: string[];
+  reviewStatus: ReviewStatus;
+  filesChanged: string[];
+  additions: number;
+  deletions: number;
+  diff: string;
+}
+
+interface FindingsGap {
+  description: string;
+  reason: 'not_found' | 'unavailable' | 'not_implemented' | 'invalid_request' | 'unknown';
+}
+
+interface EvidenceSource {
+  provider: EvidenceSourceProvider;
+  ref: string;
+  asOf: string;
+  revision?: string;
+  path?: string;
+}
+
+interface LoadedRawPr {
+  raw: string | null;
+  source: EvidenceSourceProvider;
+  sourcePath?: string;
+  sourceRevision?: string;
+  actionCount: number;
+  gaps: FindingsGap[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value.replace(/^#/, ''));
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+function readNestedString(record: Record<string, unknown>, key: string, nestedKey: string): string | undefined {
+  const value = record[key];
+  return isRecord(value) ? readString(value[nestedKey]) : undefined;
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function normalizeReviewStatus(value: unknown): ReviewStatus {
+  const normalized = readString(value)?.toLowerCase().replace(/\s+/g, '_');
+  if (normalized === 'approved' || normalized === 'changes_requested' || normalized === 'pending') {
+    return normalized;
+  }
+
+  return 'none';
+}
+
+function readLabels(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((label) => label.trim())
+      .filter(Boolean);
+  }
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((label) => (typeof label === 'string' ? label : isRecord(label) ? readString(label.name) : undefined))
+    .filter((label): label is string => label !== undefined);
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function buildRepoRoot(owner: string, repo: string): string {
+  return `/github/repos/${encodePathSegment(owner)}/${encodePathSegment(repo)}`;
+}
+
+function buildPullRequestRef(owner: string, repo: string, number: number): string {
+  return `${buildRepoRoot(owner, repo)}/pulls/${number}`;
+}
+
+function directPrPaths(owner: string, repo: string, number: number): {
+  metadata: string[];
+  raw: string[];
+  diff: string;
+} {
+  const root = buildPullRequestRef(owner, repo, number);
+  return {
+    metadata: [`${root}/meta.json`, `${root}/metadata.json`],
+    raw: [`${root}/pr.md`, `${root}/pr.txt`, `${root}/summary.md`],
+    diff: `${root}/diff.patch`,
+  };
+}
+
+async function safeRead(vfs: VfsProvider, filePath: string): Promise<VfsReadResult | null> {
+  try {
+    return await vfs.read(filePath);
+  } catch {
+    return null;
+  }
+}
+
+async function readFirst(vfs: VfsProvider, paths: string[]): Promise<VfsReadResult | null> {
+  for (const filePath of paths) {
+    const result = await safeRead(vfs, filePath);
+    if (result) {
+      return result;
+    }
+  }
+
+  return null;
+}
+
+function formatPullRequest(
+  number: number,
+  metadata: Record<string, unknown> | null,
+  diff: string | null,
+): string | null {
+  if (!metadata && !diff) {
+    return null;
+  }
+
+  const title = metadata ? readString(metadata.title) ?? `PR #${number}` : `PR #${number}`;
+  const body = metadata ? readString(metadata.body) ?? '' : '';
+  const url = metadata ? readString(metadata.html_url) ?? readString(metadata.url) ?? '' : '';
+  const state = metadata ? readString(metadata.state) ?? 'open' : 'open';
+  const author = metadata
+    ? readString(metadata.author) ??
+      readNestedString(metadata, 'author', 'login') ??
+      readNestedString(metadata, 'user', 'login') ??
+      readNestedString(metadata, 'user', 'name') ??
+      'unknown'
+    : 'unknown';
+  const baseBranch = metadata
+    ? readString(metadata.baseBranch) ??
+      readString(metadata.base_branch) ??
+      readNestedString(metadata, 'base', 'ref') ??
+      'unknown'
+    : 'unknown';
+  const headBranch = metadata
+    ? readString(metadata.headBranch) ??
+      readString(metadata.head_branch) ??
+      readNestedString(metadata, 'head', 'ref') ??
+      'unknown'
+    : 'unknown';
+  const labels = metadata ? readLabels(metadata.labels) : [];
+  const reviewStatus = metadata
+    ? normalizeReviewStatus(metadata.reviewStatus ?? metadata.review_status)
+    : 'none';
+
+  return [
+    `Title: ${title}`,
+    url ? `URL: ${url}` : '',
+    `State: ${state}`,
+    `Author: ${author}`,
+    `Base Branch: ${baseBranch}`,
+    `Head Branch: ${headBranch}`,
+    `Labels: ${labels.join(', ')}`,
+    `Review Status: ${reviewStatus}`,
+    'Body:',
+    body,
+    'Diff:',
+    diff ?? '',
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+}
+
+function formatApiPullRequest(number: number, data: GitHubApiPullRequest): string | null {
+  const metadata: Record<string, unknown> = {
+    title: data.title,
+    body: data.body ?? '',
+    state: data.state,
+    html_url: data.html_url ?? data.url,
+    author: data.author,
+    user: data.user,
+    base: data.base,
+    head: data.head,
+    baseBranch: data.baseBranch,
+    headBranch: data.headBranch,
+    base_branch: data.base_branch,
+    head_branch: data.head_branch,
+    labels: data.labels,
+    reviewStatus: data.reviewStatus,
+    review_status: data.review_status,
+  };
+
+  return formatPullRequest(number, metadata, data.diff ?? null);
+}
+
+function parsePrSections(raw: string): ParsedPrSections {
+  const normalized = raw.trim();
+  const titleMatch = normalized.match(/^Title:\s*(.+)$/m);
+  const urlMatch = normalized.match(/^URL:\s*(.+)$/m);
+  const stateMatch = normalized.match(/^State:\s*(.+)$/m);
+  const authorMatch = normalized.match(/^Author:\s*(.+)$/m);
+  const baseBranchMatch = normalized.match(/^Base Branch:\s*(.+)$/m);
+  const headBranchMatch = normalized.match(/^Head Branch:\s*(.+)$/m);
+  const reviewStatusMatch = normalized.match(/^Review Status:\s*(.+)$/m);
+  const labelsMatch = normalized.match(/^Labels:\s*(.*)$/m);
+  const bodyMarker = normalized.indexOf('\nBody:');
+  const diffMarker = normalized.indexOf('\nDiff:');
+
+  const bodyStart = bodyMarker >= 0 ? bodyMarker + '\nBody:'.length : -1;
+  const diffStart = diffMarker >= 0 ? diffMarker + '\nDiff:'.length : -1;
+  const body =
+    bodyStart >= 0
+      ? normalized.slice(bodyStart, diffStart >= 0 ? diffMarker : normalized.length).trim()
+      : '';
+  const diff = diffStart >= 0 ? normalized.slice(diffStart).trim() : '';
+  const labels = readLabels(labelsMatch?.[1] ?? '');
+
+  return {
+    title: titleMatch?.[1]?.trim() ?? 'Pull request',
+    url: urlMatch?.[1]?.trim() ?? '',
+    body,
+    diff,
+    state: stateMatch?.[1]?.trim() ?? 'open',
+    author: authorMatch?.[1]?.trim() ?? 'unknown',
+    baseBranch: baseBranchMatch?.[1]?.trim() ?? 'unknown',
+    headBranch: headBranchMatch?.[1]?.trim() ?? 'unknown',
+    labels,
+    reviewStatus: normalizeReviewStatus(reviewStatusMatch?.[1]),
+  };
+}
+
+function extractFilesChanged(diff: string): string[] {
+  const files = new Set<string>();
+
+  for (const line of diff.split('\n')) {
+    const patchHeader = line.match(/^---\s+(.+?)\s+\((?:added|modified|removed|renamed)\)$/);
+    if (patchHeader?.[1]) {
+      files.add(patchHeader[1].trim());
+      continue;
+    }
+
+    const gitHeader = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (gitHeader?.[2]) {
+      files.add(gitHeader[2].trim());
+      continue;
+    }
+
+    const plusHeader = line.match(/^\+\+\+\s+b\/(.+)$/);
+    if (plusHeader?.[1]) {
+      files.add(plusHeader[1].trim());
+    }
+  }
+
+  return [...files];
+}
+
+function countDiffLines(diff: string): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++') || line.startsWith('---')) {
+      continue;
+    }
+    if (line.startsWith('+')) {
+      additions += 1;
+    } else if (line.startsWith('-')) {
+      deletions += 1;
+    }
+  }
+
+  return { additions, deletions };
+}
+
+function categorizeChanges(filesChanged: string[]): string[] {
+  const categories = new Set<string>();
+
+  for (const file of filesChanged) {
+    if (/(\.|\/)(test|spec)\./i.test(file) || /__tests__/.test(file)) {
+      categories.add('test');
+      continue;
+    }
+    if (/^docs\/|\.md$/i.test(file)) {
+      categories.add('docs');
+      continue;
+    }
+    if (/package\.json$|lock|\.ya?ml$|\.json$/i.test(file)) {
+      categories.add('config');
+      continue;
+    }
+    categories.add('feature');
+  }
+
+  return [...categories];
+}
+
+function buildRiskAreas(filesChanged: string[]): Array<Record<string, unknown>> {
+  return filesChanged.slice(0, 3).map((file) => {
+    const lower = file.toLowerCase();
+    if (/auth|security|permission|token/.test(lower)) {
+      return {
+        file,
+        concern: 'Authentication or security-sensitive paths changed and need regression review.',
+        severity: 'high',
+      };
+    }
+    if (/config|workflow|deploy|migration/.test(lower)) {
+      return {
+        file,
+        concern: 'Operational or rollout-sensitive changes need validation in deployment paths.',
+        severity: 'medium',
+      };
+    }
+    return {
+      file,
+      concern: 'Behavioral changes should be checked for test coverage and edge-case regressions.',
+      severity: /(\.|\/)(test|spec)\./i.test(lower) ? 'low' : 'medium',
+    };
+  });
+}
+
+function buildStructuredPr(raw: string): StructuredPr {
+  const parsed = parsePrSections(raw);
+  const filesChanged = extractFilesChanged(parsed.diff);
+  const { additions, deletions } = countDiffLines(parsed.diff);
+
+  return {
+    title: parsed.title,
+    body: parsed.body,
+    url: parsed.url,
+    state: parsed.state || 'open',
+    author: parsed.author,
+    baseBranch: parsed.baseBranch,
+    headBranch: parsed.headBranch,
+    labels: parsed.labels,
+    reviewStatus: parsed.reviewStatus,
+    filesChanged,
+    additions,
+    deletions,
+    diff: parsed.diff,
+  };
+}
+
+function buildSummary(structured: StructuredPr, riskAreas: Array<Record<string, unknown>>): string {
+  const fileList = structured.filesChanged.slice(0, 3).join(', ');
+  const topRisk = riskAreas[0];
+  const topRiskText =
+    topRisk && typeof topRisk.concern === 'string' && typeof topRisk.file === 'string'
+      ? ` Top risk: ${topRisk.file} - ${topRisk.concern}`
+      : '';
+
+  return `${structured.title} touches ${structured.filesChanged.length} file(s)${
+    fileList ? `, including ${fileList}.` : '.'
+  }${topRiskText}`;
+}
+
+function sourceMetadata(source: EvidenceSource): Record<string, unknown> {
+  return {
+    provider: source.provider,
+    ref: source.ref,
+    asOf: source.asOf,
+    ...(source.revision === undefined ? {} : { revision: source.revision }),
+    ...(source.path === undefined ? {} : { path: source.path }),
+  };
+}
+
+function buildMetadataFinding(
+  request: PrInvestigationRequest,
+  structured: StructuredPr,
+  source: EvidenceSource,
+): SpecialistFinding {
+  const metadata = {
+    number: request.pr.number,
+    title: structured.title,
+    state: structured.state,
+    author: structured.author,
+    baseBranch: structured.baseBranch,
+    headBranch: structured.headBranch,
+    labels: structured.labels,
+    reviewStatus: structured.reviewStatus,
+    additions: structured.additions,
+    deletions: structured.deletions,
+    url: structured.url,
+  };
+
+  return {
+    title: `PR #${request.pr.number} metadata`,
+    body: JSON.stringify(metadata, null, 2),
+    ...(structured.url ? { url: structured.url } : {}),
+    metadata: {
+      id: 'pr-meta',
+      kind: 'pr_summary',
+      confidence: 0.72,
+      source: sourceMetadata(source),
+      structured: metadata,
+    },
+  };
+}
+
+async function buildDiffFinding(
+  request: PrInvestigationRequest,
+  structured: StructuredPr,
+  source: EvidenceSource,
+  evidenceWriter: EvidenceWriter | null,
+): Promise<SpecialistFinding> {
+  const riskAreas = buildRiskAreas(structured.filesChanged);
+  const structuredContent = {
+    filesChanged: structured.filesChanged,
+    riskAreas,
+    changeCategories: categorizeChanges(structured.filesChanged),
+  };
+  const changedFiles = structured.filesChanged.map((file) => `- ${file}`).join('\n');
+  let body = `Changed files:\n${changedFiles}\n\nDiff:\n${structured.diff}`.trim();
+  let durableRef: DurableEvidenceRef | undefined;
+
+  if (
+    evidenceWriter &&
+    request.allowDurableEvidence !== false &&
+    byteLength(body) > DURABLE_EVIDENCE_THRESHOLD_BYTES
+  ) {
+    durableRef = await evidenceWriter.writeEvidence({
+      requestId: request.requestId,
+      evidenceId: 'pr-diff',
+      kind: 'diff_analysis',
+      title: `PR #${request.pr.number} diff analysis`,
+      content: body,
+      contentType: 'text/markdown',
+      confidence: structured.filesChanged.length > 0 ? 0.88 : 0.62,
+    });
+    body = `Changed files:\n${changedFiles}\n\nDiff analysis persisted as durable evidence.`;
+  }
+
+  return {
+    title: `PR #${request.pr.number} diff analysis`,
+    body,
+    metadata: {
+      id: 'pr-diff',
+      kind: 'diff_analysis',
+      confidence: structured.filesChanged.length > 0 ? 0.88 : 0.62,
+      source: sourceMetadata(source),
+      structured: structuredContent,
+      ...(durableRef === undefined ? {} : { durableRef }),
+    },
+  };
+}
+
+async function loadRawPrFromVfs(request: PrInvestigationRequest, vfs: VfsProvider): Promise<LoadedRawPr> {
+  const { owner, repo } = request.repo;
+  const { number } = request.pr;
+  const paths = directPrPaths(owner, repo, number);
+
+  const [metadataResult, rawResult, diffResult] = await Promise.all([
+    readFirst(vfs, paths.metadata),
+    readFirst(vfs, paths.raw),
+    safeRead(vfs, paths.diff),
+  ]);
+
+  if (rawResult) {
+    return {
+      raw: rawResult.content,
+      source: 'vfs',
+      sourcePath: rawResult.path,
+      ...(rawResult.revision === undefined ? {} : { sourceRevision: rawResult.revision }),
+      actionCount: 1,
+      gaps: [],
+    };
+  }
+
+  const metadata = metadataResult ? parseJsonRecord(metadataResult.content) : null;
+  const raw = formatPullRequest(number, metadata, diffResult?.content ?? null);
+  if (raw) {
+    const sourcePath = metadataResult?.path ?? diffResult?.path;
+    const sourceRevision = metadataResult?.revision ?? diffResult?.revision;
+    return {
+      raw,
+      source: 'vfs',
+      ...(sourcePath === undefined ? {} : { sourcePath }),
+      ...(sourceRevision === undefined ? {} : { sourceRevision }),
+      actionCount: 1,
+      gaps: [],
+    };
+  }
+
+  return {
+    raw: null,
+    source: 'vfs',
+    actionCount: 1,
+    gaps: [
+      {
+        description: `PR #${number} in ${owner}/${repo} was unavailable from VFS.`,
+        reason: 'not_found',
+      },
+    ],
+  };
+}
+
+function extractApiData(result: { data: GitHubApiPullRequest } | GitHubApiPullRequest | null): GitHubApiPullRequest | null {
+  if (!result) {
+    return null;
+  }
+
+  if (isRecord(result) && isRecord(result.data)) {
+    return result.data as GitHubApiPullRequest;
+  }
+
+  return isRecord(result) ? (result as GitHubApiPullRequest) : null;
+}
+
+async function loadRawPr(request: PrInvestigationRequest, deps: GitHubInvestigatorDeps): Promise<LoadedRawPr> {
+  const loadedFromVfs = await loadRawPrFromVfs(request, deps.vfs);
+  if (loadedFromVfs.raw) {
+    return loadedFromVfs;
+  }
+
+  const apiFallback = deps.apiFallback ?? deps.github ?? null;
+  if (!apiFallback) {
+    return loadedFromVfs;
+  }
+
+  const { owner, repo } = request.repo;
+  const { number } = request.pr;
+  const result = extractApiData(await apiFallback.readPRDiff(owner, repo, number));
+  if (!result || (!readString(result.title) && !readString(result.diff))) {
+    return {
+      raw: null,
+      source: 'github_api',
+      actionCount: loadedFromVfs.actionCount + 1,
+      gaps: [
+        {
+          description: `PR #${number} in ${owner}/${repo} could not be loaded from GitHub API fallback.`,
+          reason: 'unavailable',
+        },
+      ],
+    };
+  }
+
+  return {
+    raw: formatApiPullRequest(number, result),
+    source: 'github_api',
+    actionCount: loadedFromVfs.actionCount + 1,
+    gaps: [],
+  };
+}
+
+function createFindings(input: {
+  request: PrInvestigationRequest;
+  status: SpecialistFindings['status'];
+  summary: string;
+  findings: SpecialistFinding[];
+  confidence: number;
+  metadata: Record<string, unknown>;
+}): SpecialistFindings {
+  return {
+    requestId: input.request.requestId,
+    capability: PR_INVESTIGATION_CAPABILITY,
+    status: input.status,
+    summary: input.summary,
+    findings: input.findings,
+    confidence: input.confidence,
+    metadata: {
+      specialistName: SPECIALIST_NAME,
+      specialistVersion: SPECIALIST_VERSION,
+      ...input.metadata,
+    },
+  };
+}
+
+function failedFindings(
+  request: PrInvestigationRequest,
+  summary: string,
+  gaps: FindingsGap[],
+  confidence: number,
+  metadata: Record<string, unknown>,
+): SpecialistFindings {
+  return createFindings({
+    request,
+    status: 'failed',
+    summary,
+    findings: [],
+    confidence,
+    metadata: {
+      gaps,
+      recommendedNext: [
+        {
+          type: 'fallback_inline',
+          description: 'Coordinator should fall back to the inline GitHub PR read path.',
+        },
+      ],
+      ...metadata,
+    },
+  });
+}
+
+export async function investigatePullRequest(
+  request: PrInvestigationRequest,
+  deps: GitHubInvestigatorDeps,
+): Promise<SpecialistFindings> {
+  const startedAt = deps.now?.() ?? Date.now();
+  const producedAt = new Date(startedAt).toISOString();
+  const evidenceWriter = deps.evidenceWriter ?? null;
+
+  try {
+    const loaded = await loadRawPr(request, deps);
+    if (!loaded.raw) {
+      return failedFindings(
+        request,
+        `Unable to investigate PR #${request.pr.number}.`,
+        loaded.gaps,
+        0.2,
+        {
+          durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+          actionCount: loaded.actionCount,
+          durableEvidenceCount: 0,
+          producedAt,
+        },
+      );
+    }
+
+    const structured = buildStructuredPr(loaded.raw);
+    const source: EvidenceSource = {
+      provider: loaded.source,
+      ref: `${buildPullRequestRef(request.repo.owner, request.repo.repo, request.pr.number)}`,
+      asOf: producedAt,
+      ...(loaded.sourcePath === undefined ? {} : { path: loaded.sourcePath }),
+      ...(loaded.sourceRevision === undefined ? {} : { revision: loaded.sourceRevision }),
+    };
+    const metaFinding = buildMetadataFinding(request, structured, source);
+    const diffFinding = await buildDiffFinding(request, structured, source, evidenceWriter);
+    await evidenceWriter?.finalize?.();
+
+    const findings = [metaFinding, diffFinding];
+    const riskAreas =
+      (diffFinding.metadata?.structured as { riskAreas?: Array<Record<string, unknown>> } | undefined)?.riskAreas ??
+      [];
+    const gaps: FindingsGap[] = [
+      {
+        description: 'PR comments and review discussion are not implemented in the v1 specialist path.',
+        reason: 'not_implemented',
+      },
+      ...loaded.gaps,
+    ];
+    const durableEvidenceCount = findings.filter((finding) => finding.metadata?.durableRef).length;
+
+    return createFindings({
+      request,
+      status: 'complete',
+      summary: buildSummary(structured, riskAreas),
+      findings,
+      confidence: 0.86,
+      metadata: {
+        gaps,
+        recommendedNext: [
+          {
+            type: 'none',
+            description: 'No further specialist action required for the current PR investigation.',
+          },
+        ],
+        durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+        actionCount: loaded.actionCount,
+        durableEvidenceCount,
+        producedAt,
+      },
+    });
+  } catch (error) {
+    return failedFindings(
+      request,
+      `Unable to investigate PR #${request.pr.number}.`,
+      [
+        {
+          description: error instanceof Error ? error.message : String(error),
+          reason: 'unknown',
+        },
+      ],
+      0.1,
+      {
+        durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+        actionCount: 1,
+        durableEvidenceCount: 0,
+        producedAt,
+      },
+    );
+  }
+}
+
+function readRepoRef(value: unknown): GitHubRepoRef | null {
+  if (typeof value === 'string') {
+    const match = value.match(/^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/);
+    return match ? { owner: match[1]!, repo: match[2]! } : null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const owner = readString(value.owner);
+  const repo = readString(value.repo) ?? readString(value.name);
+  return owner && repo ? { owner, repo } : null;
+}
+
+function readPrNumber(value: unknown): number | undefined {
+  if (isRecord(value)) {
+    return readNumber(value.number) ?? readNumber(value.id);
+  }
+
+  return readNumber(value);
+}
+
+function readFilters(value: unknown): GitHubQueryFilterSet | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const filters: GitHubQueryFilterSet = {};
+  for (const [key, filterValue] of Object.entries(value)) {
+    if (!Array.isArray(filterValue)) {
+      continue;
+    }
+
+    const strings = filterValue
+      .map((item) => (typeof item === 'string' ? item : undefined))
+      .filter((item): item is string => item !== undefined);
+    if (strings.length > 0) {
+      filters[key] = strings;
+    }
+  }
+
+  return Object.keys(filters).length > 0 ? filters : undefined;
+}
+
+function parseTargetFromText(text: string, filters?: GitHubQueryFilterSet): GitHubPullRequestRef | null {
+  const githubUrl = text.match(/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/pull\/(\d+)/i);
+  if (githubUrl) {
+    return {
+      owner: githubUrl[1]!,
+      repo: githubUrl[2]!,
+      number: Number(githubUrl[3]),
+    };
+  }
+
+  const compact = text.match(/\b([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)#(\d+)\b/);
+  if (compact) {
+    return {
+      owner: compact[1]!,
+      repo: compact[2]!,
+      number: Number(compact[3]),
+    };
+  }
+
+  const repoFilter = filters?.repo?.[0];
+  const inlineRepo = text.match(/\brepo:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\b/)?.[1];
+  const genericRepo = text.match(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\b/)?.[1];
+  const repo = readRepoRef(repoFilter ?? inlineRepo ?? genericRepo);
+  const numberMatch =
+    text.match(/\b(?:pr|pull request|pull)\s*#?\s*(\d+)\b/i) ?? text.match(/#(\d+)\b/);
+  const number = numberMatch ? Number(numberMatch[1]) : undefined;
+
+  return repo && number ? { ...repo, number } : null;
+}
+
+function requestIdFromContext(context?: SpecialistContext): string {
+  if (!context) {
+    return `github-investigator-${Date.now()}`;
+  }
+
+  return `${context.turnId || 'turn'}-${context.stepIndex}`;
+}
+
+function requestFromRecord(record: Record<string, unknown>, fallbackRequestId: string): PrInvestigationRequest | null {
+  const candidates = [record.parameters, record.params, record].filter(isRecord);
+  const requestId = readString(record.requestId) ?? fallbackRequestId;
+  const instruction = readString(record.instruction);
+  const bounds = isRecord(record.bounds) ? record.bounds : null;
+  const allowDurableEvidence =
+    typeof bounds?.allowDurableEvidence === 'boolean' ? bounds.allowDurableEvidence : undefined;
+
+  for (const candidate of candidates) {
+    const directRepo = readRepoRef(candidate.repo) ?? readRepoRef(candidate.repository);
+    const directNumber =
+      readPrNumber(candidate.pr) ?? readPrNumber(candidate.pullRequest) ?? readPrNumber(candidate.number);
+    if (directRepo && directNumber) {
+      return {
+        requestId,
+        repo: directRepo,
+        pr: { number: directNumber },
+        ...(instruction === undefined ? {} : { query: instruction }),
+        ...(allowDurableEvidence === undefined ? {} : { allowDurableEvidence }),
+      };
+    }
+
+    const query = readString(candidate.query) ?? instruction;
+    const filters = readFilters(candidate.filters);
+    if (query) {
+      const parsed = parseTargetFromText(query, filters);
+      if (parsed) {
+        return {
+          requestId,
+          repo: { owner: parsed.owner, repo: parsed.repo },
+          pr: { number: parsed.number },
+          query,
+          ...(allowDurableEvidence === undefined ? {} : { allowDurableEvidence }),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function parseGitHubInvestigationInstruction(
+  instruction: string,
+  context?: SpecialistContext,
+): PrInvestigationRequest | null {
+  const fallbackRequestId = requestIdFromContext(context);
+  try {
+    const parsed = JSON.parse(instruction) as unknown;
+    if (isRecord(parsed)) {
+      const request = requestFromRecord(parsed, fallbackRequestId);
+      if (request) {
+        return request;
+      }
+    }
+  } catch {
+    // Plain text instructions are handled below.
+  }
+
+  const target = parseTargetFromText(instruction);
+  if (!target) {
+    return null;
+  }
+
+  return {
+    requestId: fallbackRequestId,
+    repo: { owner: target.owner, repo: target.repo },
+    pr: { number: target.number },
+    query: instruction,
+  };
+}
+
+function unparseableRequest(instruction: string, context?: SpecialistContext): PrInvestigationRequest {
+  return {
+    requestId: requestIdFromContext(context),
+    repo: { owner: 'unknown', repo: 'unknown' },
+    pr: { number: 0 },
+    query: instruction,
+    allowDurableEvidence: false,
+  };
+}
+
+export async function investigateGitHub(
+  params: GitHubInvestigationParams,
+  deps: GitHubInvestigatorDeps,
+): Promise<SpecialistFindings> {
+  const direct = params.pr
+    ? {
+        requestId: `github-investigation-${params.pr.owner}-${params.pr.repo}-${params.pr.number}`,
+        repo: { owner: params.pr.owner, repo: params.pr.repo },
+        pr: { number: params.pr.number },
+        query: params.query,
+      }
+    : null;
+  const request =
+    direct ??
+    requestFromRecord(
+      {
+        requestId: 'github-investigation',
+        params,
+      },
+      'github-investigation',
+    );
+
+  if (!request) {
+    return failedFindings(
+      unparseableRequest(params.query),
+      'Unable to investigate PR because the instruction did not include a GitHub pull request target.',
+      [
+        {
+          description: 'Expected a GitHub PR URL, owner/repo#number, repo filter with PR number, or params.pr.',
+          reason: 'invalid_request',
+        },
+      ],
+      0.05,
+      {
+        actionCount: 0,
+        durableEvidenceCount: 0,
+        producedAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+      },
+    );
+  }
+
+  return investigatePullRequest(request, deps);
+}
+
+function toSpecialistResult(findings: SpecialistFindings): SpecialistResult {
+  return {
+    specialistName: SPECIALIST_NAME,
+    output: JSON.stringify(findings, null, 2),
+    status: findings.status,
+    ...(findings.confidence === undefined ? {} : { confidence: findings.confidence }),
+    metadata: {
+      requestId: findings.requestId,
+      capability: findings.capability,
+      findings,
+    },
+  };
+}
+
+export function createGitHubInvestigator(deps: GitHubInvestigatorDeps): Specialist {
+  return {
+    name: SPECIALIST_NAME,
+    description: 'Investigates GitHub pull requests using VFS evidence with an optional API fallback.',
+    capabilities: [PR_INVESTIGATION_CAPABILITY],
+    handler: {
+      async execute(instruction, context) {
+        const request = parseGitHubInvestigationInstruction(instruction, context);
+        if (!request) {
+          return toSpecialistResult(
+            failedFindings(
+              unparseableRequest(instruction, context),
+              'Unable to investigate PR because the instruction did not include a GitHub pull request target.',
+              [
+                {
+                  description: 'Expected a GitHub PR URL, owner/repo#number, or repo filter with PR number.',
+                  reason: 'invalid_request',
+                },
+              ],
+              0.05,
+              {
+                actionCount: 0,
+                durableEvidenceCount: 0,
+                producedAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+              },
+            ),
+          );
+        }
+
+        return toSpecialistResult(await investigatePullRequest(request, deps));
+      },
+    },
+  };
+}

--- a/packages/specialists/src/github/investigator.ts
+++ b/packages/specialists/src/github/investigator.ts
@@ -1,5 +1,9 @@
 import type { Specialist, SpecialistContext, SpecialistResult } from '@agent-assistant/coordination';
 import type { VfsProvider, VfsReadResult } from '@agent-assistant/vfs';
+import {
+  githubPullRequestPath,
+  githubRepoPrefix,
+} from '@relayfile/adapter-github/path-mapper';
 
 import type { SpecialistFinding, SpecialistFindings } from '../shared/findings.js';
 import type { GitHubInvestigationParams, GitHubPullRequestRef, GitHubQueryFilterSet } from './types.js';
@@ -204,16 +208,10 @@ function readLabels(value: unknown): string[] {
     .filter((label): label is string => label !== undefined);
 }
 
-function encodePathSegment(value: string): string {
-  return encodeURIComponent(value);
-}
-
-function buildRepoRoot(owner: string, repo: string): string {
-  return `/github/repos/${encodePathSegment(owner)}/${encodePathSegment(repo)}`;
-}
-
+// Path math delegated to @relayfile/adapter-github/path-mapper — the adapter
+// is the source of truth for where GitHub VFS data lives.
 function buildPullRequestRef(owner: string, repo: string, number: number): string {
-  return `${buildRepoRoot(owner, repo)}/pulls/${number}`;
+  return `${githubRepoPrefix(owner, repo)}/pulls/${number}`;
 }
 
 function directPrPaths(owner: string, repo: string, number: number): {
@@ -221,9 +219,11 @@ function directPrPaths(owner: string, repo: string, number: number): {
   raw: string[];
   diff: string;
 } {
+  const canonicalMetadata = githubPullRequestPath(owner, repo, String(number));
   const root = buildPullRequestRef(owner, repo, number);
   return {
-    metadata: [`${root}/meta.json`, `${root}/metadata.json`],
+    // adapter-github canonical first; keep legacy /meta.json for pre-adapter VFS data.
+    metadata: [canonicalMetadata, `${root}/meta.json`],
     raw: [`${root}/pr.md`, `${root}/pr.txt`, `${root}/summary.md`],
     diff: `${root}/diff.patch`,
   };

--- a/packages/specialists/src/github/investigator.ts
+++ b/packages/specialists/src/github/investigator.ts
@@ -416,7 +416,10 @@ function categorizeChanges(filesChanged: string[]): string[] {
       categories.add('docs');
       continue;
     }
-    if (/package\.json$|lock|\.ya?ml$|\.json$/i.test(file)) {
+    // `\.lock$` covers yarn.lock/bun.lockb etc; `lock\.json$` covers package-lock.json;
+    // `\.json$` and `\.ya?ml$` catch generic config. Anchored to avoid matching
+    // unrelated substrings like "distributed-lock.ts".
+    if (/\.lock$|lock\.json$|package\.json$|\.ya?ml$|\.json$/i.test(file)) {
       categories.add('config');
       continue;
     }

--- a/packages/specialists/src/github/librarian.test.ts
+++ b/packages/specialists/src/github/librarian.test.ts
@@ -1,0 +1,121 @@
+import type { VfsEntry, VfsProvider, VfsReadResult, VfsSearchResult } from '@agent-assistant/vfs';
+import { describe, expect, it } from 'vitest';
+
+import { createGitHubLibrarian } from './librarian.js';
+
+class InMemoryVfsProvider implements VfsProvider {
+  constructor(private readonly entries: VfsEntry[]) {}
+
+  async list(rootPath: string): Promise<VfsEntry[]> {
+    const normalizedRoot = rootPath.endsWith('/') ? rootPath : `${rootPath}/`;
+    return this.entries.filter((entry) => entry.path === rootPath || entry.path.startsWith(normalizedRoot));
+  }
+
+  async read(): Promise<VfsReadResult | null> {
+    return null;
+  }
+
+  async search(): Promise<VfsSearchResult[]> {
+    return [];
+  }
+}
+
+const pullRequests: VfsEntry[] = [
+  {
+    path: '/github/repos/foo/bar/pulls/1',
+    type: 'file',
+    provider: 'github',
+    revision: 'rev-1',
+    updatedAt: '2026-04-17T12:00:00.000Z',
+    title: 'Patch token validation',
+    properties: {
+      id: 'foo-bar-pr-1',
+      type: 'pr',
+      repo: 'foo/bar',
+      number: '1',
+      state: 'open',
+      label: 'security,backend',
+      url: 'https://github.com/foo/bar/pull/1',
+    },
+  },
+  {
+    path: '/github/repos/baz/qux/pulls/2',
+    type: 'file',
+    provider: 'github',
+    revision: 'rev-2',
+    updatedAt: '2026-04-17T11:00:00.000Z',
+    title: 'Fix retry logging',
+    properties: {
+      id: 'baz-qux-pr-2',
+      type: 'pull_request',
+      repo: 'baz/qux',
+      number: '2',
+      state: 'open',
+      label: 'observability',
+      url: 'https://github.com/baz/qux/pull/2',
+    },
+  },
+  {
+    path: '/github/repos/foo/bar/pulls/3',
+    type: 'file',
+    provider: 'github',
+    revision: 'rev-3',
+    updatedAt: '2026-04-17T10:00:00.000Z',
+    title: 'Close stale dependency update',
+    properties: {
+      id: 'foo-bar-pr-3',
+      type: 'pr',
+      repo: 'foo/bar',
+      number: '3',
+      state: 'closed',
+      label: 'dependencies',
+      url: 'https://github.com/foo/bar/pull/3',
+    },
+  },
+];
+
+function createLibrarian() {
+  return createGitHubLibrarian({
+    vfs: new InMemoryVfsProvider(pullRequests),
+  });
+}
+
+function evidenceIdsFor(instruction: string): Promise<string[]> {
+  return createLibrarian()
+    .handler.execute(instruction)
+    .then((result) => result.evidence.map((item) => item.id));
+}
+
+describe('createGitHubLibrarian filter matching', () => {
+  it('matches state:open against only open PR entries', async () => {
+    await expect(evidenceIdsFor('state:open')).resolves.toEqual(['foo-bar-pr-1', 'baz-qux-pr-2']);
+  });
+
+  it('matches state:open label:security against the open security PR', async () => {
+    const result = await createLibrarian().handler.execute('state:open label:security');
+
+    expect(result.status).toBe('complete');
+    expect(result.evidence.map((item) => item.id)).toEqual(['foo-bar-pr-1']);
+    expect(result.evidence[0]?.content).toEqual(
+      expect.objectContaining({
+        type: 'pr',
+        repo: 'foo/bar',
+        state: 'open',
+        labels: ['security', 'backend'],
+        number: '1',
+      }),
+    );
+  });
+
+  it('scopes type:pr repo:foo/bar to that repository', async () => {
+    const result = await createLibrarian().handler.execute('type:pr repo:foo/bar');
+
+    expect(result.status).toBe('complete');
+    expect(result.metadata.filters).toEqual({
+      type: ['pr'],
+      repo: ['foo/bar'],
+    });
+    expect(result.evidence.map((item) => item.id)).toEqual(['foo-bar-pr-1', 'foo-bar-pr-3']);
+    expect(result.evidence.map((item) => item.content.repo)).toEqual(['foo/bar', 'foo/bar']);
+  });
+});

--- a/packages/specialists/src/github/librarian.ts
+++ b/packages/specialists/src/github/librarian.ts
@@ -8,7 +8,10 @@ import { parseQuery } from '../shared/query-syntax.js';
 import type { GitHubEnumerationParams } from './types.js';
 
 type GitHubEnumerationType = 'pr' | 'issue';
-type GitHubEnumerationCapability = 'github_enumeration';
+// Canonical capability literal matches types.ts GitHubEnumerationParams.capability
+// so routing/correlation keys line up across request and findings.
+type GitHubEnumerationCapability = 'github.enumerate';
+const GITHUB_ENUMERATION_CAPABILITY: GitHubEnumerationCapability = 'github.enumerate';
 type EnumerationStatus = 'complete' | 'partial' | 'failed';
 
 interface GitHubLibrarianVfs {
@@ -100,7 +103,7 @@ export function createGitHubLibrarian({
   return {
     name: 'github-librarian',
     description: 'Enumerates GitHub repositories, pull requests, and issues from VFS-backed metadata.',
-    capabilities: ['github_enumeration'],
+    capabilities: [GITHUB_ENUMERATION_CAPABILITY],
     handler: {
       async execute(instruction: string): Promise<GitHubLibrarianFindings> {
         const parsed = parseQuery(instruction);
@@ -123,18 +126,24 @@ export function createGitHubLibrarian({
         }
 
         if (entries.length === 0 && apiFallback) {
-          const fallbackEntries = await loadFallbackEntries(apiFallback, {
-            instruction,
-            text: parsed.text,
-            filters,
-            types,
-          });
-          if (fallbackEntries.length > 0) {
-            source = errors.length > 0 ? 'mixed' : 'apiFallback';
-            entries = fallbackEntries.map((entry) => ({
-              entry,
-              enumerationType: inferEnumerationType(entry),
-            }));
+          try {
+            const fallbackEntries = await loadFallbackEntries(apiFallback, {
+              instruction,
+              text: parsed.text,
+              filters,
+              types,
+            });
+            if (fallbackEntries.length > 0) {
+              source = errors.length > 0 ? 'mixed' : 'apiFallback';
+              entries = fallbackEntries.map((entry) => ({
+                entry,
+                enumerationType: inferEnumerationType(entry),
+              }));
+            }
+          } catch (error) {
+            // Mirror the VFS error-handling pattern so a failing apiFallback
+            // never crashes the handler — surface via errors + 'failed' status.
+            errors.push(errorMessage(error));
           }
         }
 
@@ -145,7 +154,7 @@ export function createGitHubLibrarian({
         const status = statusFor(evidence.length, errors.length);
 
         return {
-          capability: 'github_enumeration',
+          capability: GITHUB_ENUMERATION_CAPABILITY,
           status,
           summary: summarizeMatches(evidence),
           evidence,
@@ -156,8 +165,36 @@ export function createGitHubLibrarian({
   };
 }
 
-export async function enumerateGitHub(_params: GitHubEnumerationParams): Promise<never> {
-  throw new Error('enumerateGitHub requires a VFS instance; use createGitHubLibrarian({ vfs }).handler.execute().');
+// Functional counterpart to investigateGitHub — runs the librarian handler
+// for callers that have params + deps but don't want to instantiate a
+// Specialist. Uses params.query as the instruction when present.
+export async function enumerateGitHub(
+  params: GitHubEnumerationParams,
+  options: GitHubLibrarianOptions,
+): Promise<GitHubLibrarianFindings> {
+  const librarian = createGitHubLibrarian(options);
+  const instruction = buildEnumerationInstruction(params);
+  return librarian.handler.execute(instruction);
+}
+
+function buildEnumerationInstruction(params: GitHubEnumerationParams): string {
+  const parts: string[] = [];
+  if (params.query && params.query.trim()) {
+    parts.push(params.query.trim());
+  }
+
+  const filters = params.filters ?? {};
+  for (const key of ['state', 'repo', 'label', 'type'] as const) {
+    const values = filters[key];
+    if (!values || values.length === 0) {
+      continue;
+    }
+    for (const value of values) {
+      parts.push(`${key}:${value}`);
+    }
+  }
+
+  return parts.join(' ').trim();
 }
 
 function inferEnumerationFilters(text: string, parsedFilters: Record<string, string[]>): Record<string, string[]> {

--- a/packages/specialists/src/github/librarian.ts
+++ b/packages/specialists/src/github/librarian.ts
@@ -1,0 +1,583 @@
+import type { VfsEntry } from '@agent-assistant/vfs';
+
+import { parseQuery } from '../shared/query-syntax.js';
+import type { GitHubEnumerationParams } from './types.js';
+
+type GitHubEnumerationType = 'pr' | 'issue';
+type GitHubEnumerationCapability = 'github_enumeration';
+type EnumerationStatus = 'complete' | 'partial' | 'failed';
+
+interface GitHubLibrarianVfs {
+  list?(path: string, options?: { depth?: number; limit?: number }): Promise<readonly VfsEntry[]>;
+  search?(query: string, options?: { provider?: string; limit?: number }): Promise<readonly VfsEntry[]>;
+}
+
+interface GitHubLibrarianFallbackRequest {
+  instruction: string;
+  text: string;
+  filters: Record<string, string[]>;
+  types: GitHubEnumerationType[];
+}
+
+type GitHubLibrarianApiFallback =
+  | ((request: GitHubLibrarianFallbackRequest) => Promise<readonly VfsEntry[]>)
+  | {
+      list?(request: GitHubLibrarianFallbackRequest): Promise<readonly VfsEntry[]>;
+      search?(request: GitHubLibrarianFallbackRequest): Promise<readonly VfsEntry[]>;
+    };
+
+export interface GitHubLibrarianOptions {
+  vfs: GitHubLibrarianVfs;
+  apiFallback?: GitHubLibrarianApiFallback;
+}
+
+export interface GitHubEnumerationEvidenceContent {
+  type: GitHubEnumerationType | 'github';
+  path: string;
+  repo: string;
+  title: string;
+  state: string;
+  labels: string[];
+  properties: Record<string, string>;
+  provider?: string;
+  revision?: string;
+  updatedAt?: string;
+  url?: string;
+  number?: string;
+  snippet?: string;
+}
+
+export interface GitHubEnumerationEvidence {
+  id: string;
+  kind: 'enumeration_hit';
+  content: GitHubEnumerationEvidenceContent;
+}
+
+export interface GitHubLibrarianFindings {
+  capability: GitHubEnumerationCapability;
+  status: EnumerationStatus;
+  summary: string;
+  evidence: GitHubEnumerationEvidence[];
+  metadata: {
+    text: string;
+    filters: Record<string, string[]>;
+    resultCount: number;
+    source: 'vfs' | 'apiFallback' | 'mixed';
+    errors?: string[];
+  };
+}
+
+export interface GitHubLibrarianSpecialist {
+  name: 'github-librarian';
+  description: string;
+  capabilities: GitHubEnumerationCapability[];
+  handler: {
+    execute(instruction: string, context?: unknown): Promise<GitHubLibrarianFindings>;
+  };
+}
+
+interface EnumerationEntry {
+  entry: VfsEntry;
+  enumerationType: GitHubEnumerationType | 'github';
+}
+
+const DEFAULT_LIMIT = 1_000;
+const SUMMARY_LIMIT = 10;
+const GITHUB_PROVIDER = 'github';
+const COLLECTION_BY_TYPE: Record<GitHubEnumerationType, string> = {
+  pr: 'pulls',
+  issue: 'issues',
+};
+
+export function createGitHubLibrarian({
+  vfs,
+  apiFallback,
+}: GitHubLibrarianOptions): GitHubLibrarianSpecialist {
+  return {
+    name: 'github-librarian',
+    description: 'Enumerates GitHub repositories, pull requests, and issues from VFS-backed metadata.',
+    capabilities: ['github_enumeration'],
+    handler: {
+      async execute(instruction: string): Promise<GitHubLibrarianFindings> {
+        const parsed = parseQuery(instruction);
+        const filters = inferEnumerationFilters(parsed.text, parsed.filters);
+        const types = requestedTypes(filters);
+        const errors: string[] = [];
+        let source: GitHubLibrarianFindings['metadata']['source'] = 'vfs';
+        let entries: EnumerationEntry[] = [];
+
+        try {
+          if (types.length > 0) {
+            entries = await listEnumerationEntries(vfs, types, filters, errors);
+          } else if (hasNoFilters(filters)) {
+            entries = await searchGitHub(vfs, parsed.text, errors);
+          } else {
+            entries = await listEnumerationEntries(vfs, ['pr', 'issue'], filters, errors);
+          }
+        } catch (error) {
+          errors.push(errorMessage(error));
+        }
+
+        if (entries.length === 0 && apiFallback) {
+          const fallbackEntries = await loadFallbackEntries(apiFallback, {
+            instruction,
+            text: parsed.text,
+            filters,
+            types,
+          });
+          if (fallbackEntries.length > 0) {
+            source = errors.length > 0 ? 'mixed' : 'apiFallback';
+            entries = fallbackEntries.map((entry) => ({
+              entry,
+              enumerationType: inferEnumerationType(entry),
+            }));
+          }
+        }
+
+        const matchedEntries = dedupeEntries(entries)
+          .filter(({ entry }) => matchesRequestedFilters(entry, filters))
+          .sort(compareEntries);
+        const evidence = matchedEntries.map(({ entry, enumerationType }) => toEvidence(entry, enumerationType));
+        const status = statusFor(evidence.length, errors.length);
+
+        return {
+          capability: 'github_enumeration',
+          status,
+          summary: summarizeMatches(evidence),
+          evidence,
+          metadata: metadataFor(parsed.text, filters, evidence.length, source, errors),
+        };
+      },
+    },
+  };
+}
+
+export async function enumerateGitHub(_params: GitHubEnumerationParams): Promise<never> {
+  throw new Error('enumerateGitHub requires a VFS instance; use createGitHubLibrarian({ vfs }).handler.execute().');
+}
+
+function inferEnumerationFilters(text: string, parsedFilters: Record<string, string[]>): Record<string, string[]> {
+  const filters = cloneFilters(parsedFilters);
+  const normalizedText = ` ${text.toLowerCase()} `;
+
+  if (!filters.type || filters.type.length === 0) {
+    if (/\b(pr|prs|pull request|pull requests)\b/.test(normalizedText)) {
+      filters.type = ['pr'];
+    } else if (/\b(issue|issues)\b/.test(normalizedText)) {
+      filters.type = ['issue'];
+    }
+  }
+
+  if (!filters.state || filters.state.length === 0) {
+    if (/\bopen\b/.test(normalizedText)) {
+      filters.state = ['open'];
+    } else if (/\bclosed\b/.test(normalizedText)) {
+      filters.state = ['closed'];
+    }
+  }
+
+  if (!filters.label || filters.label.length === 0) {
+    const label = text.match(/\b(?:label|labeled|labelled)\s+["']?([^"'\s]+)["']?/i)?.[1];
+    if (label) {
+      filters.label = [label];
+    }
+  }
+
+  return filters;
+}
+
+function cloneFilters(filters: Record<string, string[]>): Record<string, string[]> {
+  return Object.fromEntries(Object.entries(filters).map(([key, values]) => [key, [...values]]));
+}
+
+function requestedTypes(filters: Record<string, string[]>): GitHubEnumerationType[] {
+  const values = filters.type ?? [];
+  const types: GitHubEnumerationType[] = [];
+
+  if (values.includes('pr')) {
+    types.push('pr');
+  }
+  if (values.includes('issue')) {
+    types.push('issue');
+  }
+
+  return types;
+}
+
+function hasNoFilters(filters: Record<string, string[]>): boolean {
+  return Object.values(filters).every((values) => values.length === 0) || Object.keys(filters).length === 0;
+}
+
+async function listEnumerationEntries(
+  vfs: GitHubLibrarianVfs,
+  types: GitHubEnumerationType[],
+  filters: Record<string, string[]>,
+  errors: string[],
+): Promise<EnumerationEntry[]> {
+  const listedEntries: EnumerationEntry[] = [];
+
+  if (vfs.list) {
+    const repoFilters = filters.repo ?? [];
+    const listRoots =
+      repoFilters.length > 0
+        ? repoFilters.flatMap((repo) => types.map((type) => `/github/repos/${repo}/${COLLECTION_BY_TYPE[type]}/`))
+        : ['/github/repos'];
+
+    for (const root of listRoots) {
+      try {
+        const entries = await vfs.list(root, { depth: repoFilters.length > 0 ? 2 : 5, limit: DEFAULT_LIMIT });
+        listedEntries.push(...entries.flatMap((entry) => toEnumerationEntry(entry, types)));
+      } catch (error) {
+        errors.push(errorMessage(error));
+      }
+    }
+  }
+
+  if (listedEntries.length > 0 || !vfs.search) {
+    return listedEntries;
+  }
+
+  const searchQuery = types.map((type) => (type === 'pr' ? 'pull request' : 'issue')).join(' ');
+  try {
+    const results = await vfs.search(searchQuery, { provider: GITHUB_PROVIDER, limit: DEFAULT_LIMIT });
+    return results.flatMap((entry) => toEnumerationEntry(entry, types));
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return [];
+  }
+}
+
+async function searchGitHub(
+  vfs: GitHubLibrarianVfs,
+  text: string,
+  errors: string[],
+): Promise<EnumerationEntry[]> {
+  if (!vfs.search) {
+    errors.push('VFS search is unavailable.');
+    return [];
+  }
+
+  try {
+    const results = await vfs.search(text.trim(), { provider: GITHUB_PROVIDER, limit: DEFAULT_LIMIT });
+    return results.map((entry) => ({
+      entry,
+      enumerationType: inferEnumerationType(entry),
+    }));
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return [];
+  }
+}
+
+async function loadFallbackEntries(
+  apiFallback: GitHubLibrarianApiFallback,
+  request: GitHubLibrarianFallbackRequest,
+): Promise<readonly VfsEntry[]> {
+  if (typeof apiFallback === 'function') {
+    return apiFallback(request);
+  }
+
+  if (request.types.length > 0 && apiFallback.list) {
+    return apiFallback.list(request);
+  }
+
+  if (apiFallback.search) {
+    return apiFallback.search(request);
+  }
+
+  if (apiFallback.list) {
+    return apiFallback.list(request);
+  }
+
+  return [];
+}
+
+function toEnumerationEntry(entry: VfsEntry, requested: GitHubEnumerationType[]): EnumerationEntry[] {
+  const inferredType = inferEnumerationType(entry);
+  if (inferredType === 'github') {
+    return [];
+  }
+  if (!requested.includes(inferredType)) {
+    return [];
+  }
+
+  return [{ entry, enumerationType: inferredType }];
+}
+
+function inferEnumerationType(entry: VfsEntry): GitHubEnumerationType | 'github' {
+  const propertyType = entry.properties?.type?.toLowerCase();
+  if (propertyType === 'pr' || propertyType === 'pull_request' || propertyType === 'pull-request') {
+    return 'pr';
+  }
+  if (propertyType === 'issue') {
+    return 'issue';
+  }
+
+  return collectionItemTypeFromPath(entry.path) ?? 'github';
+}
+
+function matchesRequestedFilters(entry: VfsEntry, filters: Record<string, string[]>): boolean {
+  return filterMatches(entry, filters, 'state') && filterMatches(entry, filters, 'repo') && filterMatches(entry, filters, 'label');
+}
+
+function filterMatches(entry: VfsEntry, filters: Record<string, string[]>, key: 'state' | 'repo' | 'label'): boolean {
+  const requested = filters[key];
+  if (!requested || requested.length === 0) {
+    return true;
+  }
+
+  const actual = valuesForFilter(entry, key).map((value) => normalizeComparable(value));
+  return requested.some((value) => actual.includes(normalizeComparable(value)));
+}
+
+function valuesForFilter(entry: VfsEntry, key: 'state' | 'repo' | 'label'): string[] {
+  const properties = entry.properties ?? {};
+
+  if (key === 'repo') {
+    return [properties.repo, properties.repository, repoFromPath(entry.path)].filter(isString);
+  }
+
+  if (key === 'label') {
+    return [
+      ...expandPropertyValues(properties.label),
+      ...expandPropertyValues(properties.labels),
+    ];
+  }
+
+  return expandPropertyValues(properties.state);
+}
+
+function toEvidence(entry: VfsEntry, enumerationType: GitHubEnumerationType | 'github'): GitHubEnumerationEvidence {
+  const properties = entry.properties ?? {};
+  const labels = [
+    ...expandPropertyValues(properties.label),
+    ...expandPropertyValues(properties.labels),
+  ];
+  const content: GitHubEnumerationEvidenceContent = {
+    type: enumerationType,
+    path: entry.path,
+    repo: firstString(properties.repo, properties.repository, repoFromPath(entry.path), 'unknown'),
+    title: firstString(entry.title, properties.title, titleFromPath(entry.path)),
+    state: firstString(properties.state, 'unknown'),
+    labels,
+    properties,
+  };
+  const number = firstString(properties.number, properties.pr, properties.issue, numberFromPath(entry.path));
+  const snippet = snippetFromEntry(entry);
+
+  if (entry.provider) {
+    content.provider = entry.provider;
+  }
+  if (entry.revision) {
+    content.revision = entry.revision;
+  }
+  if (entry.updatedAt) {
+    content.updatedAt = entry.updatedAt;
+  }
+  if (properties.url) {
+    content.url = properties.url;
+  }
+  if (number !== '') {
+    content.number = number;
+  }
+  if (snippet) {
+    content.snippet = snippet;
+  }
+
+  return {
+    id: firstString(properties.id, entry.path),
+    kind: 'enumeration_hit',
+    content,
+  };
+}
+
+function summarizeMatches(evidence: GitHubEnumerationEvidence[]): string {
+  if (evidence.length === 0) {
+    return 'No GitHub enumeration matches found.';
+  }
+
+  const lines = [`Found ${evidence.length} GitHub enumeration match${evidence.length === 1 ? '' : 'es'}.`];
+  for (const [index, item] of evidence.slice(0, SUMMARY_LIMIT).entries()) {
+    lines.push(`${index + 1}. ${item.content.repo} - ${item.content.title} [${item.content.state}]`);
+  }
+
+  if (evidence.length > SUMMARY_LIMIT) {
+    lines.push(`...and ${evidence.length - SUMMARY_LIMIT} more.`);
+  }
+
+  return lines.join('\n');
+}
+
+function metadataFor(
+  text: string,
+  filters: Record<string, string[]>,
+  resultCount: number,
+  source: GitHubLibrarianFindings['metadata']['source'],
+  errors: string[],
+): GitHubLibrarianFindings['metadata'] {
+  const metadata: GitHubLibrarianFindings['metadata'] = {
+    text,
+    filters,
+    resultCount,
+    source,
+  };
+
+  if (errors.length > 0) {
+    metadata.errors = errors;
+  }
+
+  return metadata;
+}
+
+function statusFor(resultCount: number, errorCount: number): EnumerationStatus {
+  if (errorCount === 0) {
+    return 'complete';
+  }
+
+  return resultCount > 0 ? 'partial' : 'failed';
+}
+
+function dedupeEntries(entries: EnumerationEntry[]): EnumerationEntry[] {
+  const seen = new Set<string>();
+  const deduped: EnumerationEntry[] = [];
+
+  for (const item of entries) {
+    const key = item.entry.path;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+function compareEntries(left: EnumerationEntry, right: EnumerationEntry): number {
+  const leftUpdated = left.entry.updatedAt ?? '';
+  const rightUpdated = right.entry.updatedAt ?? '';
+  const updatedComparison = rightUpdated.localeCompare(leftUpdated);
+  if (updatedComparison !== 0) {
+    return updatedComparison;
+  }
+
+  return left.entry.path.localeCompare(right.entry.path);
+}
+
+function expandPropertyValues(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(isString).map((item) => item.trim()).filter((item) => item.length > 0);
+      }
+    } catch {
+      // Fall through to comma-separated handling.
+    }
+  }
+
+  return trimmed.split(',').map((item) => item.trim()).filter((item) => item.length > 0);
+}
+
+function repoFromPath(path: string): string | undefined {
+  const segments = pathSegments(path);
+  const reposIndex = segments.indexOf('repos');
+  if (reposIndex < 0) {
+    return undefined;
+  }
+
+  const owner = segments[reposIndex + 1];
+  const repo = segments[reposIndex + 2];
+  if (!owner || !repo) {
+    return undefined;
+  }
+
+  return `${owner}/${repo}`;
+}
+
+function numberFromPath(path: string): string | undefined {
+  const segments = pathSegments(path);
+  const collectionIndex = collectionIndexFromPath(path);
+  if (collectionIndex < 0) {
+    return undefined;
+  }
+
+  return segments[collectionIndex + 1];
+}
+
+function collectionItemTypeFromPath(path: string): GitHubEnumerationType | undefined {
+  const segments = pathSegments(path);
+  const collectionIndex = collectionIndexFromPath(path);
+  if (collectionIndex < 0 || !segments[collectionIndex + 1]) {
+    return undefined;
+  }
+
+  if (segments[collectionIndex] === 'pulls') {
+    return 'pr';
+  }
+
+  if (segments[collectionIndex] === 'issues') {
+    return 'issue';
+  }
+
+  return undefined;
+}
+
+function collectionIndexFromPath(path: string): number {
+  const segments = pathSegments(path);
+  const reposIndex = segments.indexOf('repos');
+  if (reposIndex < 0) {
+    return -1;
+  }
+
+  const collectionIndex = reposIndex + 3;
+  const collection = segments[collectionIndex];
+  return collection === 'pulls' || collection === 'issues' ? collectionIndex : -1;
+}
+
+function titleFromPath(path: string): string {
+  const segments = pathSegments(path);
+  return segments[segments.length - 1] ?? path;
+}
+
+function pathSegments(path: string): string[] {
+  return path.split('/').filter(Boolean).map(decodeSegment);
+}
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function normalizeComparable(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function firstString(...values: Array<string | undefined>): string {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0) ?? '';
+}
+
+function snippetFromEntry(entry: VfsEntry): string | undefined {
+  if ('snippet' in entry && typeof entry.snippet === 'string') {
+    return entry.snippet;
+  }
+
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}

--- a/packages/specialists/src/github/librarian.ts
+++ b/packages/specialists/src/github/librarian.ts
@@ -1,4 +1,8 @@
 import type { VfsEntry } from '@agent-assistant/vfs';
+import {
+  GITHUB_PATH_ROOT,
+  githubRepoPrefix,
+} from '@relayfile/adapter-github/path-mapper';
 
 import { parseQuery } from '../shared/query-syntax.js';
 import type { GitHubEnumerationParams } from './types.js';
@@ -220,8 +224,17 @@ async function listEnumerationEntries(
     const repoFilters = filters.repo ?? [];
     const listRoots =
       repoFilters.length > 0
-        ? repoFilters.flatMap((repo) => types.map((type) => `/github/repos/${repo}/${COLLECTION_BY_TYPE[type]}/`))
-        : ['/github/repos'];
+        ? repoFilters.flatMap((repoSlug) =>
+            types.map((type) => {
+              const [owner, repo] = repoSlug.split('/');
+              // Fall back to raw path if the slug isn't owner/name shaped.
+              if (!owner || !repo) {
+                return `${GITHUB_PATH_ROOT}/repos/${repoSlug}/${COLLECTION_BY_TYPE[type]}/`;
+              }
+              return `${githubRepoPrefix(owner, repo)}/${COLLECTION_BY_TYPE[type]}/`;
+            }),
+          )
+        : [`${GITHUB_PATH_ROOT}/repos`];
 
     for (const root of listRoots) {
       try {

--- a/packages/specialists/src/github/types.ts
+++ b/packages/specialists/src/github/types.ts
@@ -1,0 +1,36 @@
+export type GitHubInvestigationCapability = 'pr_investigation' | 'github.investigate';
+export type GitHubCapability = GitHubInvestigationCapability | 'github.enumerate';
+export type GitHubSearchType = 'pr' | 'issue';
+export type GitHubSearchState = 'open' | 'closed';
+
+export interface GitHubQueryFilterSet {
+  repo?: string[];
+  label?: string[];
+  type?: GitHubSearchType[];
+  state?: GitHubSearchState[];
+  [filter: string]: string[] | undefined;
+}
+
+export interface GitHubPullRequestRef {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+export interface GitHubInvestigationParams {
+  capability: GitHubInvestigationCapability;
+  query: string;
+  filters?: GitHubQueryFilterSet;
+  limit?: number;
+  pr?: GitHubPullRequestRef;
+}
+
+export interface GitHubEnumerationParams {
+  capability: 'github.enumerate';
+  query?: string;
+  filters?: GitHubQueryFilterSet;
+  cursor?: string;
+  limit?: number;
+}
+
+export type GitHubCapabilityParams = GitHubInvestigationParams | GitHubEnumerationParams;

--- a/packages/specialists/src/index.ts
+++ b/packages/specialists/src/index.ts
@@ -1,0 +1,2 @@
+export * from './shared/index.js';
+export * from './github/index.js';

--- a/packages/specialists/src/shared/findings.ts
+++ b/packages/specialists/src/shared/findings.ts
@@ -1,0 +1,64 @@
+import type {
+  GitHubCapabilityParams,
+  GitHubEnumerationParams,
+  GitHubInvestigationParams,
+} from '../github/types.js';
+
+export type DelegationStatus = 'complete' | 'partial' | 'failed';
+
+export interface DelegationRequestFor<TParams extends GitHubCapabilityParams> {
+  requestId: string;
+  capability: TParams['capability'];
+  params: TParams;
+  timeoutMs?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type DelegationRequest =
+  | DelegationRequestFor<GitHubInvestigationParams>
+  | DelegationRequestFor<GitHubEnumerationParams>;
+
+export interface SpecialistFinding {
+  title: string;
+  body?: string;
+  url?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpecialistFindingsFor<TParams extends GitHubCapabilityParams> {
+  requestId: string;
+  capability: TParams['capability'];
+  status: DelegationStatus;
+  summary: string;
+  findings: SpecialistFinding[];
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type SpecialistFindings =
+  | SpecialistFindingsFor<GitHubInvestigationParams>
+  | SpecialistFindingsFor<GitHubEnumerationParams>;
+
+export interface DelegationTransport {
+  delegate<TParams extends GitHubCapabilityParams>(
+    request: DelegationRequestFor<TParams>,
+  ): Promise<SpecialistFindingsFor<TParams>>;
+}
+
+export class DelegationTimeoutError extends Error {
+  readonly requestId?: string;
+  readonly timeoutMs?: number;
+
+  constructor(message = 'Delegation timed out', options: { requestId?: string; timeoutMs?: number } = {}) {
+    super(message);
+    this.name = 'DelegationTimeoutError';
+
+    if (options.requestId !== undefined) {
+      this.requestId = options.requestId;
+    }
+
+    if (options.timeoutMs !== undefined) {
+      this.timeoutMs = options.timeoutMs;
+    }
+  }
+}

--- a/packages/specialists/src/shared/index.ts
+++ b/packages/specialists/src/shared/index.ts
@@ -1,0 +1,3 @@
+export * from './findings.js';
+export * from './query-syntax.js';
+export * from './vfs-adapter.js';

--- a/packages/specialists/src/shared/query-syntax.test.ts
+++ b/packages/specialists/src/shared/query-syntax.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseQuery } from './query-syntax.js';
+
+describe('parseQuery', () => {
+  it('keeps bare text as query text', () => {
+    expect(parseQuery('open pull requests')).toEqual({
+      text: 'open pull requests',
+      filters: {},
+    });
+  });
+
+  it('extracts mixed free text and recognized filters', () => {
+    expect(parseQuery('retry state:open repo:AgentWorkforce/sage')).toEqual({
+      text: 'retry',
+      filters: {
+        state: ['open'],
+        repo: ['AgentWorkforce/sage'],
+      },
+    });
+  });
+
+  it('collects repeated keys in order', () => {
+    expect(parseQuery('label:bug label:security')).toEqual({
+      text: '',
+      filters: {
+        label: ['bug', 'security'],
+      },
+    });
+  });
+
+  it('extracts type filters', () => {
+    expect(parseQuery('type:pr')).toEqual({
+      text: '',
+      filters: {
+        type: ['pr'],
+      },
+    });
+  });
+
+  it('leaves unknown keys in query text', () => {
+    expect(parseQuery('foo:bar')).toEqual({
+      text: 'foo:bar',
+      filters: {},
+    });
+  });
+});

--- a/packages/specialists/src/shared/query-syntax.ts
+++ b/packages/specialists/src/shared/query-syntax.ts
@@ -1,0 +1,68 @@
+export interface ParsedQuery {
+  text: string;
+  filters: Record<string, string[]>;
+}
+
+const REPO_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const TYPE_VALUES = new Set(['pr', 'issue']);
+const STATE_VALUES = new Set(['open', 'closed']);
+
+function addFilter(filters: Record<string, string[]>, key: string, value: string): void {
+  const values = filters[key] ?? [];
+  values.push(value);
+  filters[key] = values;
+}
+
+function normalizeFilter(token: string): { key: string; value: string } | null {
+  const separatorIndex = token.indexOf(':');
+  if (separatorIndex <= 0 || separatorIndex === token.length - 1) {
+    return null;
+  }
+
+  const key = token.slice(0, separatorIndex).toLowerCase();
+  const value = token.slice(separatorIndex + 1);
+
+  if (key === 'repo' && REPO_PATTERN.test(value)) {
+    return { key, value };
+  }
+
+  if (key === 'label') {
+    return { key, value };
+  }
+
+  const normalizedValue = value.toLowerCase();
+
+  if (key === 'state' && STATE_VALUES.has(normalizedValue)) {
+    return { key, value: normalizedValue };
+  }
+
+  if (key === 'type' && TYPE_VALUES.has(normalizedValue)) {
+    return { key, value: normalizedValue };
+  }
+
+  return null;
+}
+
+export function parseQuery(input: string): ParsedQuery {
+  const filters: Record<string, string[]> = {};
+  const textParts: string[] = [];
+
+  for (const token of input.trim().split(/\s+/)) {
+    if (token.length === 0) {
+      continue;
+    }
+
+    const filter = normalizeFilter(token);
+    if (filter) {
+      addFilter(filters, filter.key, filter.value);
+      continue;
+    }
+
+    textParts.push(token);
+  }
+
+  return {
+    text: textParts.join(' '),
+    filters,
+  };
+}

--- a/packages/specialists/src/shared/vfs-adapter.test.ts
+++ b/packages/specialists/src/shared/vfs-adapter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesFilters } from './vfs-adapter.js';
+
+describe('matchesFilters', () => {
+  it('matches filters against VFS entry properties', () => {
+    expect(
+      matchesFilters(
+        {
+          path: '/issues/1',
+          type: 'file',
+          properties: {
+            state: 'open',
+            repo: 'AgentWorkforce/sage',
+          },
+        },
+        {
+          state: ['open'],
+          repo: ['AgentWorkforce/sage'],
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects entries missing a requested property value', () => {
+    expect(
+      matchesFilters(
+        {
+          path: '/issues/2',
+          type: 'file',
+          properties: {
+            state: 'closed',
+          },
+        },
+        {
+          state: ['open'],
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/specialists/src/shared/vfs-adapter.ts
+++ b/packages/specialists/src/shared/vfs-adapter.ts
@@ -1,0 +1,14 @@
+import type { VfsEntry } from '@agent-assistant/vfs';
+
+export function matchesFilters(entry: VfsEntry, filters: Record<string, string[]>): boolean {
+  const properties = entry.properties ?? {};
+
+  return Object.entries(filters).every(([key, values]) => {
+    if (values.length === 0) {
+      return true;
+    }
+
+    const propertyValue = properties[key];
+    return propertyValue !== undefined && values.includes(propertyValue);
+  });
+}

--- a/packages/specialists/src/shared/vfs-module.d.ts
+++ b/packages/specialists/src/shared/vfs-module.d.ts
@@ -1,0 +1,12 @@
+declare module '@agent-assistant/vfs' {
+  export interface VfsEntry {
+    path: string;
+    type: 'file' | 'dir' | 'unknown';
+    provider?: string;
+    title?: string;
+    revision?: string;
+    updatedAt?: string;
+    size?: number;
+    properties?: Record<string, string>;
+  }
+}

--- a/packages/specialists/tsconfig.json
+++ b/packages/specialists/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
Adds @agent-assistant/specialists with the GitHub investigator salvaged from Sage PR #42 (VFS-provider-backed, capability-generic contract) plus a new github librarian for enumeration queries. Consumed by Sage for live PR-enumeration via Relay communicate transport.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
