### PR TITLE
fix(publish): include specialists in dependency-aware build ORDER

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs)
+          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs specialists)
           for pkg in "${ORDER[@]}"; do
             if echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -e --arg pkg "$pkg" '.[] | select(. == $pkg)' >/dev/null; then
               echo "==> Building $pkg"


### PR DESCRIPTION
## Summary
The publish pipeline fails with `cp: cannot stat 'packages/specialists/dist': No such file or directory` because the dependency-aware build step at `.github/workflows/publish.yml:161` iterates a hardcoded `ORDER` array that never got updated when `specialists` was added to the publish matrix.

```diff
- ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs)
+ ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs specialists)
```

The loop only builds packages that appear in both `ORDER` *and* the resolved matrix, so `specialists/dist` never got created — and the later "Upload build artifacts" step tried to copy it and died.

## Why `vfs` position
`specialists` type-imports from `@agent-assistant/vfs` and `@agent-assistant/coordination`. `vfs` is already earlier in `ORDER`; `coordination` is built in the "Prepare harness test dependencies" step, so both dists exist by the time `specialists` builds.

## Test plan
- [ ] Re-run the publish workflow with `dry_run=true` and confirm the build step completes for `specialists`
- [ ] Confirm subsequent "Upload build artifacts" step no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
