### PR TITLE
fix(specialists): register workspace + rescue engine/linear work stranded off PR #12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "packages/policy",
         "packages/integration",
         "packages/sdk",
+        "packages/specialists",
         "packages/examples"
       ],
       "dependencies": {
@@ -88,6 +89,10 @@
     },
     "node_modules/@agent-assistant/sessions": {
       "resolved": "packages/sessions",
+      "link": true
+    },
+    "node_modules/@agent-assistant/specialists": {
+      "resolved": "packages/specialists",
       "link": true
     },
     "node_modules/@agent-assistant/surfaces": {
@@ -825,6 +830,42 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@relayfile/adapter-core": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-core/-/adapter-core-0.1.6.tgz",
+      "integrity": "sha512-YHzNfkx/G/ZeeVqGzh4+keRHKBgdCCu+srAfTMxYciuyfhnR5iSUUulggC7DWuZGNQMFY9Wdjhham4XFRVGkQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/postman-to-openapi": "^0.6.0",
+        "cheerio": "^1.2.0",
+        "minimatch": "^10.0.3",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "adapter-core": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": "^0.1.7"
+      }
+    },
+    "node_modules/@relayfile/adapter-github": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-github/-/adapter-github-0.1.6.tgz",
+      "integrity": "sha512-nN9C+tyUhnKfEbrONjFms+rXDt/xHQD1jh5kSAIo6OdZ1J0oRvGE/v/mC+PMnuGOsCDX5b6BKLM8e8uiiunyEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@relayfile/adapter-core": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": "^0.1.7"
+      }
+    },
     "node_modules/@relayfile/sdk": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.1.7.tgz",
@@ -1184,6 +1225,37 @@
         "win32"
       ]
     },
+    "node_modules/@scalar/helpers": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.0.tgz",
+      "integrity": "sha512-S7m46UWqngUmDXuihUerNKS58vlUqF/qaXle3QREfc8Xh9wperAKxFmmxrnulAayrcCQ/fTJyGu5oSM2STlxkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
+      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/postman-to-openapi": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.6.2.tgz",
+      "integrity": "sha512-b8XcDqeVOXTdvBqj0JK72HiZDelhAC6ysuToHJnyP4a57O5D2szuHBOfsoAWHG98AOi3bcJzKnnQpWzPIapbmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.5.0",
+        "@scalar/openapi-types": "0.7.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1434,6 +1506,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1500,6 +1599,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chownr": {
@@ -1591,6 +1732,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1629,11 +1798,91 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1823,6 +2072,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -1831,6 +2111,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2047,6 +2339,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -2135,6 +2442,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -2165,6 +2484,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-key": {
@@ -2376,6 +2744,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2654,6 +3028,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -2832,6 +3215,28 @@
         }
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2983,7 +3388,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@agent-assistant/harness": "^0.1.3"
       },
@@ -3023,7 +3428,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3043,7 +3448,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@agent-assistant/connectivity": "file:../connectivity",
         "@agent-assistant/coordination": "file:../coordination",
@@ -3068,7 +3473,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -3856,7 +4261,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -3868,7 +4273,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4648,7 +5053,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.7"
@@ -4669,7 +5074,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4686,7 +5091,20 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.0",
+      "version": "0.2.2",
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/specialists": {
+      "name": "@agent-assistant/specialists",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agent-assistant/coordination": "^0.1.0",
+        "@agent-assistant/vfs": "^0.2.2",
+        "@relayfile/adapter-github": "^0.1.6"
+      },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4694,7 +5112,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4702,7 +5120,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4711,7 +5129,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.1.3",
@@ -4756,7 +5174,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,6 +312,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -865,6 +866,80 @@
       "peerDependencies": {
         "@relayfile/sdk": "^0.1.7"
       }
