### PR TITLE
fix(publish): add connectivity + coordination to runtime-core matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           case "${{ github.event.inputs.package_group }}" in
             runtime-core)
-              PACKAGES='["traits","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk","vfs","specialists"]'
+              PACKAGES='["traits","connectivity","coordination","core","sessions","surfaces","policy","proactive","harness","memory","turn-context","inbox","continuation","sdk","vfs","specialists"]'
               FIRST='traits'
               ;;
             *)
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ORDER=(traits core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs specialists)
+          ORDER=(traits connectivity coordination core sessions surfaces policy proactive harness memory turn-context inbox continuation sdk vfs specialists)
           for pkg in "${ORDER[@]}"; do
             if echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -e --arg pkg "$pkg" '.[] | select(. == $pkg)' >/dev/null; then
               echo "==> Building $pkg"


### PR DESCRIPTION
## Summary
`@agent-assistant/coordination@0.1.0` and `@agent-assistant/harness` currently ship broken dependency specs on npm:

\`\`\`bash
$ npm view @agent-assistant/coordination dependencies
{ '@agent-assistant/connectivity': 'file:../connectivity', nanoid: '^5.1.6' }

$ npm view @agent-assistant/harness dependencies
{
  '@agent-assistant/connectivity': 'file:../connectivity',
  '@agent-assistant/coordination': 'file:../coordination',
  ...
}
\`\`\`

The `file:../connectivity` / `file:../coordination` specs are monorepo-only — consumers can't resolve them. Concretely this breaks `npm ci` for any downstream consumer that pulls these packages (Sage PR #49 hit it through `@agent-assistant/specialists` → `@agent-assistant/coordination`):

\`\`\`
npm error Missing: @agent-assistant/connectivity@ from lock file
\`\`\`

## Root cause
The publish workflow has a **rewrite step** (`.github/workflows/publish.yml:241`) that converts `file:` workspace deps to `^<version>` on publish — but only for packages present in the `packageNames` set (the current matrix). `connectivity` and `coordination` were never in the matrix, so when `harness` and `coordination` were published, their `file:` deps were left intact.

## Fix
Add `connectivity` and `coordination` to:

1. `PACKAGES` at `publish.yml:84` (the runtime-core matrix)
2. `ORDER` at `publish.yml:161` — positioned right after `traits`, before any package that depends on them (`harness`, `specialists`)

Next publish will:
- publish `@agent-assistant/connectivity` (no local deps)
- publish `@agent-assistant/coordination` with its `file:../connectivity` rewritten to `^<new-version>`
- republish `@agent-assistant/harness` with both file: deps rewritten

## Test plan
- [ ] Dry-run the publish workflow; verify the build step builds `connectivity` + `coordination` and the rewrite step updates coordination's + harness's deps
- [ ] After the next real publish, verify `npm view @agent-assistant/coordination dependencies` shows `^<version>` (not `file:`)
- [ ] Verify Sage PR #49's CI goes green without the `overrides` workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