+    },
+    "node_modules/@relayfile/adapter-linear": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-linear/-/adapter-linear-0.1.7.tgz",
+      "integrity": "sha512-EthBq81bP5GWhRDaaSID2V15460TlFHpwu0eo9HZrN6t4LUGW+M0ZcAdUvKsDOSt4d4Az+KEs6Zu0ULAO0lGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/sdk": "^3.2.22",
+        "@relayfile/sdk": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@relayfile/adapter-linear/node_modules/@agent-relay/config": {
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-3.2.22.tgz",
+      "integrity": "sha512-+/wHXQEcog7yjKMVdka1qzuYacv6J+K1z0Z6QJAXNVWC2xnNy58osnAE1AQfIweZQjd4PSaSpYMuHNjYrR2uDA==",
+      "dependencies": {
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
+      }
+    },
+    "node_modules/@relayfile/adapter-linear/node_modules/@agent-relay/sdk": {
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-3.2.22.tgz",
+      "integrity": "sha512-ArDrpEodG+k2AoCaDC3PTOIqjhc3BW/Uvu1A87XsPYbU0jdLKgDaPbHBwfzj8cIculiDtvKp0mfPkrEkJU73kQ==",
+      "dependencies": {
+        "@agent-relay/config": "3.2.22",
+        "@relaycast/sdk": "^1.1.0",
+        "@sinclair/typebox": "^0.34.48",
+        "chalk": "^4.1.2",
+        "listr2": "^10.2.1",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@relayfile/adapter-linear/node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
     },
     "node_modules/@relayfile/sdk": {
       "version": "0.1.7",
@@ -5103,7 +5178,8 @@
       "dependencies": {
         "@agent-assistant/coordination": "^0.1.0",
         "@agent-assistant/vfs": "^0.2.2",
-        "@relayfile/adapter-github": "^0.1.6"
+        "@relayfile/adapter-github": "^0.1.6",
+        "@relayfile/adapter-linear": "^0.1.7"
       },
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "packages/policy",
     "packages/integration",
     "packages/sdk",
+    "packages/specialists",
     "packages/examples"
   ],
   "scripts": {

--- a/packages/specialists/LIBRARIAN_ADAPTERS.md
+++ b/packages/specialists/LIBRARIAN_ADAPTERS.md
@@ -1,0 +1,118 @@
+# Librarian Adapters
+
+## Engines
+
+`createLibrarian(adapter, options)` gives you query parsing, natural-language filter inference, VFS list/search, optional API fallback, a non-throwing error envelope in `metadata.errors`, dedupe by `entry.path`, adapter-defined filtering, sort by `updatedAt` descending then `path`, evidence mapping, and a concise summary.
+
+`createInvestigator(adapter, deps)` gives you JSON/plain-text target parsing, raw/metadata/diff VFS reads, optional API fallback, failed findings with `gaps`, a consistent specialist result envelope, optional durable evidence writes, source metadata, action counts, duration, confidence, and summary hooks.
+
+## LibrarianAdapter
+
+| Field | Description |
+| --- | --- |
+| `capability` | Public capability string, usually `<provider>.enumerate`. |
+| `entityTypes` | Supported typed collections, such as `issue`, `project`, or `pr`. |
+| `listRoots(types, filters)` | VFS roots to list for requested types and filters. |
+| `inferFilters(text, filters)` | Converts domain language cues into normalized filters. |
+| `filterKeys` | Filter names the engine should enforce. |
+| `valuesForFilter(entry, key)` | Comparable values extracted from one VFS entry. |
+| `inferEntityType(entry)` | Entity type inferred from properties or path shape. |
+| `toEvidence(entry, type)` | Domain evidence shape returned to callers. |
+| `searchProvider` | Optional VFS search provider hint, such as `github`. |
+
+## InvestigatorAdapter
+
+| Field | Description |
+| --- | --- |
+| `capability` | Public capability string for the investigation. |
+| `specialistName` | Stable coordination specialist name. |
+| `specialistVersion` | Version emitted in result metadata. |
+| `paths(target)` | Candidate VFS metadata/raw paths and optional diff path. |
+| `parse(raw)` | Converts VFS/API text into a typed entity, or returns `null`. |
+| `toEvidence(entity, target)` | Converts the typed entity into findings. |
+| `apiFallback(target)` | Optional direct API read when VFS misses. |
+| `durableEvidenceThresholdBytes` | Optional large-evidence persistence threshold. |
+
+## Next Integration Skeleton
+
+Import path helpers from `@relayfile/adapter-<name>/path-mapper`; for Notion, use `@relayfile/adapter-notion/path-mapper`.
+
+```ts
+import { notionDatabasePath, notionPagePath } from '@relayfile/adapter-notion/path-mapper';
+import {
+  createLibrarian,
+  type LibrarianAdapter,
+  type LibrarianApiFallback,
+  type LibrarianVfs,
+} from '../shared/librarian-engine.js';
+
+type NotionEntityType = 'page' | 'database';
+const NOTION_CAPABILITY = 'notion.enumerate';
+
+export interface NotionLibrarianOptions {
+  vfs: LibrarianVfs;
+  apiFallback?: LibrarianApiFallback<NotionEntityType>;
+}
+
+const ROOT_BY_TYPE: Record<NotionEntityType, string> = {
+  page: collectionRootFromPath(notionPagePath('__root__')),
+  database: collectionRootFromPath(notionDatabasePath('__root__')),
+};
+
+const notionLibrarianAdapter: LibrarianAdapter<NotionEntityType> = {
+  capability: NOTION_CAPABILITY,
+  entityTypes: ['page', 'database'],
+  filterKeys: ['workspace', 'parent', 'tag', 'type'],
+  searchProvider: 'notion',
+  listRoots(types) {
+    return types.map((type) => ROOT_BY_TYPE[type]);
+  },
+  inferFilters(text, parsedFilters) {
+    const filters = cloneFilters(parsedFilters);
+    // TODO: infer type/tag/workspace cues from text.
+    return filters;
+  },
+  valuesForFilter(entry, key) {
+    const properties = entry.properties ?? {};
+    if (key === 'type') return [properties.type].filter(isString);
+    if (key === 'workspace') return [properties.workspace, properties.workspaceId].filter(isString);
+    if (key === 'parent') return [properties.parent, properties.parentId].filter(isString);
+    if (key === 'tag') return expandPropertyValues(properties.tag, properties.tags);
+    return [];
+  },
+  inferEntityType(entry) {
+    // TODO: prefer properties.type, then path collection.
+    return 'unknown';
+  },
+  toEvidence(entry, type) {
+    const properties = entry.properties ?? {};
+    return {
+      id: properties.id ?? entry.path,
+      kind: 'enumeration_hit',
+      content: { type, path: entry.path, title: entry.title ?? properties.title ?? entry.path, properties },
+    };
+  },
+};
+
+export function createNotionLibrarian(input: NotionLibrarianOptions) {
+  const options = { vfs: input.vfs, name: 'notion-librarian', description: 'Enumerates Notion from VFS metadata.' };
+  return createLibrarian(notionLibrarianAdapter, input.apiFallback ? { ...options, apiFallback: input.apiFallback } : options);
+}
+```
+
+Fill in domain types, evidence interfaces, typed specialist return shape, `inferEntityType`, `toEvidence`, and small helpers such as `collectionRootFromPath`, `cloneFilters`, `expandPropertyValues`, and `isString`.
+
+## Testing Recipe
+
+- Put focused tests beside the adapter, e.g. `src/notion/librarian.test.ts`.
+- Define an inline `InMemoryVfsProvider implements VfsProvider`; back it with literal `VfsEntry[]` or a file map.
+- Implement `list`, `read`, and `search` only as much as the case needs.
+- Do not mock real modules, path mappers, or shared engines.
+- Import the public factory, execute it, and assert evidence ids, typed content, filters, empty failures, fallback behavior, and fixed-`updatedAt` sort order.
+- For investigators, record `vfs.reads` and assert expected metadata/diff paths.
+
+## References
+
+- `src/github/librarian.ts`: repo-scoped roots via `githubRepoPrefix`, PR/issue inference, label expansion.
+- `src/linear/librarian.ts`: path-mapper collection roots, explicit filters, state/team/assignee matching.
+- `src/github/librarian.test.ts` and `src/linear/librarian.test.ts`: inline fake VFS providers with no real module mocks.

--- a/packages/specialists/package-lock.json
+++ b/packages/specialists/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@agent-assistant/coordination": "^0.1.0",
         "@agent-assistant/vfs": "^0.2.2",
-        "@relayfile/adapter-github": "^0.1.6"
+        "@relayfile/adapter-github": "^0.1.6",
+        "@relayfile/adapter-linear": "^0.1.7"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -47,6 +48,61 @@
     "node_modules/@agent-assistant/vfs": {
       "resolved": "../vfs",
       "link": true
+    },
+    "node_modules/@agent-relay/config": {
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-3.2.22.tgz",
+      "integrity": "sha512-+/wHXQEcog7yjKMVdka1qzuYacv6J+K1z0Z6QJAXNVWC2xnNy58osnAE1AQfIweZQjd4PSaSpYMuHNjYrR2uDA==",
+      "dependencies": {
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
+      }
+    },
+    "node_modules/@agent-relay/sdk": {
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-3.2.22.tgz",
+      "integrity": "sha512-ArDrpEodG+k2AoCaDC3PTOIqjhc3BW/Uvu1A87XsPYbU0jdLKgDaPbHBwfzj8cIculiDtvKp0mfPkrEkJU73kQ==",
+      "dependencies": {
+        "@agent-relay/config": "3.2.22",
+        "@relaycast/sdk": "^1.1.0",
+        "@sinclair/typebox": "^0.34.48",
+        "chalk": "^4.1.2",
+        "listr2": "^10.2.1",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -497,6 +553,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@relaycast/sdk": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@relaycast/sdk/-/sdk-1.1.2.tgz",
+      "integrity": "sha512-s0QsKUd5UNS8PUZIds8EdIUJUSOTEN9cn6oQTY41rvdvcOu9UI8+TH0rP4LAYCqwutRP6v3KDmF1s/6qwk4LPg==",
+      "dependencies": {
+        "@relaycast/types": "1.1.2",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@relaycast/sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@relaycast/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@relaycast/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-Lfx2oGDMpFNJx1AZNU7xaAE+3Fs5ZrUmVgAjZ2pMiHlbJx2gOHxpB57cQDjZY+JG4bM7C4Ao2JTOy3FqXbXlww==",
+      "dependencies": {
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@relaycast/types/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@relayfile/adapter-core": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@relayfile/adapter-core/-/adapter-core-0.1.6.tgz",
@@ -533,12 +624,24 @@
         "@relayfile/sdk": "^0.1.7"
       }
     },
+    "node_modules/@relayfile/adapter-linear": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-linear/-/adapter-linear-0.1.7.tgz",
+      "integrity": "sha512-EthBq81bP5GWhRDaaSID2V15460TlFHpwu0eo9HZrN6t4LUGW+M0ZcAdUvKsDOSt4d4Az+KEs6Zu0ULAO0lGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/sdk": "^3.2.22",
+        "@relayfile/sdk": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@relayfile/sdk": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.1.12.tgz",
       "integrity": "sha512-tgGkIV2vWt068g2rQtSrUSksYC5QnQ2QL8s6rgpQZkM8u/+UxK77YYJ5YQUTQ8BWusa3cgvKdk4STpquS3wXEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -924,6 +1027,12 @@
         "node": ">=22"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1064,6 +1173,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1128,6 +1279,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1179,6 +1346,55 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -1291,6 +1507,12 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -1314,6 +1536,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1375,6 +1609,12 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1416,6 +1656,27 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/htmlparser2": {
@@ -1461,12 +1722,124 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/listr2": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1483,6 +1856,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -1536,6 +1921,21 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parse5": {
@@ -1653,6 +2053,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -1711,6 +2133,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1735,6 +2197,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -1746,6 +2239,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tinybench": {
@@ -2042,6 +2547,56 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -2055,6 +2610,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -26,5 +26,12 @@
   "devDependencies": {
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/agent-assistant"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@agent-assistant/coordination": "^0.1.0",
     "@agent-assistant/vfs": "^0.2.2",
-    "@relayfile/adapter-github": "^0.1.6"
+    "@relayfile/adapter-github": "^0.1.6",
+    "@relayfile/adapter-linear": "^0.1.7"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/specialists/src/github/investigator.ts
+++ b/packages/specialists/src/github/investigator.ts
@@ -469,6 +469,46 @@ function normalizeInvestigatorEvidenceBlob(raw: string, number: number): string 
   return formatPullRequest(number, null, blob.diff ?? null) ?? raw;
 }
 
+/**
+ * A PR payload is "meaningful" if we can extract at least one grounded field —
+ * a section marker (Title/Body/Diff) OR a structured JSON metadata shape with
+ * at least a title/number/body/html_url. Empty, whitespace, or truncated blobs
+ * that yield nothing but silent defaults must return null so the engine falls
+ * through to apiFallback instead of emitting placeholder findings.
+ */
+function isMeaningfulPrPayload(raw: string): boolean {
+  const normalized = raw?.trim();
+  if (!normalized) {
+    return false;
+  }
+
+  // Formatted text (produced by Sage's formatGitHubPr or the specialist's own formatter).
+  if (/^(Title|Body|Diff|State|Author|URL|Labels):/m.test(normalized)) {
+    return true;
+  }
+
+  // Raw JSON metadata written by @relayfile/adapter-github.
+  if (normalized.startsWith('{') || normalized.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(normalized) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const record = parsed as Record<string, unknown>;
+        return (
+          typeof record.title === 'string' ||
+          typeof record.number === 'number' ||
+          typeof record.body === 'string' ||
+          typeof record.html_url === 'string' ||
+          typeof record.state === 'string'
+        );
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
 function parsePrSections(raw: string): ParsedPrSections {
   const normalized = raw.trim();
   const titleMatch = normalized.match(/^Title:\s*(.+)$/m);
@@ -1204,6 +1244,11 @@ function createGitHubPrInvestigatorAdapter(
       return investigatorEnginePaths(request.repo.owner, request.repo.repo, request.pr.number);
     },
     parse(raw) {
+      // Return null for unparseable/empty blobs so the engine falls through
+      // to apiFallback instead of emitting "complete" placeholder findings.
+      if (!isMeaningfulPrPayload(raw)) {
+        return null;
+      }
       return { raw };
     },
     toEvidence(entity, target) {

--- a/packages/specialists/src/github/investigator.ts
+++ b/packages/specialists/src/github/investigator.ts
@@ -1,4 +1,4 @@
-import type { Specialist, SpecialistContext, SpecialistResult } from '@agent-assistant/coordination';
+import type { Specialist, SpecialistContext } from '@agent-assistant/coordination';
 import type { VfsProvider, VfsReadResult } from '@agent-assistant/vfs';
 import {
   githubPullRequestPath,
@@ -6,6 +6,13 @@ import {
 } from '@relayfile/adapter-github/path-mapper';
 
 import type { SpecialistFinding, SpecialistFindings } from '../shared/findings.js';
+import { createInvestigator } from '../shared/investigator-engine.js';
+import type {
+  InvestigatorAdapter,
+  InvestigatorDeps,
+  InvestigatorPaths,
+  InvestigatorTarget,
+} from '../shared/investigator-engine.js';
 import type { GitHubInvestigationParams, GitHubPullRequestRef, GitHubQueryFilterSet } from './types.js';
 
 const SPECIALIST_NAME = 'github-investigator';
@@ -141,6 +148,21 @@ interface LoadedRawPr {
   gaps: FindingsGap[];
 }
 
+interface PrInvestigationEntity {
+  raw: string;
+  source?: EvidenceSource;
+}
+
+interface InvestigatorEvidenceBlob {
+  metadata?: string;
+  diff?: string;
+}
+
+interface SourceTrackingVfs {
+  vfs: VfsProvider;
+  sourceForRaw(raw: string, request: PrInvestigationRequest, asOf: string): EvidenceSource | undefined;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -226,6 +248,79 @@ function directPrPaths(owner: string, repo: string, number: number): {
     metadata: [canonicalMetadata, `${root}/meta.json`],
     raw: [`${root}/pr.md`, `${root}/pr.txt`, `${root}/summary.md`],
     diff: `${root}/diff.patch`,
+  };
+}
+
+function investigatorEnginePaths(owner: string, repo: string, number: number): InvestigatorPaths {
+  const paths = directPrPaths(owner, repo, number);
+  return {
+    // The shared engine reads `metadata` before `diff`; include legacy raw PR
+    // blobs here to preserve canonical metadata -> legacy metadata -> raw PR order.
+    metadata: [...paths.metadata, ...paths.raw],
+    diff: paths.diff,
+  };
+}
+
+function createSourceTrackingVfs(provider: VfsProvider): SourceTrackingVfs {
+  const reads: VfsReadResult[] = [];
+  const vfs: VfsProvider = {
+    async read(filePath) {
+      const result = await provider.read(filePath);
+      if (result) {
+        reads.push(result);
+      }
+      return result;
+    },
+    list(path, options) {
+      return provider.list(path, options);
+    },
+    search(query, options) {
+      return provider.search(query, options);
+    },
+    ...(provider.stat
+      ? {
+          stat(path: string) {
+            return provider.stat!(path);
+          },
+        }
+      : {}),
+  };
+
+  return {
+    vfs,
+    sourceForRaw(raw, request, asOf) {
+      const { owner, repo } = request.repo;
+      const { number } = request.pr;
+      const paths = directPrPaths(owner, repo, number);
+      const orderedPaths = [...paths.metadata, ...paths.raw, paths.diff];
+      const blob = splitInvestigatorEvidenceBlob(raw);
+      const sourceContents = [blob.metadata, blob.diff, raw].filter(
+        (content): content is string => typeof content === 'string' && content.length > 0,
+      );
+
+      for (const filePath of orderedPaths) {
+        const result = [...reads]
+          .reverse()
+          .find(
+            (read) =>
+              read.path === filePath &&
+              sourceContents.some(
+                (content) => read.content === content || read.content.trim() === content.trim(),
+              ),
+          );
+        if (result) {
+          return {
+            provider: 'vfs',
+            ref: buildPullRequestRef(owner, repo, number),
+            asOf,
+            path: result.path,
+            ...(result.revision === undefined ? {} : { revision: result.revision }),
+          };
+        }
+      }
+
+      return undefined;
+    },
   };
 }
 
@@ -323,6 +418,55 @@ function formatApiPullRequest(number: number, data: GitHubApiPullRequest): strin
   };
 
   return formatPullRequest(number, metadata, data.diff ?? null);
+}
+
+function splitInvestigatorEvidenceBlob(raw: string): InvestigatorEvidenceBlob {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('Metadata:\n')) {
+    const rest = trimmed.slice('Metadata:\n'.length);
+    const diffMarker = '\n\nDiff:\n';
+    const diffIndex = rest.indexOf(diffMarker);
+    if (diffIndex >= 0) {
+      return {
+        metadata: rest.slice(0, diffIndex),
+        diff: rest.slice(diffIndex + diffMarker.length),
+      };
+    }
+
+    return { metadata: rest };
+  }
+
+  if (trimmed.startsWith('Diff:\n')) {
+    return { diff: trimmed.slice('Diff:\n'.length) };
+  }
+
+  return {};
+}
+
+function appendDiffToRawPr(raw: string, diff: string | undefined): string {
+  if (!diff || /\nDiff:\s*/.test(raw)) {
+    return raw;
+  }
+
+  return `${raw.trim()}\nDiff:\n${diff.trim()}`;
+}
+
+function normalizeInvestigatorEvidenceBlob(raw: string, number: number): string {
+  const blob = splitInvestigatorEvidenceBlob(raw);
+  if (!blob.metadata && !blob.diff) {
+    return raw;
+  }
+
+  const metadata = blob.metadata ? parseJsonRecord(blob.metadata) : null;
+  if (metadata) {
+    return formatPullRequest(number, metadata, blob.diff ?? null) ?? raw;
+  }
+
+  if (blob.metadata) {
+    return appendDiffToRawPr(blob.metadata, blob.diff);
+  }
+
+  return formatPullRequest(number, null, blob.diff ?? null) ?? raw;
 }
 
 function parsePrSections(raw: string): ParsedPrSections {
@@ -476,6 +620,10 @@ function buildStructuredPr(raw: string): StructuredPr {
   };
 }
 
+function buildStructuredPrForRequest(raw: string, request: PrInvestigationRequest): StructuredPr {
+  return buildStructuredPr(normalizeInvestigatorEvidenceBlob(raw, request.pr.number));
+}
+
 function buildSummary(structured: StructuredPr, riskAreas: Array<Record<string, unknown>>): string {
   const fileList = structured.filesChanged.slice(0, 3).join(', ');
   const topRisk = riskAreas[0];
@@ -532,21 +680,56 @@ function buildMetadataFinding(
   };
 }
 
-async function buildDiffFinding(
+function buildDiffFindingBody(structured: StructuredPr): string {
+  const changedFiles = structured.filesChanged.map((file) => `- ${file}`).join('\n');
+  return `Changed files:\n${changedFiles}\n\nDiff:\n${structured.diff}`.trim();
+}
+
+function buildDiffFindingBase(
   request: PrInvestigationRequest,
   structured: StructuredPr,
   source: EvidenceSource,
-  evidenceWriter: EvidenceWriter | null,
-): Promise<SpecialistFinding> {
+  body: string,
+  durableRef?: DurableEvidenceRef,
+): SpecialistFinding {
   const riskAreas = buildRiskAreas(structured.filesChanged);
   const structuredContent = {
     filesChanged: structured.filesChanged,
     riskAreas,
     changeCategories: categorizeChanges(structured.filesChanged),
   };
-  const changedFiles = structured.filesChanged.map((file) => `- ${file}`).join('\n');
-  let body = `Changed files:\n${changedFiles}\n\nDiff:\n${structured.diff}`.trim();
+
+  return {
+    title: `PR #${request.pr.number} diff analysis`,
+    body,
+    metadata: {
+      id: 'pr-diff',
+      kind: 'diff_analysis',
+      confidence: structured.filesChanged.length > 0 ? 0.88 : 0.62,
+      source: sourceMetadata(source),
+      structured: structuredContent,
+      ...(durableRef === undefined ? {} : { durableRef }),
+    },
+  };
+}
+
+function buildDiffFindingForEngine(
+  request: PrInvestigationRequest,
+  structured: StructuredPr,
+  source: EvidenceSource,
+): SpecialistFinding {
+  return buildDiffFindingBase(request, structured, source, buildDiffFindingBody(structured));
+}
+
+async function buildDiffFinding(
+  request: PrInvestigationRequest,
+  structured: StructuredPr,
+  source: EvidenceSource,
+  evidenceWriter: EvidenceWriter | null,
+): Promise<SpecialistFinding> {
+  const body = buildDiffFindingBody(structured);
   let durableRef: DurableEvidenceRef | undefined;
+  let finalBody = body;
 
   if (
     evidenceWriter &&
@@ -562,21 +745,11 @@ async function buildDiffFinding(
       contentType: 'text/markdown',
       confidence: structured.filesChanged.length > 0 ? 0.88 : 0.62,
     });
-    body = `Changed files:\n${changedFiles}\n\nDiff analysis persisted as durable evidence.`;
+    const changedFiles = structured.filesChanged.map((file) => `- ${file}`).join('\n');
+    finalBody = `Changed files:\n${changedFiles}\n\nDiff analysis persisted as durable evidence.`;
   }
 
-  return {
-    title: `PR #${request.pr.number} diff analysis`,
-    body,
-    metadata: {
-      id: 'pr-diff',
-      kind: 'diff_analysis',
-      confidence: structured.filesChanged.length > 0 ? 0.88 : 0.62,
-      source: sourceMetadata(source),
-      structured: structuredContent,
-      ...(durableRef === undefined ? {} : { durableRef }),
-    },
-  };
+  return buildDiffFindingBase(request, structured, source, finalBody, durableRef);
 }
 
 async function loadRawPrFromVfs(request: PrInvestigationRequest, vfs: VfsProvider): Promise<LoadedRawPr> {
@@ -981,6 +1154,170 @@ function unparseableRequest(instruction: string, context?: SpecialistContext): P
   };
 }
 
+function requestFromInvestigatorTarget(target: InvestigatorTarget): PrInvestigationRequest | null {
+  return requestFromRecord(target, readString(target.requestId) ?? 'github-investigation');
+}
+
+function describePrTarget(target: InvestigatorTarget): string {
+  const request = requestFromInvestigatorTarget(target);
+  return request ? `PR #${request.pr.number} in ${request.repo.owner}/${request.repo.repo}` : 'GitHub pull request';
+}
+
+function sourceForEngineEvidence(
+  entity: PrInvestigationEntity,
+  target: InvestigatorTarget,
+  deps: GitHubInvestigatorDeps,
+  sourceTracker: SourceTrackingVfs | null,
+): EvidenceSource | null {
+  const request = requestFromInvestigatorTarget(target);
+  if (!request) {
+    return null;
+  }
+
+  const asOf = new Date(deps.now?.() ?? Date.now()).toISOString();
+  return (
+    entity.source ??
+    sourceTracker?.sourceForRaw(entity.raw, request, asOf) ?? {
+      provider: 'vfs',
+      ref: buildPullRequestRef(request.repo.owner, request.repo.repo, request.pr.number),
+      asOf,
+    }
+  );
+}
+
+function createGitHubPrInvestigatorAdapter(
+  deps: GitHubInvestigatorDeps,
+  sourceTracker: SourceTrackingVfs | null,
+): InvestigatorAdapter<PrInvestigationEntity> {
+  const apiFallback = deps.apiFallback ?? deps.github ?? null;
+  const baseAdapter: InvestigatorAdapter<PrInvestigationEntity> = {
+    capability: PR_INVESTIGATION_CAPABILITY,
+    specialistName: SPECIALIST_NAME,
+    specialistVersion: SPECIALIST_VERSION,
+    durableEvidenceThresholdBytes: DURABLE_EVIDENCE_THRESHOLD_BYTES,
+    paths(target) {
+      const request = requestFromInvestigatorTarget(target);
+      if (!request) {
+        return { metadata: [] };
+      }
+
+      return investigatorEnginePaths(request.repo.owner, request.repo.repo, request.pr.number);
+    },
+    parse(raw) {
+      return { raw };
+    },
+    toEvidence(entity, target) {
+      const request = requestFromInvestigatorTarget(target);
+      const source = sourceForEngineEvidence(entity, target, deps, sourceTracker);
+      if (!request || !source) {
+        return [];
+      }
+
+      const structured = buildStructuredPrForRequest(entity.raw, request);
+      return [
+        buildMetadataFinding(request, structured, source),
+        buildDiffFindingForEngine(request, structured, source),
+      ];
+    },
+  };
+
+  if (!apiFallback) {
+    return baseAdapter;
+  }
+
+  return {
+    ...baseAdapter,
+    async apiFallback(target) {
+      const request = requestFromInvestigatorTarget(target);
+      if (!request) {
+        return null;
+      }
+
+      const result = extractApiData(
+        await apiFallback.readPRDiff(request.repo.owner, request.repo.repo, request.pr.number),
+      );
+      if (!result || (!readString(result.title) && !readString(result.diff))) {
+        return null;
+      }
+
+      const raw = formatApiPullRequest(request.pr.number, result);
+      if (!raw) {
+        return null;
+      }
+
+      return {
+        raw,
+        source: {
+          provider: 'github_api',
+          ref: buildPullRequestRef(request.repo.owner, request.repo.repo, request.pr.number),
+          asOf: new Date(deps.now?.() ?? Date.now()).toISOString(),
+        },
+      };
+    },
+  };
+}
+
+function summarizeGitHubInvestigation(input: { findings: SpecialistFinding[] }): string | undefined {
+  const metadata = input.findings.find((finding) => finding.metadata?.id === 'pr-meta')?.metadata
+    ?.structured;
+  const diff = input.findings.find((finding) => finding.metadata?.id === 'pr-diff')?.metadata?.structured;
+
+  if (!isRecord(metadata) || !isRecord(diff) || !Array.isArray(diff.filesChanged)) {
+    return undefined;
+  }
+
+  const title = readString(metadata.title) ?? 'Pull request';
+  const filesChanged = diff.filesChanged.filter((file): file is string => typeof file === 'string');
+  const riskAreas = Array.isArray(diff.riskAreas)
+    ? diff.riskAreas.filter((risk): risk is Record<string, unknown> => isRecord(risk))
+    : [];
+
+  return buildSummary(
+    {
+      title,
+      body: '',
+      url: readString(metadata.url) ?? '',
+      state: readString(metadata.state) ?? 'open',
+      author: readString(metadata.author) ?? 'unknown',
+      baseBranch: readString(metadata.baseBranch) ?? 'unknown',
+      headBranch: readString(metadata.headBranch) ?? 'unknown',
+      labels: Array.isArray(metadata.labels)
+        ? metadata.labels.filter((label): label is string => typeof label === 'string')
+        : [],
+      reviewStatus: normalizeReviewStatus(metadata.reviewStatus),
+      filesChanged,
+      additions: typeof metadata.additions === 'number' ? metadata.additions : 0,
+      deletions: typeof metadata.deletions === 'number' ? metadata.deletions : 0,
+      diff: '',
+    },
+    riskAreas,
+  );
+}
+
+function createGitHubInvestigatorEngineDeps(
+  deps: GitHubInvestigatorDeps,
+  sourceTracker: SourceTrackingVfs,
+): InvestigatorDeps {
+  return {
+    vfs: sourceTracker.vfs,
+    ...(deps.evidenceWriter === undefined ? {} : { evidenceWriter: deps.evidenceWriter }),
+    ...(deps.now === undefined ? {} : { now: deps.now }),
+    parseTarget(instruction, context) {
+      return parseGitHubInvestigationInstruction(instruction, context) as unknown as InvestigatorTarget | null;
+    },
+    describeTarget: describePrTarget,
+    summarize({ target, findings }) {
+      return (
+        summarizeGitHubInvestigation({ findings }) ??
+        `${describePrTarget(target)} produced ${findings.length} finding(s).`
+      );
+    },
+    confidence() {
+      return 0.86;
+    },
+  };
+}
+
 export async function investigateGitHub(
   params: GitHubInvestigationParams,
   deps: GitHubInvestigatorDeps,
@@ -1025,51 +1362,10 @@ export async function investigateGitHub(
   return investigatePullRequest(request, deps);
 }
 
-function toSpecialistResult(findings: SpecialistFindings): SpecialistResult {
-  return {
-    specialistName: SPECIALIST_NAME,
-    output: JSON.stringify(findings, null, 2),
-    status: findings.status,
-    ...(findings.confidence === undefined ? {} : { confidence: findings.confidence }),
-    metadata: {
-      requestId: findings.requestId,
-      capability: findings.capability,
-      findings,
-    },
-  };
-}
-
 export function createGitHubInvestigator(deps: GitHubInvestigatorDeps): Specialist {
-  return {
-    name: SPECIALIST_NAME,
-    description: 'Investigates GitHub pull requests using VFS evidence with an optional API fallback.',
-    capabilities: [PR_INVESTIGATION_CAPABILITY],
-    handler: {
-      async execute(instruction, context) {
-        const request = parseGitHubInvestigationInstruction(instruction, context);
-        if (!request) {
-          return toSpecialistResult(
-            failedFindings(
-              unparseableRequest(instruction, context),
-              'Unable to investigate PR because the instruction did not include a GitHub pull request target.',
-              [
-                {
-                  description: 'Expected a GitHub PR URL, owner/repo#number, or repo filter with PR number.',
-                  reason: 'invalid_request',
-                },
-              ],
-              0.05,
-              {
-                actionCount: 0,
-                durableEvidenceCount: 0,
-                producedAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
-              },
-            ),
-          );
-        }
-
-        return toSpecialistResult(await investigatePullRequest(request, deps));
-      },
-    },
-  };
+  const sourceTracker = createSourceTrackingVfs(deps.vfs);
+  return createInvestigator(
+    createGitHubPrInvestigatorAdapter(deps, sourceTracker),
+    createGitHubInvestigatorEngineDeps(deps, sourceTracker),
+  );
 }

--- a/packages/specialists/src/github/librarian.ts
+++ b/packages/specialists/src/github/librarian.ts
@@ -1,44 +1,34 @@
 import type { VfsEntry } from '@agent-assistant/vfs';
-import {
-  GITHUB_PATH_ROOT,
-  githubRepoPrefix,
-} from '@relayfile/adapter-github/path-mapper';
+import { GITHUB_PATH_ROOT, githubRepoPrefix } from '@relayfile/adapter-github/path-mapper';
 
-import { parseQuery } from '../shared/query-syntax.js';
+import {
+  createLibrarian,
+  type GenericLibrarianFindings,
+  type GenericLibrarianSpecialist,
+  type LibrarianAdapter,
+  type LibrarianApiFallback,
+  type LibrarianFallbackRequest,
+  type LibrarianStatus,
+  type LibrarianVfs,
+} from '../shared/librarian-engine.js';
 import type { GitHubEnumerationParams } from './types.js';
 
 type GitHubEnumerationType = 'pr' | 'issue';
-// Canonical capability literal matches types.ts GitHubEnumerationParams.capability
-// so routing/correlation keys line up across request and findings.
 type GitHubEnumerationCapability = 'github.enumerate';
 const GITHUB_ENUMERATION_CAPABILITY: GitHubEnumerationCapability = 'github.enumerate';
-type EnumerationStatus = 'complete' | 'partial' | 'failed';
+type EnumerationStatus = LibrarianStatus;
 
-interface GitHubLibrarianVfs {
-  list?(path: string, options?: { depth?: number; limit?: number }): Promise<readonly VfsEntry[]>;
-  search?(query: string, options?: { provider?: string; limit?: number }): Promise<readonly VfsEntry[]>;
-}
-
-interface GitHubLibrarianFallbackRequest {
-  instruction: string;
-  text: string;
-  filters: Record<string, string[]>;
-  types: GitHubEnumerationType[];
-}
-
-type GitHubLibrarianApiFallback =
-  | ((request: GitHubLibrarianFallbackRequest) => Promise<readonly VfsEntry[]>)
-  | {
-      list?(request: GitHubLibrarianFallbackRequest): Promise<readonly VfsEntry[]>;
-      search?(request: GitHubLibrarianFallbackRequest): Promise<readonly VfsEntry[]>;
-    };
+type GitHubLibrarianVfs = LibrarianVfs;
+type GitHubLibrarianFallbackRequest = LibrarianFallbackRequest<GitHubEnumerationType>;
+type GitHubLibrarianApiFallback = LibrarianApiFallback<GitHubEnumerationType>;
 
 export interface GitHubLibrarianOptions {
   vfs: GitHubLibrarianVfs;
   apiFallback?: GitHubLibrarianApiFallback;
 }
 
-export interface GitHubEnumerationEvidenceContent {
+export interface GitHubEnumerationEvidenceContent
+  extends Partial<Record<'provider' | 'revision' | 'updatedAt' | 'url' | 'number' | 'snippet', string>> {
   type: GitHubEnumerationType | 'github';
   path: string;
   repo: string;
@@ -46,12 +36,6 @@ export interface GitHubEnumerationEvidenceContent {
   state: string;
   labels: string[];
   properties: Record<string, string>;
-  provider?: string;
-  revision?: string;
-  updatedAt?: string;
-  url?: string;
-  number?: string;
-  snippet?: string;
 }
 
 export interface GitHubEnumerationEvidence {
@@ -60,140 +44,74 @@ export interface GitHubEnumerationEvidence {
   content: GitHubEnumerationEvidenceContent;
 }
 
-export interface GitHubLibrarianFindings {
+export interface GitHubLibrarianFindings
+  extends Omit<GenericLibrarianFindings, 'capability' | 'status' | 'evidence'> {
   capability: GitHubEnumerationCapability;
   status: EnumerationStatus;
-  summary: string;
   evidence: GitHubEnumerationEvidence[];
-  metadata: {
-    text: string;
-    filters: Record<string, string[]>;
-    resultCount: number;
-    source: 'vfs' | 'apiFallback' | 'mixed';
-    errors?: string[];
-  };
 }
 
-export interface GitHubLibrarianSpecialist {
+export interface GitHubLibrarianSpecialist
+  extends Omit<GenericLibrarianSpecialist<GitHubEnumerationType>, 'name' | 'capabilities' | 'handler'> {
   name: 'github-librarian';
-  description: string;
   capabilities: GitHubEnumerationCapability[];
   handler: {
     execute(instruction: string, context?: unknown): Promise<GitHubLibrarianFindings>;
   };
 }
 
-interface EnumerationEntry {
-  entry: VfsEntry;
-  enumerationType: GitHubEnumerationType | 'github';
-}
+const COLLECTION_BY_TYPE: Record<GitHubEnumerationType, string> = { pr: 'pulls', issue: 'issues' };
 
-const DEFAULT_LIMIT = 1_000;
-const SUMMARY_LIMIT = 10;
-const GITHUB_PROVIDER = 'github';
-const COLLECTION_BY_TYPE: Record<GitHubEnumerationType, string> = {
-  pr: 'pulls',
-  issue: 'issues',
+const githubLibrarianAdapter: LibrarianAdapter<GitHubEnumerationType> = {
+  capability: GITHUB_ENUMERATION_CAPABILITY,
+  entityTypes: ['pr', 'issue'],
+  filterKeys: ['state', 'repo', 'label', 'type'],
+  searchProvider: 'github',
+  listRoots(types, filters) {
+    const repoFilters = filters.repo ?? [];
+    if (repoFilters.length === 0) return [`${GITHUB_PATH_ROOT}/repos`];
+
+    return repoFilters.flatMap((repoSlug) =>
+      types.map((type) => {
+        const [owner, repo] = repoSlug.split('/');
+        return owner && repo
+          ? `${githubRepoPrefix(owner, repo)}/${COLLECTION_BY_TYPE[type]}/`
+          : `${GITHUB_PATH_ROOT}/repos/${repoSlug}/${COLLECTION_BY_TYPE[type]}/`;
+      }),
+    );
+  },
+  inferFilters: inferEnumerationFilters,
+  valuesForFilter,
+  inferEntityType,
+  toEvidence,
 };
 
 export function createGitHubLibrarian({
   vfs,
   apiFallback,
 }: GitHubLibrarianOptions): GitHubLibrarianSpecialist {
-  return {
+  const options = {
+    vfs,
     name: 'github-librarian',
     description: 'Enumerates GitHub repositories, pull requests, and issues from VFS-backed metadata.',
-    capabilities: [GITHUB_ENUMERATION_CAPABILITY],
-    handler: {
-      async execute(instruction: string): Promise<GitHubLibrarianFindings> {
-        const parsed = parseQuery(instruction);
-        const filters = inferEnumerationFilters(parsed.text, parsed.filters);
-        const types = requestedTypes(filters);
-        const errors: string[] = [];
-        let source: GitHubLibrarianFindings['metadata']['source'] = 'vfs';
-        let entries: EnumerationEntry[] = [];
-
-        try {
-          if (types.length > 0) {
-            entries = await listEnumerationEntries(vfs, types, filters, errors);
-          } else if (hasNoFilters(filters)) {
-            entries = await searchGitHub(vfs, parsed.text, errors);
-          } else {
-            entries = await listEnumerationEntries(vfs, ['pr', 'issue'], filters, errors);
-          }
-        } catch (error) {
-          errors.push(errorMessage(error));
-        }
-
-        if (entries.length === 0 && apiFallback) {
-          try {
-            const fallbackEntries = await loadFallbackEntries(apiFallback, {
-              instruction,
-              text: parsed.text,
-              filters,
-              types,
-            });
-            if (fallbackEntries.length > 0) {
-              source = errors.length > 0 ? 'mixed' : 'apiFallback';
-              entries = fallbackEntries.map((entry) => ({
-                entry,
-                enumerationType: inferEnumerationType(entry),
-              }));
-            }
-          } catch (error) {
-            // Mirror the VFS error-handling pattern so a failing apiFallback
-            // never crashes the handler — surface via errors + 'failed' status.
-            errors.push(errorMessage(error));
-          }
-        }
-
-        const matchedEntries = dedupeEntries(entries)
-          .filter(({ entry }) => matchesRequestedFilters(entry, filters))
-          .sort(compareEntries);
-        const evidence = matchedEntries.map(({ entry, enumerationType }) => toEvidence(entry, enumerationType));
-        const status = statusFor(evidence.length, errors.length);
-
-        return {
-          capability: GITHUB_ENUMERATION_CAPABILITY,
-          status,
-          summary: summarizeMatches(evidence),
-          evidence,
-          metadata: metadataFor(parsed.text, filters, evidence.length, source, errors),
-        };
-      },
-    },
   };
+  const engine = createLibrarian(githubLibrarianAdapter, apiFallback ? { ...options, apiFallback } : options);
+  return engine as unknown as GitHubLibrarianSpecialist;
 }
 
-// Functional counterpart to investigateGitHub — runs the librarian handler
-// for callers that have params + deps but don't want to instantiate a
-// Specialist. Uses params.query as the instruction when present.
 export async function enumerateGitHub(
   params: GitHubEnumerationParams,
   options: GitHubLibrarianOptions,
 ): Promise<GitHubLibrarianFindings> {
-  const librarian = createGitHubLibrarian(options);
-  const instruction = buildEnumerationInstruction(params);
-  return librarian.handler.execute(instruction);
+  return createGitHubLibrarian(options).handler.execute(buildEnumerationInstruction(params));
 }
 
 function buildEnumerationInstruction(params: GitHubEnumerationParams): string {
-  const parts: string[] = [];
-  if (params.query && params.query.trim()) {
-    parts.push(params.query.trim());
-  }
-
+  const parts = params.query?.trim() ? [params.query.trim()] : [];
   const filters = params.filters ?? {};
   for (const key of ['state', 'repo', 'label', 'type'] as const) {
-    const values = filters[key];
-    if (!values || values.length === 0) {
-      continue;
-    }
-    for (const value of values) {
-      parts.push(`${key}:${value}`);
-    }
+    for (const value of filters[key] ?? []) parts.push(`${key}:${value}`);
   }
-
   return parts.join(' ').trim();
 }
 
@@ -201,403 +119,110 @@ function inferEnumerationFilters(text: string, parsedFilters: Record<string, str
   const filters = cloneFilters(parsedFilters);
   const normalizedText = ` ${text.toLowerCase()} `;
 
-  if (!filters.type || filters.type.length === 0) {
-    if (/\b(pr|prs|pull request|pull requests)\b/.test(normalizedText)) {
-      filters.type = ['pr'];
-    } else if (/\b(issue|issues)\b/.test(normalizedText)) {
-      filters.type = ['issue'];
-    }
+  if (!filters.type?.length) {
+    if (/\b(pr|prs|pull request|pull requests)\b/.test(normalizedText)) filters.type = ['pr'];
+    else if (/\b(issue|issues)\b/.test(normalizedText)) filters.type = ['issue'];
   }
-
-  if (!filters.state || filters.state.length === 0) {
-    if (/\bopen\b/.test(normalizedText)) {
-      filters.state = ['open'];
-    } else if (/\bclosed\b/.test(normalizedText)) {
-      filters.state = ['closed'];
-    }
+  if (!filters.state?.length) {
+    if (/\bopen\b/.test(normalizedText)) filters.state = ['open'];
+    else if (/\bclosed\b/.test(normalizedText)) filters.state = ['closed'];
   }
-
-  if (!filters.label || filters.label.length === 0) {
+  if (!filters.label?.length) {
     const label = text.match(/\b(?:label|labeled|labelled)\s+["']?([^"'\s]+)["']?/i)?.[1];
-    if (label) {
-      filters.label = [label];
-    }
+    if (label) filters.label = [label];
   }
 
   return filters;
+}
+
+function valuesForFilter(entry: VfsEntry, key: string): string[] {
+  const properties = entry.properties ?? {};
+  if (key === 'repo') return [properties.repo, properties.repository, repoFromPath(entry.path)].filter(isString);
+  if (key === 'label') return [...expandPropertyValues(properties.label), ...expandPropertyValues(properties.labels)];
+  if (key === 'type') {
+    const type = inferEntityType(entry);
+    return [properties.type, type === 'unknown' ? undefined : type].filter(isString);
+  }
+  return expandPropertyValues(properties.state);
+}
+
+function inferEntityType(entry: VfsEntry): GitHubEnumerationType | 'unknown' {
+  const propertyType = entry.properties?.type?.toLowerCase();
+  if (propertyType === 'pr' || propertyType === 'pull_request' || propertyType === 'pull-request') return 'pr';
+  if (propertyType === 'issue') return 'issue';
+  return collectionItemTypeFromPath(entry.path) ?? 'unknown';
+}
+
+function toEvidence(entry: VfsEntry, type: GitHubEnumerationType | 'unknown'): GitHubEnumerationEvidence {
+  const properties = entry.properties ?? {};
+  const content: GitHubEnumerationEvidenceContent = {
+    type: type === 'unknown' ? 'github' : type,
+    path: entry.path,
+    repo: firstString(properties.repo, properties.repository, repoFromPath(entry.path), 'unknown'),
+    title: firstString(entry.title, properties.title, titleFromPath(entry.path)),
+    state: firstString(properties.state, 'unknown'),
+    labels: [...expandPropertyValues(properties.label), ...expandPropertyValues(properties.labels)],
+    properties,
+  };
+  const number = firstString(properties.number, properties.pr, properties.issue, numberFromPath(entry.path));
+  const snippet = snippetFromEntry(entry);
+
+  for (const key of ['provider', 'revision', 'updatedAt'] as const) {
+    const value = entry[key];
+    if (value) content[key] = value;
+  }
+  if (properties.url) content.url = properties.url;
+  if (number) content.number = number;
+  if (snippet) content.snippet = snippet;
+
+  return { id: firstString(properties.id, entry.path), kind: 'enumeration_hit', content };
+}
+
+function repoFromPath(path: string): string | undefined {
+  const match = /\/repos\/([^/]+)\/([^/]+)/.exec(path);
+  const owner = match?.[1];
+  const repo = match?.[2];
+  return owner && repo ? `${decodeSegment(owner)}/${decodeSegment(repo)}` : undefined;
+}
+
+function numberFromPath(path: string): string | undefined {
+  const match = /\/repos\/[^/]+\/[^/]+\/(?:pulls|issues)\/([^/]+)/.exec(path);
+  return match?.[1] ? decodeSegment(match[1]) : undefined;
+}
+
+function collectionItemTypeFromPath(path: string): GitHubEnumerationType | undefined {
+  const match = /\/repos\/[^/]+\/[^/]+\/(pulls|issues)\/[^/]+/.exec(path);
+  return match?.[1] === 'pulls' ? 'pr' : match?.[1] === 'issues' ? 'issue' : undefined;
+}
+
+function titleFromPath(path: string): string {
+  return decodeSegment(path.split('/').filter(Boolean).at(-1) ?? path);
+}
+
+function expandPropertyValues(value: string | undefined): string[] {
+  if (!value) return [];
+  const trimmed = value.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed.filter(isString).map((item) => item.trim()).filter(Boolean);
+    } catch {
+      // Fall through to comma-separated handling.
+    }
+  }
+  return trimmed.split(',').map((item) => item.trim()).filter(Boolean);
 }
 
 function cloneFilters(filters: Record<string, string[]>): Record<string, string[]> {
   return Object.fromEntries(Object.entries(filters).map(([key, values]) => [key, [...values]]));
 }
 
-function requestedTypes(filters: Record<string, string[]>): GitHubEnumerationType[] {
-  const values = filters.type ?? [];
-  const types: GitHubEnumerationType[] = [];
-
-  if (values.includes('pr')) {
-    types.push('pr');
-  }
-  if (values.includes('issue')) {
-    types.push('issue');
-  }
-
-  return types;
+function firstString(...values: Array<string | undefined>): string {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0) ?? '';
 }
 
-function hasNoFilters(filters: Record<string, string[]>): boolean {
-  return Object.values(filters).every((values) => values.length === 0) || Object.keys(filters).length === 0;
-}
-
-async function listEnumerationEntries(
-  vfs: GitHubLibrarianVfs,
-  types: GitHubEnumerationType[],
-  filters: Record<string, string[]>,
-  errors: string[],
-): Promise<EnumerationEntry[]> {
-  const listedEntries: EnumerationEntry[] = [];
-
-  if (vfs.list) {
-    const repoFilters = filters.repo ?? [];
-    const listRoots =
-      repoFilters.length > 0
-        ? repoFilters.flatMap((repoSlug) =>
-            types.map((type) => {
-              const [owner, repo] = repoSlug.split('/');
-              // Fall back to raw path if the slug isn't owner/name shaped.
-              if (!owner || !repo) {
-                return `${GITHUB_PATH_ROOT}/repos/${repoSlug}/${COLLECTION_BY_TYPE[type]}/`;
-              }
-              return `${githubRepoPrefix(owner, repo)}/${COLLECTION_BY_TYPE[type]}/`;
-            }),
-          )
-        : [`${GITHUB_PATH_ROOT}/repos`];
-
-    for (const root of listRoots) {
-      try {
-        const entries = await vfs.list(root, { depth: repoFilters.length > 0 ? 2 : 5, limit: DEFAULT_LIMIT });
-        listedEntries.push(...entries.flatMap((entry) => toEnumerationEntry(entry, types)));
-      } catch (error) {
-        errors.push(errorMessage(error));
-      }
-    }
-  }
-
-  if (listedEntries.length > 0 || !vfs.search) {
-    return listedEntries;
-  }
-
-  const searchQuery = types.map((type) => (type === 'pr' ? 'pull request' : 'issue')).join(' ');
-  try {
-    const results = await vfs.search(searchQuery, { provider: GITHUB_PROVIDER, limit: DEFAULT_LIMIT });
-    return results.flatMap((entry) => toEnumerationEntry(entry, types));
-  } catch (error) {
-    errors.push(errorMessage(error));
-    return [];
-  }
-}
-
-async function searchGitHub(
-  vfs: GitHubLibrarianVfs,
-  text: string,
-  errors: string[],
-): Promise<EnumerationEntry[]> {
-  if (!vfs.search) {
-    errors.push('VFS search is unavailable.');
-    return [];
-  }
-
-  try {
-    const results = await vfs.search(text.trim(), { provider: GITHUB_PROVIDER, limit: DEFAULT_LIMIT });
-    return results.map((entry) => ({
-      entry,
-      enumerationType: inferEnumerationType(entry),
-    }));
-  } catch (error) {
-    errors.push(errorMessage(error));
-    return [];
-  }
-}
-
-async function loadFallbackEntries(
-  apiFallback: GitHubLibrarianApiFallback,
-  request: GitHubLibrarianFallbackRequest,
-): Promise<readonly VfsEntry[]> {
-  if (typeof apiFallback === 'function') {
-    return apiFallback(request);
-  }
-
-  if (request.types.length > 0 && apiFallback.list) {
-    return apiFallback.list(request);
-  }
-
-  if (apiFallback.search) {
-    return apiFallback.search(request);
-  }
-
-  if (apiFallback.list) {
-    return apiFallback.list(request);
-  }
-
-  return [];
-}
-
-function toEnumerationEntry(entry: VfsEntry, requested: GitHubEnumerationType[]): EnumerationEntry[] {
-  const inferredType = inferEnumerationType(entry);
-  if (inferredType === 'github') {
-    return [];
-  }
-  if (!requested.includes(inferredType)) {
-    return [];
-  }
-
-  return [{ entry, enumerationType: inferredType }];
-}
-
-function inferEnumerationType(entry: VfsEntry): GitHubEnumerationType | 'github' {
-  const propertyType = entry.properties?.type?.toLowerCase();
-  if (propertyType === 'pr' || propertyType === 'pull_request' || propertyType === 'pull-request') {
-    return 'pr';
-  }
-  if (propertyType === 'issue') {
-    return 'issue';
-  }
-
-  return collectionItemTypeFromPath(entry.path) ?? 'github';
-}
-
-function matchesRequestedFilters(entry: VfsEntry, filters: Record<string, string[]>): boolean {
-  return filterMatches(entry, filters, 'state') && filterMatches(entry, filters, 'repo') && filterMatches(entry, filters, 'label');
-}
-
-function filterMatches(entry: VfsEntry, filters: Record<string, string[]>, key: 'state' | 'repo' | 'label'): boolean {
-  const requested = filters[key];
-  if (!requested || requested.length === 0) {
-    return true;
-  }
-
-  const actual = valuesForFilter(entry, key).map((value) => normalizeComparable(value));
-  return requested.some((value) => actual.includes(normalizeComparable(value)));
-}
-
-function valuesForFilter(entry: VfsEntry, key: 'state' | 'repo' | 'label'): string[] {
-  const properties = entry.properties ?? {};
-
-  if (key === 'repo') {
-    return [properties.repo, properties.repository, repoFromPath(entry.path)].filter(isString);
-  }
-
-  if (key === 'label') {
-    return [
-      ...expandPropertyValues(properties.label),
-      ...expandPropertyValues(properties.labels),
-    ];
-  }
-
-  return expandPropertyValues(properties.state);
-}
-
-function toEvidence(entry: VfsEntry, enumerationType: GitHubEnumerationType | 'github'): GitHubEnumerationEvidence {
-  const properties = entry.properties ?? {};
-  const labels = [
-    ...expandPropertyValues(properties.label),
-    ...expandPropertyValues(properties.labels),
-  ];
-  const content: GitHubEnumerationEvidenceContent = {
-    type: enumerationType,
-    path: entry.path,
-    repo: firstString(properties.repo, properties.repository, repoFromPath(entry.path), 'unknown'),
-    title: firstString(entry.title, properties.title, titleFromPath(entry.path)),
-    state: firstString(properties.state, 'unknown'),
-    labels,
-    properties,
-  };
-  const number = firstString(properties.number, properties.pr, properties.issue, numberFromPath(entry.path));
-  const snippet = snippetFromEntry(entry);
-
-  if (entry.provider) {
-    content.provider = entry.provider;
-  }
-  if (entry.revision) {
-    content.revision = entry.revision;
-  }
-  if (entry.updatedAt) {
-    content.updatedAt = entry.updatedAt;
-  }
-  if (properties.url) {
-    content.url = properties.url;
-  }
-  if (number !== '') {
-    content.number = number;
-  }
-  if (snippet) {
-    content.snippet = snippet;
-  }
-
-  return {
-    id: firstString(properties.id, entry.path),
-    kind: 'enumeration_hit',
-    content,
-  };
-}
-
-function summarizeMatches(evidence: GitHubEnumerationEvidence[]): string {
-  if (evidence.length === 0) {
-    return 'No GitHub enumeration matches found.';
-  }
-
-  const lines = [`Found ${evidence.length} GitHub enumeration match${evidence.length === 1 ? '' : 'es'}.`];
-  for (const [index, item] of evidence.slice(0, SUMMARY_LIMIT).entries()) {
-    lines.push(`${index + 1}. ${item.content.repo} - ${item.content.title} [${item.content.state}]`);
-  }
-
-  if (evidence.length > SUMMARY_LIMIT) {
-    lines.push(`...and ${evidence.length - SUMMARY_LIMIT} more.`);
-  }
-
-  return lines.join('\n');
-}
-
-function metadataFor(
-  text: string,
-  filters: Record<string, string[]>,
-  resultCount: number,
-  source: GitHubLibrarianFindings['metadata']['source'],
-  errors: string[],
-): GitHubLibrarianFindings['metadata'] {
-  const metadata: GitHubLibrarianFindings['metadata'] = {
-    text,
-    filters,
-    resultCount,
-    source,
-  };
-
-  if (errors.length > 0) {
-    metadata.errors = errors;
-  }
-
-  return metadata;
-}
-
-function statusFor(resultCount: number, errorCount: number): EnumerationStatus {
-  if (errorCount === 0) {
-    return 'complete';
-  }
-
-  return resultCount > 0 ? 'partial' : 'failed';
-}
-
-function dedupeEntries(entries: EnumerationEntry[]): EnumerationEntry[] {
-  const seen = new Set<string>();
-  const deduped: EnumerationEntry[] = [];
-
-  for (const item of entries) {
-    const key = item.entry.path;
-    if (seen.has(key)) {
-      continue;
-    }
-
-    seen.add(key);
-    deduped.push(item);
-  }
-
-  return deduped;
-}
-
-function compareEntries(left: EnumerationEntry, right: EnumerationEntry): number {
-  const leftUpdated = left.entry.updatedAt ?? '';
-  const rightUpdated = right.entry.updatedAt ?? '';
-  const updatedComparison = rightUpdated.localeCompare(leftUpdated);
-  if (updatedComparison !== 0) {
-    return updatedComparison;
-  }
-
-  return left.entry.path.localeCompare(right.entry.path);
-}
-
-function expandPropertyValues(value: string | undefined): string[] {
-  if (!value) {
-    return [];
-  }
-
-  const trimmed = value.trim();
-  if (trimmed.startsWith('[')) {
-    try {
-      const parsed: unknown = JSON.parse(trimmed);
-      if (Array.isArray(parsed)) {
-        return parsed.filter(isString).map((item) => item.trim()).filter((item) => item.length > 0);
-      }
-    } catch {
-      // Fall through to comma-separated handling.
-    }
-  }
-
-  return trimmed.split(',').map((item) => item.trim()).filter((item) => item.length > 0);
-}
-
-function repoFromPath(path: string): string | undefined {
-  const segments = pathSegments(path);
-  const reposIndex = segments.indexOf('repos');
-  if (reposIndex < 0) {
-    return undefined;
-  }
-
-  const owner = segments[reposIndex + 1];
-  const repo = segments[reposIndex + 2];
-  if (!owner || !repo) {
-    return undefined;
-  }
-
-  return `${owner}/${repo}`;
-}
-
-function numberFromPath(path: string): string | undefined {
-  const segments = pathSegments(path);
-  const collectionIndex = collectionIndexFromPath(path);
-  if (collectionIndex < 0) {
-    return undefined;
-  }
-
-  return segments[collectionIndex + 1];
-}
-
-function collectionItemTypeFromPath(path: string): GitHubEnumerationType | undefined {
-  const segments = pathSegments(path);
-  const collectionIndex = collectionIndexFromPath(path);
-  if (collectionIndex < 0 || !segments[collectionIndex + 1]) {
-    return undefined;
-  }
-
-  if (segments[collectionIndex] === 'pulls') {
-    return 'pr';
-  }
-
-  if (segments[collectionIndex] === 'issues') {
-    return 'issue';
-  }
-
-  return undefined;
-}
-
-function collectionIndexFromPath(path: string): number {
-  const segments = pathSegments(path);
-  const reposIndex = segments.indexOf('repos');
-  if (reposIndex < 0) {
-    return -1;
-  }
-
-  const collectionIndex = reposIndex + 3;
-  const collection = segments[collectionIndex];
-  return collection === 'pulls' || collection === 'issues' ? collectionIndex : -1;
-}
-
-function titleFromPath(path: string): string {
-  const segments = pathSegments(path);
-  return segments[segments.length - 1] ?? path;
-}
-
-function pathSegments(path: string): string[] {
-  return path.split('/').filter(Boolean).map(decodeSegment);
+function snippetFromEntry(entry: VfsEntry): string | undefined {
+  return 'snippet' in entry && typeof entry.snippet === 'string' ? entry.snippet : undefined;
 }
 
 function decodeSegment(segment: string): string {
@@ -606,26 +231,6 @@ function decodeSegment(segment: string): string {
   } catch {
     return segment;
   }
-}
-
-function normalizeComparable(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-function firstString(...values: Array<string | undefined>): string {
-  return values.find((value): value is string => typeof value === 'string' && value.length > 0) ?? '';
-}
-
-function snippetFromEntry(entry: VfsEntry): string | undefined {
-  if ('snippet' in entry && typeof entry.snippet === 'string') {
-    return entry.snippet;
-  }
-
-  return undefined;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }
 
 function isString(value: unknown): value is string {

--- a/packages/specialists/src/github/librarian.ts
+++ b/packages/specialists/src/github/librarian.ts
@@ -84,6 +84,9 @@ const githubLibrarianAdapter: LibrarianAdapter<GitHubEnumerationType> = {
   valuesForFilter,
   inferEntityType,
   toEvidence,
+  // "pr" alone is a weak search term for GitHub-indexed VFS stores; emit the
+  // richer natural-language form so list-miss → vfs.search doesn't drop valid hits.
+  searchTerm: (type) => (type === 'pr' ? 'pull request' : type),
 };
 
 export function createGitHubLibrarian({

--- a/packages/specialists/src/index.ts
+++ b/packages/specialists/src/index.ts
@@ -1,2 +1,3 @@
 export * from './shared/index.js';
 export * from './github/index.js';
+export * from './linear/index.js';

--- a/packages/specialists/src/linear/index.ts
+++ b/packages/specialists/src/linear/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export * from './librarian.js';

--- a/packages/specialists/src/linear/librarian.test.ts
+++ b/packages/specialists/src/linear/librarian.test.ts
@@ -1,0 +1,113 @@
+import type { VfsEntry, VfsProvider, VfsReadResult, VfsSearchResult } from '@agent-assistant/vfs';
+import { describe, expect, it } from 'vitest';
+
+import { createLinearLibrarian } from './librarian.js';
+
+class InMemoryVfsProvider implements VfsProvider {
+  constructor(private readonly entries: VfsEntry[]) {}
+
+  async list(rootPath: string): Promise<VfsEntry[]> {
+    const normalizedRoot = rootPath.endsWith('/') ? rootPath : `${rootPath}/`;
+    return this.entries.filter((entry) => entry.path === rootPath || entry.path.startsWith(normalizedRoot));
+  }
+
+  async read(): Promise<VfsReadResult | null> {
+    return null;
+  }
+
+  async search(): Promise<VfsSearchResult[]> {
+    return this.entries;
+  }
+}
+
+const issues: VfsEntry[] = [
+  {
+    path: '/linear/issues/ENG-101.json',
+    type: 'file',
+    provider: 'linear',
+    revision: 'rev-1',
+    updatedAt: '2026-04-17T12:00:00.000Z',
+    title: 'Harden token refresh',
+    properties: {
+      id: 'linear-issue-1',
+      type: 'issue',
+      identifier: 'ENG-101',
+      state: 'open',
+      team: 'ENG',
+      teamKey: 'ENG',
+      url: 'https://linear.app/acme/issue/ENG-101/harden-token-refresh',
+    },
+  },
+  {
+    path: '/linear/issues/OPS-202.json',
+    type: 'file',
+    provider: 'linear',
+    revision: 'rev-2',
+    updatedAt: '2026-04-17T11:00:00.000Z',
+    title: 'Rotate incident webhook secret',
+    properties: {
+      id: 'linear-issue-2',
+      type: 'issue',
+      identifier: 'OPS-202',
+      state: 'open',
+      team: 'OPS',
+      teamKey: 'OPS',
+      url: 'https://linear.app/acme/issue/OPS-202/rotate-incident-webhook-secret',
+    },
+  },
+  {
+    path: '/linear/issues/ENG-303.json',
+    type: 'file',
+    provider: 'linear',
+    revision: 'rev-3',
+    updatedAt: '2026-04-17T10:00:00.000Z',
+    title: 'Archive legacy OAuth client',
+    properties: {
+      id: 'linear-issue-3',
+      type: 'issue',
+      identifier: 'ENG-303',
+      state: 'done',
+      team: 'ENG',
+      teamKey: 'ENG',
+      url: 'https://linear.app/acme/issue/ENG-303/archive-legacy-oauth-client',
+    },
+  },
+];
+
+function createLibrarian() {
+  return createLinearLibrarian({
+    vfs: new InMemoryVfsProvider(issues),
+  });
+}
+
+function evidenceIdsFor(instruction: string): Promise<string[]> {
+  return createLibrarian()
+    .handler.execute(instruction)
+    .then((result) => result.evidence.map((item) => item.id));
+}
+
+describe('createLinearLibrarian filter matching', () => {
+  it('matches open issues against only state:open issue entries', async () => {
+    await expect(evidenceIdsFor('open issues')).resolves.toEqual(['linear-issue-1', 'linear-issue-2']);
+  });
+
+  it('scopes state:open team:ENG to that Linear team', async () => {
+    const result = await createLibrarian().handler.execute('state:open team:ENG');
+
+    expect(result.status).toBe('complete');
+    expect(result.metadata.filters).toMatchObject({
+      state: ['open'],
+      team: ['ENG'],
+    });
+    expect(result.evidence.map((item) => item.id)).toEqual(['linear-issue-1']);
+    expect(result.evidence.map((item) => item.content.team)).toEqual(['ENG']);
+  });
+
+  it('returns failed status and empty evidence when no Linear issues match', async () => {
+    const result = await createLibrarian().handler.execute('state:open team:DESIGN');
+
+    expect(result.status).toBe('failed');
+    expect(result.evidence).toEqual([]);
+    expect(result.metadata.resultCount).toBe(0);
+  });
+});

--- a/packages/specialists/src/linear/librarian.ts
+++ b/packages/specialists/src/linear/librarian.ts
@@ -1,0 +1,378 @@
+import type { VfsEntry } from '@agent-assistant/vfs';
+import {
+  linearCommentPath,
+  linearIssuePath,
+  linearProjectPath,
+} from '@relayfile/adapter-linear/path-mapper';
+
+import {
+  createLibrarian,
+  type GenericLibrarianFindings,
+  type GenericLibrarianSpecialist,
+  type LibrarianAdapter,
+  type LibrarianApiFallback,
+  type LibrarianFallbackRequest,
+  type LibrarianStatus,
+  type LibrarianVfs,
+} from '../shared/librarian-engine.js';
+import type { LinearEntityType, LinearEnumerationCapability } from './types.js';
+
+const LINEAR_ENUMERATION_CAPABILITY: LinearEnumerationCapability = 'linear.enumerate';
+type EnumerationStatus = LibrarianStatus;
+const LINEAR_FILTER_KEYS = ['state', 'team', 'assignee', 'priority', 'project', 'type'] as const;
+const LINEAR_ENTITY_TYPES = new Set<string>(['issue', 'project', 'comment']);
+
+type LinearLibrarianVfs = LibrarianVfs;
+type LinearLibrarianFallbackRequest = LibrarianFallbackRequest<LinearEntityType>;
+type LinearLibrarianApiFallback = LibrarianApiFallback<LinearEntityType>;
+
+export interface LinearLibrarianOptions {
+  vfs: LinearLibrarianVfs;
+  apiFallback?: LinearLibrarianApiFallback;
+}
+
+export interface LinearEnumerationEvidenceContent
+  extends Partial<
+    Record<
+      | 'provider'
+      | 'revision'
+      | 'updatedAt'
+      | 'createdAt'
+      | 'url'
+      | 'identifier'
+      | 'number'
+      | 'issue'
+      | 'author'
+      | 'snippet',
+      string
+    >
+  > {
+  type: LinearEntityType | 'linear';
+  path: string;
+  title: string;
+  state: string;
+  team: string;
+  assignee: string;
+  priority: string;
+  project: string;
+  properties: Record<string, string>;
+}
+
+export interface LinearEnumerationEvidence {
+  id: string;
+  kind: 'enumeration_hit';
+  content: LinearEnumerationEvidenceContent;
+}
+
+export interface LinearLibrarianFindings
+  extends Omit<GenericLibrarianFindings, 'capability' | 'status' | 'evidence'> {
+  capability: LinearEnumerationCapability;
+  status: EnumerationStatus;
+  evidence: LinearEnumerationEvidence[];
+}
+
+export interface LinearLibrarianSpecialist
+  extends Omit<GenericLibrarianSpecialist<LinearEntityType>, 'name' | 'capabilities' | 'handler'> {
+  name: 'linear-librarian';
+  capabilities: LinearEnumerationCapability[];
+  handler: {
+    execute(instruction: string, context?: unknown): Promise<LinearLibrarianFindings>;
+  };
+}
+
+const COLLECTION_ROOT_BY_TYPE: Record<LinearEntityType, string> = {
+  issue: collectionRootFromPath(linearIssuePath('__root__')),
+  project: collectionRootFromPath(linearProjectPath('__root__')),
+  comment: collectionRootFromPath(linearCommentPath('__root__')),
+};
+
+const linearLibrarianAdapter: LibrarianAdapter<LinearEntityType> = {
+  capability: LINEAR_ENUMERATION_CAPABILITY,
+  entityTypes: ['issue', 'project', 'comment'],
+  filterKeys: ['state', 'team', 'assignee', 'priority', 'project'],
+  searchProvider: 'linear',
+  listRoots(types) {
+    return types.map((type) => COLLECTION_ROOT_BY_TYPE[type]);
+  },
+  inferFilters: inferEnumerationFilters,
+  valuesForFilter,
+  inferEntityType,
+  toEvidence,
+};
+
+export function createLinearLibrarian({
+  vfs,
+  apiFallback,
+}: LinearLibrarianOptions): LinearLibrarianSpecialist {
+  const options = {
+    vfs,
+    name: 'linear-librarian',
+    description: 'Enumerates Linear issues, projects, and comments from VFS-backed metadata.',
+  };
+  const engine = createLibrarian(linearLibrarianAdapter, apiFallback ? { ...options, apiFallback } : options);
+  return engine as unknown as LinearLibrarianSpecialist;
+}
+
+function inferEnumerationFilters(text: string, parsedFilters: Record<string, string[]>): Record<string, string[]> {
+  const filters = cloneFilters(parsedFilters);
+  inferExplicitFilters(text, filters);
+  const normalizedText = ` ${text.toLowerCase().replace(/[-_]+/g, ' ')} `;
+
+  if (!filters.type?.length) {
+    if (/\b(issue|issues)\b/.test(normalizedText)) filters.type = ['issue'];
+    else if (/\b(project|projects)\b/.test(normalizedText)) filters.type = ['project'];
+    else if (/\b(comment|comments)\b/.test(normalizedText)) filters.type = ['comment'];
+  }
+  if (!filters.state?.length) {
+    if (/\bin progress\b/.test(normalizedText)) filters.state = ['in progress'];
+    else if (/\bcancell?ed\b/.test(normalizedText)) filters.state = ['cancelled'];
+    else if (/\bopen\b/.test(normalizedText)) filters.state = ['open'];
+    else if (/\bdone\b/.test(normalizedText)) filters.state = ['done'];
+  }
+  if (!filters.team?.length) {
+    const team = cueValue(text, /\bteam\s+(?:"([^"]+)"|'([^']+)'|([^\s]+))/i);
+    if (team) filters.team = [team];
+  }
+  if (!filters.assignee?.length) {
+    const assignee = cueValue(text, /\bassigned\s+to\s+(?:"([^"]+)"|'([^']+)'|([^\s]+))/i);
+    if (assignee) filters.assignee = [assignee];
+  }
+  if (!filters.priority?.length) {
+    const priority = text.match(/\bpriority\s+(high|medium|low)\b/i)?.[1];
+    if (priority) filters.priority = [priority];
+  }
+
+  return filters;
+}
+
+function inferExplicitFilters(text: string, filters: Record<string, string[]>): void {
+  for (const token of text.trim().split(/\s+/)) {
+    if (!token) continue;
+
+    const separatorIndex = token.indexOf(':');
+    if (separatorIndex <= 0 || separatorIndex === token.length - 1) continue;
+
+    const key = token.slice(0, separatorIndex).toLowerCase();
+    if (!LINEAR_FILTER_KEYS.includes(key as (typeof LINEAR_FILTER_KEYS)[number])) continue;
+
+    const value = normalizeExplicitFilterValue(key, token.slice(separatorIndex + 1));
+    if (!value) continue;
+
+    const existing = filters[key] ?? [];
+    if (!existing.includes(value)) filters[key] = [...existing, value];
+  }
+}
+
+function normalizeExplicitFilterValue(key: string, value: string): string | undefined {
+  const trimmed = unquote(value.replace(/[,.]$/g, '').trim());
+  if (!trimmed) return undefined;
+
+  if (key === 'type') {
+    const normalizedType = trimmed.toLowerCase();
+    return LINEAR_ENTITY_TYPES.has(normalizedType) ? normalizedType : undefined;
+  }
+
+  if (key === 'state') {
+    return trimmed.toLowerCase().replace(/[-_]+/g, ' ');
+  }
+
+  return trimmed;
+}
+
+function unquote(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
+function valuesForFilter(entry: VfsEntry, key: string): string[] {
+  const properties = entry.properties ?? {};
+  if (key === 'state') {
+    return expandStateValues(properties.state, properties.status, properties.stateName);
+  }
+  if (key === 'team') {
+    return expandPropertyValues(
+      properties.team,
+      properties.teamId,
+      properties.teamKey,
+      properties.teamName,
+      properties.teamSlug,
+    );
+  }
+  if (key === 'assignee') {
+    return expandPropertyValues(
+      properties.assignee,
+      properties.assigneeId,
+      properties.assigneeName,
+      properties.assigneeEmail,
+      properties.assigneeUsername,
+    );
+  }
+  if (key === 'priority') {
+    return expandPropertyValues(properties.priority, properties.priorityLabel, properties.priorityName);
+  }
+  if (key === 'project') {
+    return expandPropertyValues(
+      properties.project,
+      properties.projectId,
+      properties.projectKey,
+      properties.projectName,
+      properties.projectSlug,
+    );
+  }
+  if (key === 'type') {
+    const type = inferEntityType(entry);
+    return [properties.type, type === 'unknown' ? undefined : type].filter(isString);
+  }
+  return [];
+}
+
+function inferEntityType(entry: VfsEntry): LinearEntityType | 'unknown' {
+  const propertyType = firstString(
+    entry.properties?.type,
+    entry.properties?.objectType,
+    entry.properties?.entityType,
+  )
+    .toLowerCase()
+    .replace(/[-_\s]+/g, '');
+
+  if (propertyType === 'issue' || propertyType === 'linearissue') return 'issue';
+  if (propertyType === 'project' || propertyType === 'linearproject') return 'project';
+  if (propertyType === 'comment' || propertyType === 'linearcomment') return 'comment';
+  return collectionItemTypeFromPath(entry.path) ?? 'unknown';
+}
+
+function toEvidence(entry: VfsEntry, type: LinearEntityType | 'unknown'): LinearEnumerationEvidence {
+  const properties = entry.properties ?? {};
+  const content: LinearEnumerationEvidenceContent = {
+    type: type === 'unknown' ? 'linear' : type,
+    path: entry.path,
+    title: firstString(entry.title, properties.title, properties.name, properties.identifier, idFromPath(entry.path)),
+    state: firstString(properties.state, properties.status, properties.stateName, 'unknown'),
+    team: firstString(properties.team, properties.teamName, properties.teamKey, properties.teamId),
+    assignee: firstString(
+      properties.assignee,
+      properties.assigneeName,
+      properties.assigneeEmail,
+      properties.assigneeId,
+    ),
+    priority: firstString(properties.priority, properties.priorityLabel, properties.priorityName),
+    project: firstString(properties.project, properties.projectName, properties.projectId),
+    properties,
+  };
+  const id = firstString(properties.id, properties.identifier, properties.key, idFromPath(entry.path), entry.path);
+  const identifier = firstString(properties.identifier, properties.key, idFromPath(entry.path));
+  const issue = firstString(properties.issue, properties.issueIdentifier, properties.issueId);
+  const snippet = snippetFromEntry(entry);
+
+  for (const key of ['provider', 'revision', 'updatedAt'] as const) {
+    const value = entry[key];
+    if (value) content[key] = value;
+  }
+  for (const key of ['createdAt', 'url', 'number', 'author'] as const) {
+    const value = properties[key];
+    if (value) content[key] = value;
+  }
+  if (identifier) content.identifier = identifier;
+  if (issue) content.issue = issue;
+  if (snippet) content.snippet = snippet;
+
+  return { id, kind: 'enumeration_hit', content };
+}
+
+function collectionRootFromPath(path: string): string {
+  const lastSlash = path.lastIndexOf('/');
+  return lastSlash >= 0 ? path.slice(0, lastSlash + 1) : path;
+}
+
+function collectionItemTypeFromPath(path: string): LinearEntityType | undefined {
+  const match = /\/linear\/(issues|projects|comments)\/[^/]+(?:\.json)?$/.exec(path);
+  if (match?.[1] === 'issues') return 'issue';
+  if (match?.[1] === 'projects') return 'project';
+  if (match?.[1] === 'comments') return 'comment';
+  return undefined;
+}
+
+function idFromPath(path: string): string | undefined {
+  const leaf = path.split('/').filter(Boolean).at(-1);
+  if (!leaf) return undefined;
+  return decodeSegment(leaf.replace(/\.json$/i, ''));
+}
+
+function expandStateValues(...values: Array<string | undefined>): string[] {
+  return unique(expandPropertyValues(...values).flatMap(stateValueVariants));
+}
+
+function stateValueVariants(value: string): string[] {
+  const normalized = value.trim().toLowerCase().replace(/[-_]+/g, ' ');
+  const variants = [value, normalized];
+
+  if (normalized === 'in progress') {
+    variants.push('in_progress', 'in-progress');
+  }
+  if (normalized === 'cancelled' || normalized === 'canceled') {
+    variants.push('cancelled', 'canceled');
+  }
+
+  return unique(variants);
+}
+
+function expandPropertyValues(...values: Array<string | undefined>): string[] {
+  return values.flatMap((value) => expandPropertyValue(value));
+}
+
+function expandPropertyValue(value: string | undefined): string[] {
+  if (!value) return [];
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed.filter(isString).map((item) => item.trim()).filter(Boolean);
+    } catch {
+      // Fall through to comma-separated handling.
+    }
+  }
+
+  return trimmed.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function cueValue(text: string, pattern: RegExp): string | undefined {
+  const match = pattern.exec(text);
+  const value = firstString(match?.[1], match?.[2], match?.[3]);
+  return value?.replace(/[,.]$/g, '');
+}
+
+function cloneFilters(filters: Record<string, string[]>): Record<string, string[]> {
+  return Object.fromEntries(Object.entries(filters).map(([key, values]) => [key, [...values]]));
+}
+
+function firstString(...values: Array<string | undefined>): string {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0) ?? '';
+}
+
+function snippetFromEntry(entry: VfsEntry): string | undefined {
+  return 'snippet' in entry && typeof entry.snippet === 'string' ? entry.snippet : undefined;
+}
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}

--- a/packages/specialists/src/linear/types.ts
+++ b/packages/specialists/src/linear/types.ts
@@ -1,0 +1,20 @@
+export type LinearEnumerationCapability = 'linear.enumerate';
+export type LinearEntityType = 'issue' | 'project' | 'comment';
+
+export interface LinearQueryFilterSet {
+  state?: string[];
+  team?: string[];
+  assignee?: string[];
+  priority?: string[];
+  project?: string[];
+  type?: LinearEntityType[];
+  [filter: string]: string[] | undefined;
+}
+
+export interface LinearEnumerationParams {
+  capability: LinearEnumerationCapability;
+  query?: string;
+  filters?: LinearQueryFilterSet;
+  cursor?: string;
+  limit?: number;
+}

--- a/packages/specialists/src/shared/investigator-engine.ts
+++ b/packages/specialists/src/shared/investigator-engine.ts
@@ -1,0 +1,695 @@
+import type {
+  Specialist,
+  SpecialistContext,
+  SpecialistExecutionStatus,
+  SpecialistResult,
+} from '@agent-assistant/coordination';
+import type { VfsProvider, VfsReadResult } from '@agent-assistant/vfs';
+
+import type { DelegationStatus, SpecialistFinding } from './findings.js';
+
+const DEFAULT_DURABLE_EVIDENCE_THRESHOLD_BYTES = 4_096;
+
+export type InvestigatorTarget = Record<string, unknown>;
+
+export interface InvestigatorPaths {
+  metadata: string[];
+  raw?: string[];
+  diff?: string;
+}
+
+export interface InvestigatorAdapter<TEntity> {
+  capability: string;
+  specialistName: string;
+  specialistVersion: string;
+  paths(target: InvestigatorTarget): InvestigatorPaths;
+  parse(raw: string): TEntity | null;
+  toEvidence(entity: TEntity, target: InvestigatorTarget): SpecialistFinding[];
+  apiFallback?(target: InvestigatorTarget): Promise<TEntity | null>;
+  durableEvidenceThresholdBytes?: number;
+}
+
+export interface DurableEvidenceRef {
+  path: string;
+  revision?: string;
+  workspaceId?: string;
+  [key: string]: unknown;
+}
+
+export interface EvidenceWriteInput {
+  requestId: string;
+  evidenceId: string;
+  kind: string;
+  title: string;
+  content: string;
+  contentType: string;
+  confidence?: number;
+}
+
+export interface EvidenceWriter {
+  writeEvidence(input: EvidenceWriteInput): Promise<DurableEvidenceRef>;
+  finalize?(): Promise<void> | void;
+}
+
+export interface InvestigatorDeps {
+  vfs: VfsProvider;
+  evidenceWriter?: EvidenceWriter | null;
+  now?: () => number;
+  parseTarget?(instruction: string, context?: SpecialistContext): InvestigatorTarget | null;
+  describeTarget?(target: InvestigatorTarget): string;
+  summarize?(input: {
+    target: InvestigatorTarget;
+    findings: SpecialistFinding[];
+    source: InvestigatorEvidenceSource;
+  }): string;
+  confidence?(input: {
+    target: InvestigatorTarget;
+    findings: SpecialistFinding[];
+    source: InvestigatorEvidenceSource;
+  }): number | undefined;
+}
+
+export type InvestigatorEvidenceSourceProvider = 'vfs' | 'apiFallback';
+
+export interface InvestigatorEvidenceSource {
+  provider: InvestigatorEvidenceSourceProvider;
+  asOf: string;
+  path?: string;
+  revision?: string;
+}
+
+export interface InvestigatorGap {
+  description: string;
+  reason: 'not_found' | 'unavailable' | 'invalid_request' | 'unknown';
+}
+
+export interface InvestigatorFindings {
+  requestId: string;
+  capability: string;
+  status: DelegationStatus;
+  summary: string;
+  findings: SpecialistFinding[];
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface LoadedEntity<TEntity> {
+  entity: TEntity | null;
+  source?: InvestigatorEvidenceSource;
+  actionCount: number;
+  gaps: InvestigatorGap[];
+}
+
+interface ReadAttempt {
+  result: VfsReadResult | null;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function requestIdFromContext(adapter: InvestigatorAdapter<unknown>, context?: SpecialistContext): string {
+  if (context) {
+    return `${context.turnId || adapter.specialistName}-${context.stepIndex}`;
+  }
+
+  return `${adapter.specialistName}-${Date.now()}`;
+}
+
+function readRequestId(target: InvestigatorTarget, adapter: InvestigatorAdapter<unknown>, context?: SpecialistContext): string {
+  return readString(target.requestId) ?? requestIdFromContext(adapter, context);
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultParseTarget(
+  instruction: string,
+  adapter: InvestigatorAdapter<unknown>,
+  context?: SpecialistContext,
+): InvestigatorTarget {
+  const fallbackRequestId = requestIdFromContext(adapter, context);
+  const parsed = parseJsonObject(instruction);
+  if (!parsed) {
+    return {
+      requestId: fallbackRequestId,
+      instruction,
+      query: instruction,
+    };
+  }
+
+  const requestId = readString(parsed.requestId) ?? fallbackRequestId;
+  const candidates = [parsed.target, parsed.params, parsed.parameters, parsed].filter(isRecord);
+  const target = candidates[0] ?? parsed;
+  return {
+    ...target,
+    requestId: readString(target.requestId) ?? requestId,
+  };
+}
+
+function parseTarget(
+  instruction: string,
+  context: SpecialistContext | undefined,
+  adapter: InvestigatorAdapter<unknown>,
+  deps: InvestigatorDeps,
+): InvestigatorTarget | null {
+  if (deps.parseTarget) {
+    return deps.parseTarget(instruction, context);
+  }
+
+  return defaultParseTarget(instruction, adapter, context);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function safeRead(vfs: VfsProvider, filePath: string): Promise<ReadAttempt> {
+  try {
+    return { result: await vfs.read(filePath) };
+  } catch (error) {
+    return { result: null, error: errorMessage(error) };
+  }
+}
+
+async function readFirst(vfs: VfsProvider, paths: string[]): Promise<{
+  result: VfsReadResult | null;
+  actionCount: number;
+  errors: string[];
+}> {
+  let actionCount = 0;
+  const errors: string[] = [];
+
+  for (const filePath of paths) {
+    actionCount += 1;
+    const attempt = await safeRead(vfs, filePath);
+    if (attempt.error) {
+      errors.push(`${filePath}: ${attempt.error}`);
+    }
+    if (attempt.result) {
+      return { result: attempt.result, actionCount, errors };
+    }
+  }
+
+  return { result: null, actionCount, errors };
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function formatVfsBlob(metadata: VfsReadResult | null, diff: VfsReadResult | null): string | null {
+  if (!metadata && !diff) {
+    return null;
+  }
+
+  return [
+    metadata ? `Metadata:\n${metadata.content}` : '',
+    diff ? `Diff:\n${diff.content}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function sourceFromRead(result: VfsReadResult, producedAt: string): InvestigatorEvidenceSource {
+  return {
+    provider: 'vfs',
+    asOf: producedAt,
+    path: result.path,
+    ...(result.revision === undefined ? {} : { revision: result.revision }),
+  };
+}
+
+function failureGap(target: InvestigatorTarget, deps: InvestigatorDeps): InvestigatorGap {
+  const label = deps.describeTarget?.(target) ?? readString(target.query) ?? readString(target.instruction) ?? 'target';
+  return {
+    description: `${label} was unavailable from VFS and API fallback.`,
+    reason: 'not_found',
+  };
+}
+
+async function parseVfsCandidate<TEntity>(
+  adapter: InvestigatorAdapter<TEntity>,
+  raw: string,
+  source: InvestigatorEvidenceSource,
+): Promise<LoadedEntity<TEntity> | null> {
+  const entity = adapter.parse(raw);
+  if (!entity) {
+    return null;
+  }
+
+  return {
+    entity,
+    source,
+    actionCount: 0,
+    gaps: [],
+  };
+}
+
+async function loadEntityFromVfs<TEntity>(
+  adapter: InvestigatorAdapter<TEntity>,
+  deps: InvestigatorDeps,
+  target: InvestigatorTarget,
+  producedAt: string,
+): Promise<LoadedEntity<TEntity>> {
+  const paths = adapter.paths(target);
+  const errors: string[] = [];
+  let actionCount = 0;
+
+  if (paths.raw && paths.raw.length > 0) {
+    const raw = await readFirst(deps.vfs, paths.raw);
+    actionCount += raw.actionCount;
+    errors.push(...raw.errors);
+    if (raw.result) {
+      const loaded = await parseVfsCandidate(adapter, raw.result.content, sourceFromRead(raw.result, producedAt));
+      if (loaded) {
+        return { ...loaded, actionCount, gaps: [] };
+      }
+    }
+  }
+
+  const metadata = await readFirst(deps.vfs, paths.metadata);
+  actionCount += metadata.actionCount;
+  errors.push(...metadata.errors);
+
+  let diffResult: VfsReadResult | null = null;
+  if (paths.diff) {
+    actionCount += 1;
+    const diff = await safeRead(deps.vfs, paths.diff);
+    if (diff.error) {
+      errors.push(`${paths.diff}: ${diff.error}`);
+    }
+    diffResult = diff.result;
+  }
+
+  const formatted = formatVfsBlob(metadata.result, diffResult);
+  if (formatted) {
+    const sourceResult = metadata.result ?? diffResult;
+    const loaded = sourceResult
+      ? await parseVfsCandidate(adapter, formatted, sourceFromRead(sourceResult, producedAt))
+      : null;
+    if (loaded) {
+      return { ...loaded, actionCount, gaps: [] };
+    }
+  }
+
+  if (metadata.result) {
+    const loaded = await parseVfsCandidate(
+      adapter,
+      metadata.result.content,
+      sourceFromRead(metadata.result, producedAt),
+    );
+    if (loaded) {
+      return { ...loaded, actionCount, gaps: [] };
+    }
+  }
+
+  if (diffResult) {
+    const loaded = await parseVfsCandidate(adapter, diffResult.content, sourceFromRead(diffResult, producedAt));
+    if (loaded) {
+      return { ...loaded, actionCount, gaps: [] };
+    }
+  }
+
+  return {
+    entity: null,
+    actionCount,
+    gaps: errors.map((description) => ({ description, reason: 'unavailable' })),
+  };
+}
+
+async function loadEntity<TEntity>(
+  adapter: InvestigatorAdapter<TEntity>,
+  deps: InvestigatorDeps,
+  target: InvestigatorTarget,
+  producedAt: string,
+): Promise<LoadedEntity<TEntity>> {
+  const loadedFromVfs = await loadEntityFromVfs(adapter, deps, target, producedAt);
+  if (loadedFromVfs.entity) {
+    return loadedFromVfs;
+  }
+
+  if (!adapter.apiFallback) {
+    return {
+      ...loadedFromVfs,
+      gaps: loadedFromVfs.gaps.length > 0 ? loadedFromVfs.gaps : [failureGap(target, deps)],
+    };
+  }
+
+  const entity = await adapter.apiFallback(target);
+  if (!entity) {
+    return {
+      entity: null,
+      source: { provider: 'apiFallback', asOf: producedAt },
+      actionCount: loadedFromVfs.actionCount + 1,
+      gaps: [
+        ...loadedFromVfs.gaps,
+        {
+          description: `${deps.describeTarget?.(target) ?? 'Target'} could not be loaded from API fallback.`,
+          reason: 'unavailable',
+        },
+      ],
+    };
+  }
+
+  return {
+    entity,
+    source: { provider: 'apiFallback', asOf: producedAt },
+    actionCount: loadedFromVfs.actionCount + 1,
+    gaps: loadedFromVfs.gaps,
+  };
+}
+
+function allowsDurableEvidence(target: InvestigatorTarget): boolean {
+  if (typeof target.allowDurableEvidence === 'boolean') {
+    return target.allowDurableEvidence;
+  }
+
+  const bounds = target.bounds;
+  if (isRecord(bounds) && typeof bounds.allowDurableEvidence === 'boolean') {
+    return bounds.allowDurableEvidence;
+  }
+
+  return true;
+}
+
+function metadataString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function metadataNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function evidenceId(finding: SpecialistFinding, index: number): string {
+  const fromMetadata = metadataString(finding.metadata?.id);
+  if (fromMetadata) {
+    return fromMetadata;
+  }
+
+  const normalized = finding.title
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || `evidence-${index + 1}`;
+}
+
+function durableRefSummary(ref: DurableEvidenceRef): string {
+  const details = [
+    `path=${ref.path}`,
+    ref.revision ? `revision=${ref.revision}` : '',
+    ref.workspaceId ? `workspaceId=${ref.workspaceId}` : '',
+  ].filter(Boolean);
+
+  return details.join(' ');
+}
+
+async function applyDurableEvidence<TEntity>(
+  findings: SpecialistFinding[],
+  adapter: InvestigatorAdapter<TEntity>,
+  deps: InvestigatorDeps,
+  target: InvestigatorTarget,
+  context?: SpecialistContext,
+): Promise<{ findings: SpecialistFinding[]; durableEvidenceCount: number }> {
+  const evidenceWriter = deps.evidenceWriter ?? null;
+  const threshold = adapter.durableEvidenceThresholdBytes ?? DEFAULT_DURABLE_EVIDENCE_THRESHOLD_BYTES;
+  const requestId = readRequestId(target, adapter, context);
+  let durableEvidenceCount = 0;
+
+  if (!evidenceWriter) {
+    return { findings, durableEvidenceCount };
+  }
+
+  if (!allowsDurableEvidence(target)) {
+    await evidenceWriter.finalize?.();
+    return { findings, durableEvidenceCount };
+  }
+
+  const rewritten: SpecialistFinding[] = [];
+  for (const [index, finding] of findings.entries()) {
+    const body = finding.body ?? '';
+    if (byteLength(body) <= threshold) {
+      rewritten.push(finding);
+      continue;
+    }
+
+    const confidence = metadataNumber(finding.metadata?.confidence);
+    const writeInput: EvidenceWriteInput = {
+      requestId,
+      evidenceId: evidenceId(finding, index),
+      kind: metadataString(finding.metadata?.kind) ?? 'investigation_evidence',
+      title: finding.title,
+      content: body,
+      contentType: 'text/markdown',
+    };
+    if (confidence !== undefined) {
+      writeInput.confidence = confidence;
+    }
+
+    const durableRef = await evidenceWriter.writeEvidence(writeInput);
+    durableEvidenceCount += 1;
+
+    rewritten.push({
+      ...finding,
+      body: `Evidence exceeded ${threshold} bytes and was persisted as durable evidence.\n${durableRefSummary(
+        durableRef,
+      )}`,
+      metadata: {
+        ...(finding.metadata ?? {}),
+        durableRef,
+      },
+    });
+  }
+
+  await evidenceWriter.finalize?.();
+
+  return { findings: rewritten, durableEvidenceCount };
+}
+
+function createFindings<TEntity>(input: {
+  adapter: InvestigatorAdapter<TEntity>;
+  target: InvestigatorTarget;
+  context: SpecialistContext | undefined;
+  status: DelegationStatus;
+  summary: string;
+  findings: SpecialistFinding[];
+  confidence?: number;
+  metadata: Record<string, unknown>;
+}): InvestigatorFindings {
+  return {
+    requestId: readRequestId(input.target, input.adapter, input.context),
+    capability: input.adapter.capability,
+    status: input.status,
+    summary: input.summary,
+    findings: input.findings,
+    ...(input.confidence === undefined ? {} : { confidence: input.confidence }),
+    metadata: {
+      specialistName: input.adapter.specialistName,
+      specialistVersion: input.adapter.specialistVersion,
+      ...input.metadata,
+    },
+  };
+}
+
+function failedFindings<TEntity>(input: {
+  adapter: InvestigatorAdapter<TEntity>;
+  target: InvestigatorTarget;
+  context: SpecialistContext | undefined;
+  summary: string;
+  gaps: InvestigatorGap[];
+  confidence: number;
+  metadata: Record<string, unknown>;
+}): InvestigatorFindings {
+  return createFindings({
+    adapter: input.adapter,
+    target: input.target,
+    context: input.context,
+    status: 'failed',
+    summary: input.summary,
+    findings: [],
+    confidence: input.confidence,
+    metadata: {
+      gaps: input.gaps,
+      ...input.metadata,
+    },
+  });
+}
+
+function defaultSummary(
+  target: InvestigatorTarget,
+  findings: SpecialistFinding[],
+  source: InvestigatorEvidenceSource,
+  deps: InvestigatorDeps,
+): string {
+  const label = deps.describeTarget?.(target) ?? readString(target.query) ?? readString(target.instruction) ?? 'Target';
+  return `${label} produced ${findings.length} finding(s) from ${source.provider}.`;
+}
+
+async function investigate<TEntity>(
+  adapter: InvestigatorAdapter<TEntity>,
+  deps: InvestigatorDeps,
+  target: InvestigatorTarget,
+  context?: SpecialistContext,
+): Promise<InvestigatorFindings> {
+  const startedAt = deps.now?.() ?? Date.now();
+  const producedAt = new Date(startedAt).toISOString();
+
+  try {
+    const loaded = await loadEntity(adapter, deps, target, producedAt);
+    if (!loaded.entity || !loaded.source) {
+      return failedFindings({
+        adapter,
+        target,
+        context,
+        summary: `Unable to investigate ${deps.describeTarget?.(target) ?? 'target'}.`,
+        gaps: loaded.gaps.length > 0 ? loaded.gaps : [failureGap(target, deps)],
+        confidence: 0.2,
+        metadata: {
+          durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+          actionCount: loaded.actionCount,
+          durableEvidenceCount: 0,
+          producedAt,
+        },
+      });
+    }
+
+    const findings = adapter.toEvidence(loaded.entity, target);
+    if (findings.length === 0) {
+      return failedFindings({
+        adapter,
+        target,
+        context,
+        summary: `Unable to investigate ${deps.describeTarget?.(target) ?? 'target'} because no evidence was produced.`,
+        gaps: [
+          {
+            description: 'Adapter returned no evidence findings.',
+            reason: 'unknown',
+          },
+        ],
+        confidence: 0.1,
+        metadata: {
+          durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+          actionCount: loaded.actionCount,
+          durableEvidenceCount: 0,
+          producedAt,
+        },
+      });
+    }
+
+    const durable = await applyDurableEvidence(findings, adapter, deps, target, context);
+    const confidence =
+      deps.confidence?.({ target, findings: durable.findings, source: loaded.source }) ??
+      Math.min(0.9, 0.6 + durable.findings.length * 0.08);
+    const summary =
+      deps.summarize?.({ target, findings: durable.findings, source: loaded.source }) ??
+      defaultSummary(target, durable.findings, loaded.source, deps);
+
+    return createFindings({
+      adapter,
+      target,
+      context,
+      status: 'complete',
+      summary,
+      findings: durable.findings,
+      confidence,
+      metadata: {
+        gaps: loaded.gaps,
+        source: loaded.source,
+        durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+        actionCount: loaded.actionCount,
+        durableEvidenceCount: durable.durableEvidenceCount,
+        producedAt,
+      },
+    });
+  } catch (error) {
+    return failedFindings({
+      adapter,
+      target,
+      context,
+      summary: `Unable to investigate ${deps.describeTarget?.(target) ?? 'target'}.`,
+      gaps: [
+        {
+          description: errorMessage(error),
+          reason: 'unknown',
+        },
+      ],
+      confidence: 0.1,
+      metadata: {
+        durationMs: (deps.now?.() ?? Date.now()) - startedAt,
+        actionCount: 1,
+        durableEvidenceCount: 0,
+        producedAt,
+      },
+    });
+  }
+}
+
+function toSpecialistResult<TEntity>(
+  adapter: InvestigatorAdapter<TEntity>,
+  findings: InvestigatorFindings,
+): SpecialistResult {
+  return {
+    specialistName: adapter.specialistName,
+    output: JSON.stringify(findings, null, 2),
+    status: findings.status as SpecialistExecutionStatus,
+    ...(findings.confidence === undefined ? {} : { confidence: findings.confidence }),
+    metadata: {
+      requestId: findings.requestId,
+      capability: findings.capability,
+      findings,
+    },
+  };
+}
+
+export function createInvestigator<TEntity>(
+  adapter: InvestigatorAdapter<TEntity>,
+  deps: InvestigatorDeps,
+): Specialist {
+  return {
+    name: adapter.specialistName,
+    description: `Investigates a single target using VFS evidence with an optional API fallback.`,
+    capabilities: [adapter.capability],
+    handler: {
+      async execute(instruction, context) {
+        const target = parseTarget(instruction, context, adapter, deps);
+        if (!target) {
+          const failed = failedFindings({
+            adapter,
+            target: {
+              requestId: requestIdFromContext(adapter, context),
+              instruction,
+            },
+            context,
+            summary: 'Unable to investigate target because the instruction could not be parsed.',
+            gaps: [
+              {
+                description: 'Expected instruction text or JSON that can be converted to an investigation target.',
+                reason: 'invalid_request',
+              },
+            ],
+            confidence: 0.05,
+            metadata: {
+              actionCount: 0,
+              durableEvidenceCount: 0,
+              producedAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+            },
+          });
+          return toSpecialistResult(adapter, failed);
+        }
+
+        return toSpecialistResult(adapter, await investigate(adapter, deps, target, context));
+      },
+    },
+  };
+}

--- a/packages/specialists/src/shared/librarian-engine.ts
+++ b/packages/specialists/src/shared/librarian-engine.ts
@@ -21,6 +21,13 @@ export interface LibrarianAdapter<TType extends string = string> {
   inferEntityType(entry: VfsEntry): TType | 'unknown';
   toEvidence(entry: VfsEntry, type: TType | 'unknown'): LibrarianEvidence;
   searchProvider?: string;
+  /**
+   * Provider-aware search term for a given entity type. Used when list-based
+   * enumeration comes back empty and the engine falls back to vfs.search.
+   * Defaults to String(type) if unspecified; adapters should override when the
+   * underlying index prefers a richer term (e.g. GitHub → "pull request" for "pr").
+   */
+  searchTerm?(type: TType): string;
 }
 
 export interface LibrarianVfs {
@@ -208,7 +215,8 @@ async function listEnumerationEntries<TType extends string>(
   }
 
   try {
-    const results = await vfs.search(types.join(' '), searchOptions(adapter, options.limit));
+    const query = types.map((type) => (adapter.searchTerm ? adapter.searchTerm(type) : String(type))).join(' ');
+    const results = await vfs.search(query, searchOptions(adapter, options.limit));
     return results.flatMap((entry) => toEnumerationEntry(adapter, entry, types));
   } catch (error) {
     errors.push(errorMessage(error));

--- a/packages/specialists/src/shared/librarian-engine.ts
+++ b/packages/specialists/src/shared/librarian-engine.ts
@@ -1,0 +1,441 @@
+import type { VfsEntry } from '@agent-assistant/vfs';
+
+import { parseQuery } from './query-syntax.js';
+
+export type LibrarianStatus = 'complete' | 'partial' | 'failed';
+export type LibrarianSource = 'vfs' | 'apiFallback' | 'mixed';
+
+export interface LibrarianEvidence {
+  id: string;
+  kind: string;
+  content: unknown;
+}
+
+export interface LibrarianAdapter<TType extends string = string> {
+  capability: string;
+  entityTypes: readonly TType[];
+  listRoots(types: readonly TType[], filters: Record<string, string[]>): string[];
+  inferFilters(text: string, filters: Record<string, string[]>): Record<string, string[]>;
+  filterKeys: readonly string[];
+  valuesForFilter(entry: VfsEntry, key: string): string[];
+  inferEntityType(entry: VfsEntry): TType | 'unknown';
+  toEvidence(entry: VfsEntry, type: TType | 'unknown'): LibrarianEvidence;
+  searchProvider?: string;
+}
+
+export interface LibrarianVfs {
+  list?(path: string, options?: { depth?: number; limit?: number }): Promise<readonly VfsEntry[]>;
+  search?(query: string, options?: { provider?: string; limit?: number }): Promise<readonly VfsEntry[]>;
+}
+
+export interface LibrarianFallbackRequest<TType extends string = string> {
+  instruction: string;
+  text: string;
+  filters: Record<string, string[]>;
+  types: TType[];
+}
+
+export type LibrarianApiFallback<TType extends string = string> =
+  | ((request: LibrarianFallbackRequest<TType>) => Promise<readonly VfsEntry[]>)
+  | {
+      list?(request: LibrarianFallbackRequest<TType>): Promise<readonly VfsEntry[]>;
+      search?(request: LibrarianFallbackRequest<TType>): Promise<readonly VfsEntry[]>;
+    };
+
+export interface LibrarianOptions<TType extends string = string> {
+  vfs: LibrarianVfs;
+  apiFallback?: LibrarianApiFallback<TType>;
+  name?: string;
+  description?: string;
+  limit?: number;
+  listDepth?: number;
+  summaryLimit?: number;
+}
+
+export interface GenericLibrarianMetadata {
+  text: string;
+  filters: Record<string, string[]>;
+  resultCount: number;
+  source: LibrarianSource;
+  errors?: string[];
+}
+
+export interface GenericLibrarianFindings {
+  capability: string;
+  status: LibrarianStatus;
+  summary: string;
+  evidence: LibrarianEvidence[];
+  metadata: GenericLibrarianMetadata;
+}
+
+export interface GenericLibrarianSpecialist<TType extends string = string> {
+  name: string;
+  description: string;
+  capabilities: string[];
+  handler: {
+    execute(instruction: string, context?: unknown): Promise<GenericLibrarianFindings>;
+  };
+}
+
+interface EnumerationEntry<TType extends string> {
+  entry: VfsEntry;
+  enumerationType: TType | 'unknown';
+}
+
+const DEFAULT_LIMIT = 1_000;
+const DEFAULT_LIST_DEPTH = 5;
+const SUMMARY_LIMIT = 10;
+
+export function createLibrarian<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  options: LibrarianOptions<TType>,
+): GenericLibrarianSpecialist<TType> {
+  const limit = options.limit ?? DEFAULT_LIMIT;
+  const listDepth = options.listDepth ?? DEFAULT_LIST_DEPTH;
+  const summaryLimit = options.summaryLimit ?? SUMMARY_LIMIT;
+
+  return {
+    name: options.name ?? defaultSpecialistName(adapter.capability),
+    description:
+      options.description ?? `Enumerates ${adapter.capability} entities from VFS-backed metadata.`,
+    capabilities: [adapter.capability],
+    handler: {
+      async execute(instruction: string): Promise<GenericLibrarianFindings> {
+        const parsed = parseQuery(instruction);
+        const filters = cloneFilters(adapter.inferFilters(parsed.text, cloneFilters(parsed.filters)));
+        const types = requestedTypes(adapter, filters);
+        const errors: string[] = [];
+        let source: LibrarianSource = 'vfs';
+        let entries: EnumerationEntry<TType>[] = [];
+
+        try {
+          if (types.length > 0) {
+            entries = await listEnumerationEntries(adapter, options.vfs, types, filters, errors, {
+              limit,
+              listDepth,
+            });
+          } else if (hasNoFilters(filters)) {
+            entries = await searchEntries(adapter, options.vfs, parsed.text, errors, limit);
+          } else {
+            entries = await listEnumerationEntries(adapter, options.vfs, adapter.entityTypes, filters, errors, {
+              limit,
+              listDepth,
+            });
+          }
+        } catch (error) {
+          errors.push(errorMessage(error));
+        }
+
+        if (entries.length === 0 && options.apiFallback) {
+          try {
+            const fallbackEntries = await loadFallbackEntries(options.apiFallback, {
+              instruction,
+              text: parsed.text,
+              filters,
+              types,
+            });
+            if (fallbackEntries.length > 0) {
+              source = errors.length > 0 ? 'mixed' : 'apiFallback';
+              entries = fallbackEntries.map((entry) => ({
+                entry,
+                enumerationType: adapter.inferEntityType(entry),
+              }));
+            }
+          } catch (error) {
+            errors.push(errorMessage(error));
+          }
+        }
+
+        const matchedEntries = dedupeEntries(entries)
+          .filter(({ entry }) => matchesRequestedFilters(adapter, entry, filters))
+          .sort(compareEntries);
+        const evidence = matchedEntries.map(({ entry, enumerationType }) =>
+          adapter.toEvidence(entry, enumerationType),
+        );
+        const status = statusFor(evidence.length, errors.length);
+
+        return {
+          capability: adapter.capability,
+          status,
+          summary: summarizeMatches(adapter.capability, evidence, summaryLimit),
+          evidence,
+          metadata: metadataFor(parsed.text, filters, evidence.length, source, errors),
+        };
+      },
+    },
+  };
+}
+
+function requestedTypes<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  filters: Record<string, string[]>,
+): TType[] {
+  const requested = new Set(filters.type ?? []);
+  if (requested.size === 0) {
+    return [];
+  }
+
+  return adapter.entityTypes.filter((type) => requested.has(type));
+}
+
+function hasNoFilters(filters: Record<string, string[]>): boolean {
+  return Object.values(filters).every((values) => values.length === 0) || Object.keys(filters).length === 0;
+}
+
+async function listEnumerationEntries<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  vfs: LibrarianVfs,
+  types: readonly TType[],
+  filters: Record<string, string[]>,
+  errors: string[],
+  options: { limit: number; listDepth: number },
+): Promise<EnumerationEntry<TType>[]> {
+  const listedEntries: EnumerationEntry<TType>[] = [];
+
+  if (vfs.list) {
+    for (const root of adapter.listRoots(types, filters)) {
+      try {
+        const entries = await vfs.list(root, { depth: options.listDepth, limit: options.limit });
+        listedEntries.push(...entries.flatMap((entry) => toEnumerationEntry(adapter, entry, types)));
+      } catch (error) {
+        errors.push(errorMessage(error));
+      }
+    }
+  }
+
+  if (listedEntries.length > 0 || !vfs.search) {
+    return listedEntries;
+  }
+
+  try {
+    const results = await vfs.search(types.join(' '), searchOptions(adapter, options.limit));
+    return results.flatMap((entry) => toEnumerationEntry(adapter, entry, types));
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return [];
+  }
+}
+
+async function searchEntries<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  vfs: LibrarianVfs,
+  text: string,
+  errors: string[],
+  limit: number,
+): Promise<EnumerationEntry<TType>[]> {
+  if (!vfs.search) {
+    errors.push('VFS search is unavailable.');
+    return [];
+  }
+
+  try {
+    const results = await vfs.search(text.trim(), searchOptions(adapter, limit));
+    return results.map((entry) => ({
+      entry,
+      enumerationType: adapter.inferEntityType(entry),
+    }));
+  } catch (error) {
+    errors.push(errorMessage(error));
+    return [];
+  }
+}
+
+async function loadFallbackEntries<TType extends string>(
+  apiFallback: LibrarianApiFallback<TType>,
+  request: LibrarianFallbackRequest<TType>,
+): Promise<readonly VfsEntry[]> {
+  if (typeof apiFallback === 'function') {
+    return apiFallback(request);
+  }
+
+  if (request.types.length > 0 && apiFallback.list) {
+    return apiFallback.list(request);
+  }
+
+  if (apiFallback.search) {
+    return apiFallback.search(request);
+  }
+
+  if (apiFallback.list) {
+    return apiFallback.list(request);
+  }
+
+  return [];
+}
+
+function toEnumerationEntry<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  entry: VfsEntry,
+  requested: readonly TType[],
+): EnumerationEntry<TType>[] {
+  const inferredType = adapter.inferEntityType(entry);
+  if (inferredType === 'unknown') {
+    return [];
+  }
+  if (!requested.includes(inferredType)) {
+    return [];
+  }
+
+  return [{ entry, enumerationType: inferredType }];
+}
+
+function matchesRequestedFilters<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  entry: VfsEntry,
+  filters: Record<string, string[]>,
+): boolean {
+  return adapter.filterKeys.every((key) => filterMatches(adapter, entry, filters, key));
+}
+
+function filterMatches<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  entry: VfsEntry,
+  filters: Record<string, string[]>,
+  key: string,
+): boolean {
+  const requested = filters[key];
+  if (!requested || requested.length === 0) {
+    return true;
+  }
+
+  const actual = adapter.valuesForFilter(entry, key).map((value) => normalizeComparable(value));
+  return requested.some((value) => actual.includes(normalizeComparable(value)));
+}
+
+function metadataFor(
+  text: string,
+  filters: Record<string, string[]>,
+  resultCount: number,
+  source: LibrarianSource,
+  errors: string[],
+): GenericLibrarianMetadata {
+  const metadata: GenericLibrarianMetadata = {
+    text,
+    filters,
+    resultCount,
+    source,
+  };
+
+  if (errors.length > 0) {
+    metadata.errors = errors;
+  }
+
+  return metadata;
+}
+
+function statusFor(resultCount: number, errorCount: number): LibrarianStatus {
+  if (resultCount > 0 && errorCount === 0) {
+    return 'complete';
+  }
+
+  return resultCount > 0 ? 'partial' : 'failed';
+}
+
+function dedupeEntries<TType extends string>(entries: EnumerationEntry<TType>[]): EnumerationEntry<TType>[] {
+  const seen = new Set<string>();
+  const deduped: EnumerationEntry<TType>[] = [];
+
+  for (const item of entries) {
+    const key = item.entry.path;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+}
+
+function compareEntries<TType extends string>(
+  left: EnumerationEntry<TType>,
+  right: EnumerationEntry<TType>,
+): number {
+  const leftUpdated = left.entry.updatedAt ?? '';
+  const rightUpdated = right.entry.updatedAt ?? '';
+  const updatedComparison = rightUpdated.localeCompare(leftUpdated);
+  if (updatedComparison !== 0) {
+    return updatedComparison;
+  }
+
+  return left.entry.path.localeCompare(right.entry.path);
+}
+
+function summarizeMatches(capability: string, evidence: LibrarianEvidence[], summaryLimit: number): string {
+  if (evidence.length === 0) {
+    return `No ${capability} enumeration matches found.`;
+  }
+
+  const lines = [`Found ${evidence.length} ${capability} enumeration match${evidence.length === 1 ? '' : 'es'}.`];
+  for (const [index, item] of evidence.slice(0, summaryLimit).entries()) {
+    lines.push(`${index + 1}. ${evidenceLabel(item)}`);
+  }
+
+  if (evidence.length > summaryLimit) {
+    lines.push(`...and ${evidence.length - summaryLimit} more.`);
+  }
+
+  return lines.join('\n');
+}
+
+function evidenceLabel(evidence: LibrarianEvidence): string {
+  if (!isRecord(evidence.content)) {
+    return evidence.id;
+  }
+
+  const title =
+    firstString(evidence.content.title, evidence.content.name, evidence.content.path, evidence.content.url) ??
+    evidence.id;
+  const scope = firstString(evidence.content.repo, evidence.content.repository, evidence.content.project);
+  const state = firstString(evidence.content.state, evidence.content.status);
+  const prefix = scope ? `${scope} - ${title}` : title;
+
+  return state ? `${prefix} [${state}]` : prefix;
+}
+
+function searchOptions<TType extends string>(
+  adapter: LibrarianAdapter<TType>,
+  limit: number,
+): { provider?: string; limit?: number } {
+  const options: { provider?: string; limit?: number } = { limit };
+  if (adapter.searchProvider) {
+    options.provider = adapter.searchProvider;
+  }
+
+  return options;
+}
+
+function cloneFilters(filters: Record<string, string[]>): Record<string, string[]> {
+  return Object.fromEntries(Object.entries(filters).map(([key, values]) => [key, [...values]]));
+}
+
+function normalizeComparable(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function defaultSpecialistName(capability: string): string {
+  const prefix = capability.split('.')[0] ?? capability;
+  return `${slugify(prefix)}-librarian`;
+}
+
+function slugify(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return normalized || 'generic';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === 'string' && value.length > 0);
+}


### PR DESCRIPTION
## Summary
- Registers `packages/specialists` in the root `workspaces` array — unblocks the publish pipeline that runs `npm test --workspace=@agent-assistant/specialists` (was failing on main with `No workspaces found`).
- Brings in the engine refactor + Linear librarian + review fixes that were stranded when PR #12 merged into the (now-deleted) `feat/specialists-package` branch instead of `main`.

## What's included (rescued from stranded PR #12)
- `src/shared/librarian-engine.ts` — generic `createLibrarian(adapter)` engine; per-integration specialists become ~150-line adapter configs.
- `src/shared/investigator-engine.ts` — generic `createInvestigator(adapter)` engine.
- `src/github/librarian.ts` + `src/github/investigator.ts` — refactored as adapter configs using the engines.
- `src/linear/*` — Linear librarian as proof-of-adapter (uses `@relayfile/adapter-linear/path-mapper`, ships with 3 tests).
- `LIBRARIAN_ADAPTERS.md` — fill-in-the-blanks guide for the next integration (notion/hubspot/slack).
- `publishConfig.access=public` + `repository.url` on `@agent-assistant/specialists` (matches sibling packages; works with `npm publish --provenance --access public`).
- Two P1 review fixes from Codex on PR #12:
  - `LibrarianAdapter.searchTerm(type)` so the `vfs.search` fallback uses provider-appropriate terms (GitHub maps `pr` → `pull request`) instead of the weak `types.join(' ')` default.
  - Investigator adapter's `parse(raw)` now returns `null` for unparseable/empty payloads so the engine triggers `apiFallback` instead of emitting placeholder findings from corrupt metadata.

## Test plan
- [x] `npm test --workspace=@agent-assistant/specialists` → 15/15 green locally (query-syntax, vfs-adapter, github investigator, github librarian, linear librarian)
- [x] `npm run build --workspace=@agent-assistant/specialists` → clean tsc
- [ ] CI publish pipeline resolves the workspace and runs tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
