### PR TITLE
feat(harness): OpenRouter model adapter + Bash tool registry

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/adapter/openrouter-model-adapter.test.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OpenRouterModelAdapter } from './openrouter-model-adapter.js';
+import type { HarnessModelInput, HarnessToolDefinition } from '../types.js';
+
+function makeInput(overrides: Partial<HarnessModelInput> = {}): HarnessModelInput {
+  return {
+    assistantId: 'a1',
+    turnId: 't1',
+    message: { id: 'm1', text: 'Hello', receivedAt: '2024-01-01T00:00:00Z' },
+    instructions: { systemPrompt: 'You are helpful.' },
+    transcript: [],
+    availableTools: [],
+    iteration: 0,
+    toolCallCount: 0,
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
+function makeOkResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+describe('OpenRouterModelAdapter', () => {
+  it('case 1: returns final_answer when response has no tool_calls', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'Hi there!', tool_calls: undefined } }],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('final_answer');
+    if (result.type === 'final_answer') {
+      expect(result.text).toBe('Hi there!');
+    }
+  });
+
+  it('case 2: returns tool_request with id, name, parsed input when response has tool_calls', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_abc',
+                  type: 'function',
+                  function: { name: 'search', arguments: '{"query":"test"}' },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('tool_request');
+    if (result.type === 'tool_request') {
+      expect(result.calls).toHaveLength(1);
+      expect(result.calls[0].id).toBe('call_abc');
+      expect(result.calls[0].name).toBe('search');
+      expect(result.calls[0].input).toEqual({ query: 'test' });
+    }
+  });
+
+  it('case 3: forwards availableTools as OpenAI tool descriptors in request body', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'done' } }],
+      }),
+    );
+    const tools: HarnessToolDefinition[] = [
+      {
+        name: 'get_weather',
+        description: 'Get current weather',
+        inputSchema: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    ];
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    await adapter.nextStep(makeInput({ availableTools: tools }));
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+
+    expect(body.tools).toHaveLength(1);
+    expect(body.tools[0]).toMatchObject({
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        description: 'Get current weather',
+        parameters: { type: 'object', properties: { city: { type: 'string' } } },
+      },
+    });
+    expect(body.tool_choice).toBe('auto');
+  });
+
+  it('case 4: maps system + developerPrompt + transcript to messages array correctly', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    await adapter.nextStep(
+      makeInput({
+        instructions: {
+          systemPrompt: 'You are a bot.',
+          developerPrompt: 'Be concise.',
+        },
+        transcript: [
+          { type: 'assistant_step', iteration: 0, outputType: 'final_answer', text: 'Hello!' },
+        ],
+        message: { id: 'm1', text: 'Follow-up question', receivedAt: '2024-01-01T00:00:00Z' },
+      }),
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    const messages: Array<{ role: string; content: string }> = body.messages;
+
+    expect(messages[0]).toMatchObject({ role: 'system', content: 'You are a bot.' });
+    expect(messages[1]).toMatchObject({ role: 'system', content: 'Be concise.' });
+    expect(messages[2]).toMatchObject({ role: 'assistant', content: 'Hello!' });
+    expect(messages[messages.length - 1]).toMatchObject({
+      role: 'user',
+      content: 'Follow-up question',
+    });
+  });
+
+  it('case 5: HTTP error returns { type:"invalid", reason } with API error message', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse(
+        { error: { message: 'Invalid model specified', code: 'invalid_model' } },
+        400,
+      ),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('invalid');
+    if (result.type === 'invalid') {
+      expect(result.reason).toBe('Invalid model specified');
+    }
+  });
+
+  it('case 6: timeout via never-resolving fetchImpl returns { type:"invalid", reason:"timeout" }', async () => {
+    const fetchImpl = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    const adapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl,
+      timeoutMs: 50,
+    });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('invalid');
+    if (result.type === 'invalid') {
+      expect(result.reason).toBe('timeout');
+    }
+  }, 3000);
+
+  it('case 7: maps usage from body.usage (prompt_tokens, completion_tokens, total_tokens)', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'done' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('final_answer');
+    if (result.type === 'final_answer') {
+      expect(result.usage).toBeDefined();
+      expect(result.usage?.inputTokens).toBe(10);
+      expect(result.usage?.outputTokens).toBe(20);
+    }
+  });
+
+  it('case 8: missing apiKey returns { type:"invalid", reason includes "API key" }', async () => {
+    const fetchImpl = vi.fn();
+    const adapter = new OpenRouterModelAdapter({ fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('invalid');
+    if (result.type === 'invalid') {
+      expect(result.reason.toLowerCase()).toContain('api key');
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('case 9: malformed tool_call arguments returns { type:"invalid", reason includes "JSON" }', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [
+          {
+            message: {
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_bad',
+                  type: 'function',
+                  function: { name: 'broken_tool', arguments: 'NOT_VALID_JSON' },
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('invalid');
+    if (result.type === 'invalid') {
+      expect(result.reason.toUpperCase()).toContain('JSON');
+    }
+  });
+});

--- a/packages/harness/src/adapter/openrouter-model-adapter.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.ts
@@ -1,0 +1,275 @@
+import type {
+  HarnessModelAdapter,
+  HarnessModelInput,
+  HarnessModelOutput,
+  HarnessToolCall,
+  HarnessToolDefinition,
+  HarnessTranscriptItem,
+  HarnessToolResultStep,
+  HarnessUsage,
+} from '../types.js';
+
+export interface OpenRouterModelAdapterConfig {
+  apiKey?: string;
+  model?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  defaultTemperature?: number;
+}
+
+const DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6';
+const DEFAULT_BASE_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: Array<{
+    id: string;
+    type: 'function';
+    function: { name: string; arguments: string };
+  }>;
+  tool_call_id?: string;
+}
+
+interface OpenRouterTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
+interface OpenRouterRequestBody {
+  model: string;
+  messages: ChatMessage[];
+  tools?: OpenRouterTool[];
+  tool_choice?: 'auto';
+  temperature?: number;
+}
+
+interface OpenRouterResponseToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+interface OpenRouterResponseBody {
+  id?: string;
+  choices?: Array<{
+    message?: {
+      content?: string | null;
+      tool_calls?: OpenRouterResponseToolCall[];
+    };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: { message?: string; code?: string | number };
+}
+
+function mapToolDefinition(tool: HarnessToolDefinition): OpenRouterTool {
+  return {
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      ...(tool.inputSchema ? { parameters: tool.inputSchema } : {}),
+    },
+  };
+}
+
+function buildTranscriptMessages(transcript: HarnessTranscriptItem[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  const items = Array.from(transcript);
+  let i = 0;
+
+  while (i < items.length) {
+    const item = items[i] as HarnessTranscriptItem;
+
+    if (item.type === 'assistant_step') {
+      if (item.outputType === 'tool_request') {
+        const toolResults: HarnessToolResultStep[] = [];
+        let j = i + 1;
+        while (j < items.length && (items[j] as HarnessTranscriptItem).type === 'tool_result') {
+          toolResults.push(items[j] as HarnessToolResultStep);
+          j++;
+        }
+
+        const toolCalls = toolResults.map((tr) => ({
+          id: tr.result.callId,
+          type: 'function' as const,
+          function: { name: tr.result.toolName, arguments: '{}' },
+        }));
+
+        messages.push({
+          role: 'assistant',
+          content: item.text ?? null,
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        });
+
+        for (const tr of toolResults) {
+          messages.push({
+            role: 'tool',
+            tool_call_id: tr.result.callId,
+            content: tr.result.output ?? tr.result.error?.message ?? '',
+          });
+        }
+
+        i = j;
+      } else {
+        messages.push({ role: 'assistant', content: item.text ?? '' });
+        i++;
+      }
+    } else if (item.type === 'tool_result') {
+      // Already consumed by lookahead above; skip standalone occurrences.
+      i++;
+    } else if (item.type === 'clarification_request') {
+      messages.push({ role: 'assistant', content: item.question });
+      i++;
+    } else if (item.type === 'approval_request') {
+      messages.push({
+        role: 'assistant',
+        content: `Approval requested: ${item.request.summary}`,
+      });
+      i++;
+    } else {
+      i++;
+    }
+  }
+
+  return messages;
+}
+
+function buildRequestBody(
+  input: HarnessModelInput,
+  model: string,
+  temperature?: number,
+): OpenRouterRequestBody {
+  const messages: ChatMessage[] = [
+    { role: 'system', content: input.instructions.systemPrompt },
+  ];
+
+  if (input.instructions.developerPrompt?.trim()) {
+    messages.push({ role: 'system', content: input.instructions.developerPrompt });
+  }
+
+  messages.push(...buildTranscriptMessages(input.transcript));
+  messages.push({ role: 'user', content: input.message.text });
+
+  const tools =
+    input.availableTools.length > 0
+      ? input.availableTools.map(mapToolDefinition)
+      : undefined;
+
+  return {
+    model,
+    messages,
+    ...(tools ? { tools, tool_choice: 'auto' } : {}),
+    ...(temperature !== undefined ? { temperature } : {}),
+  };
+}
+
+function mapUsage(raw: OpenRouterResponseBody['usage']): HarnessUsage | undefined {
+  if (!raw) return undefined;
+  const usage: HarnessUsage = {};
+  if (raw.prompt_tokens !== undefined) usage.inputTokens = raw.prompt_tokens;
+  if (raw.completion_tokens !== undefined) usage.outputTokens = raw.completion_tokens;
+  return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
+export class OpenRouterModelAdapter implements HarnessModelAdapter {
+  private readonly apiKey?: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+  private readonly defaultTemperature?: number;
+
+  constructor(config: OpenRouterModelAdapterConfig = {}) {
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? DEFAULT_MODEL;
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.defaultTemperature = config.defaultTemperature;
+  }
+
+  async nextStep(input: HarnessModelInput): Promise<HarnessModelOutput> {
+    if (!this.apiKey) {
+      return { type: 'invalid', reason: 'OpenRouter API key is not configured.' };
+    }
+
+    const abortController = new AbortController();
+    const timeout = setTimeout(() => abortController.abort(), this.timeoutMs);
+
+    let body: OpenRouterResponseBody | undefined;
+
+    try {
+      const requestBody = buildRequestBody(input, this.model, this.defaultTemperature);
+
+      const response = await this.fetchImpl(this.baseUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+        signal: abortController.signal,
+      });
+
+      body = (await response.json()) as OpenRouterResponseBody;
+
+      if (!response.ok) {
+        return {
+          type: 'invalid',
+          reason: body.error?.message ?? `HTTP ${response.status}`,
+          raw: body,
+        };
+      }
+
+      const usage = mapUsage(body.usage);
+      const message = body.choices?.[0]?.message;
+      const rawToolCalls = message?.tool_calls;
+
+      if (rawToolCalls && rawToolCalls.length > 0) {
+        const calls: HarnessToolCall[] = [];
+        for (const tc of rawToolCalls) {
+          let parsed: Record<string, unknown>;
+          try {
+            parsed = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+          } catch {
+            return { type: 'invalid', reason: 'tool_call arguments are not valid JSON', raw: body };
+          }
+          calls.push({ id: tc.id, name: tc.function.name, input: parsed });
+        }
+        return { type: 'tool_request', calls, ...(usage ? { usage } : {}) };
+      }
+
+      const text = message?.content ?? '';
+      return { type: 'final_answer', text, ...(usage ? { usage } : {}) };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return { type: 'invalid', reason: 'timeout' };
+      }
+      return {
+        type: 'invalid',
+        reason: error instanceof Error ? error.message : 'Unknown error',
+        raw: body,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function createOpenRouterModelAdapter(
+  config?: OpenRouterModelAdapterConfig,
+): HarnessModelAdapter {
+  return new OpenRouterModelAdapter(config);
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -2,6 +2,11 @@ export { createHarness } from './harness.js';
 export { HarnessConfigError } from './types.js';
 export * from './adapter/index.js';
 
+export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/openrouter-model-adapter.js';
+export type { OpenRouterModelAdapterConfig } from './adapter/openrouter-model-adapter.js';
+export { BashToolRegistry, createBashToolRegistry } from './tools/bash-tool-registry.js';
+export type { BashToolConfig } from './tools/bash-tool-registry.js';
+
 export type {
   HarnessAggregateUsage,
   HarnessApprovalAdapter,

--- a/packages/harness/src/tools/bash-tool-registry.test.ts
+++ b/packages/harness/src/tools/bash-tool-registry.test.ts
@@ -1,0 +1,204 @@
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { BashToolRegistry } from './bash-tool-registry.js';
+import type {
+  HarnessToolAvailabilityInput,
+  HarnessToolCall,
+  HarnessToolExecutionContext,
+} from '../types.js';
+
+class FakeStream extends EventEmitter {}
+
+class FakeChild extends EventEmitter {
+  stdout = new FakeStream();
+  stderr = new FakeStream();
+  kill = vi.fn<[string?], boolean>().mockReturnValue(true);
+}
+
+function buildRegistry(opts: {
+  allowedCommands?: string[];
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  onSpawn?: (child: FakeChild) => void;
+}) {
+  let lastChild: FakeChild | null = null;
+
+  const spawnImpl = vi.fn((_cmd: string, _opts: unknown) => {
+    const child = new FakeChild();
+    lastChild = child;
+    opts.onSpawn?.(child);
+    return child as unknown as ChildProcess;
+  });
+
+  const registry = new BashToolRegistry({
+    allowedCommands: opts.allowedCommands ?? ['echo', 'ls'],
+    timeoutMs: opts.timeoutMs,
+    maxOutputBytes: opts.maxOutputBytes,
+    spawnImpl: spawnImpl as unknown as typeof import('node:child_process').spawn,
+  });
+
+  return { registry, spawnImpl, getLastChild: () => lastChild };
+}
+
+const availabilityInput: HarnessToolAvailabilityInput = {
+  assistantId: 'a1',
+  turnId: 't1',
+};
+
+const execContext: HarnessToolExecutionContext = {
+  assistantId: 'a1',
+  turnId: 't1',
+  iteration: 0,
+  toolCallIndex: 0,
+};
+
+function bashCall(
+  input: Record<string, unknown> = { command: 'echo hello' },
+  name = 'bash',
+): HarnessToolCall {
+  return { id: 'c1', name, input };
+}
+
+describe('BashToolRegistry', () => {
+  it('listAvailable returns exactly one tool with correct schema', async () => {
+    const { registry } = buildRegistry({});
+    const tools = await registry.listAvailable(availabilityInput);
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe('bash');
+    expect(tools[0].inputSchema).toMatchObject({
+      type: 'object',
+      properties: { command: { type: 'string' } },
+      required: ['command'],
+    });
+  });
+
+  it('unknown tool name → unknown_tool error code', async () => {
+    const { registry } = buildRegistry({});
+    const result = await registry.execute(
+      bashCall({ command: 'echo hi' }, 'unknown_tool'),
+      execContext,
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.error?.code).toBe('unknown_tool');
+  });
+
+  it('non-string command → invalid_input error code', async () => {
+    const { registry } = buildRegistry({});
+    const result = await registry.execute(bashCall({ command: 42 }), execContext);
+
+    expect(result.status).toBe('error');
+    expect(result.error?.code).toBe('invalid_input');
+  });
+
+  it('command first-token not in allowlist → command_not_allowed with rejected token in message', async () => {
+    const { registry } = buildRegistry({ allowedCommands: ['echo'] });
+    const result = await registry.execute(bashCall({ command: 'rm -rf /' }), execContext);
+
+    expect(result.status).toBe('error');
+    expect(result.error?.code).toBe('command_not_allowed');
+    expect(result.error?.message).toContain('rm');
+  });
+
+  it('success path: stdout hello close 0 → success with hello in output', async () => {
+    const { registry } = buildRegistry({
+      onSpawn: (child) => {
+        queueMicrotask(() => {
+          child.stdout.emit('data', Buffer.from('hello\n'));
+          child.emit('close', 0);
+        });
+      },
+    });
+
+    const result = await registry.execute(bashCall({ command: 'echo hello' }), execContext);
+
+    expect(result.status).toBe('success');
+    expect(result.output).toContain('hello');
+  });
+
+  it('non-zero exit: stderr oops close 2 → nonzero_exit with 2 in message', async () => {
+    const { registry } = buildRegistry({
+      onSpawn: (child) => {
+        queueMicrotask(() => {
+          child.stderr.emit('data', Buffer.from('oops'));
+          child.emit('close', 2);
+        });
+      },
+    });
+
+    const result = await registry.execute(bashCall({ command: 'echo fail' }), execContext);
+
+    expect(result.status).toBe('error');
+    expect(result.error?.code).toBe('nonzero_exit');
+    expect(result.error?.message).toContain('2');
+  });
+
+  it('timeout: never close with timeoutMs 50 → timeout error and kill called with SIGKILL', async () => {
+    const { registry, getLastChild } = buildRegistry({
+      timeoutMs: 50,
+      onSpawn: () => {
+        // intentionally never emits close
+      },
+    });
+
+    const result = await registry.execute(bashCall({ command: 'echo hang' }), execContext);
+    const child = getLastChild()!;
+
+    expect(result.status).toBe('error');
+    expect(result.error?.code).toBe('timeout');
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('output truncation: large stdout > maxOutputBytes → output bounded with truncation marker', async () => {
+    const maxOutputBytes = 100;
+    const bigData = Buffer.alloc(200, 'x');
+
+    const { registry } = buildRegistry({
+      maxOutputBytes,
+      onSpawn: (child) => {
+        queueMicrotask(() => {
+          child.stdout.emit('data', bigData);
+          child.emit('close', 0);
+        });
+      },
+    });
+
+    const result = await registry.execute(bashCall({ command: 'echo big' }), execContext);
+
+    expect(result.status).toBe('success');
+    expect(result.output).toContain('[output truncated to');
+    // The raw captured portion must be at most maxOutputBytes characters
+    const rawPortion = result.output!.slice(0, maxOutputBytes);
+    expect(rawPortion.length).toBeLessThanOrEqual(maxOutputBytes);
+  });
+
+  it('allowlist names appear in tool description', async () => {
+    const allowedCommands = ['git', 'npm', 'node'];
+    const { registry } = buildRegistry({ allowedCommands });
+    const tools = await registry.listAvailable(availabilityInput);
+    const desc = tools[0].description;
+
+    for (const cmd of allowedCommands) {
+      expect(desc).toContain(cmd);
+    }
+  });
+
+  it('spawn error event → spawn_error error code', async () => {
+    const { registry } = buildRegistry({
+      onSpawn: (child) => {
+        queueMicrotask(() => {
+          child.emit('error', new Error('ENOENT spawn failed'));
+        });
+      },
+    });
+
+    const result = await registry.execute(bashCall({ command: 'echo test' }), execContext);
+
+    expect(result.status).toBe('error');
+    expect(result.error?.code).toBe('spawn_error');
+  });
+});

--- a/packages/harness/src/tools/bash-tool-registry.ts
+++ b/packages/harness/src/tools/bash-tool-registry.ts
@@ -1,0 +1,172 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import type {
+  HarnessToolRegistry,
+  HarnessToolAvailabilityInput,
+  HarnessToolDefinition,
+  HarnessToolCall,
+  HarnessToolExecutionContext,
+  HarnessToolResult,
+} from '../types.js';
+
+export interface BashToolConfig {
+  allowedCommands: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  spawnImpl?: typeof nodeSpawn;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 65_536;
+
+export class BashToolRegistry implements HarnessToolRegistry {
+  private readonly config: Required<Omit<BashToolConfig, 'cwd' | 'env'>> &
+    Pick<BashToolConfig, 'cwd' | 'env'>;
+
+  constructor(config: BashToolConfig) {
+    this.config = {
+      allowedCommands: config.allowedCommands,
+      cwd: config.cwd,
+      env: config.env,
+      timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxOutputBytes: config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+      spawnImpl: config.spawnImpl ?? nodeSpawn,
+    };
+  }
+
+  async listAvailable(_input: HarnessToolAvailabilityInput): Promise<HarnessToolDefinition[]> {
+    return [
+      {
+        name: 'bash',
+        description: `Execute a shell command. Only the following first-token commands are permitted: ${this.config.allowedCommands.join(', ')}. Provide the full command line as input.command.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            command: { type: 'string', description: 'Full command line to execute' },
+          },
+          required: ['command'],
+        },
+      },
+    ];
+  }
+
+  async execute(
+    call: HarnessToolCall,
+    _context: HarnessToolExecutionContext,
+  ): Promise<HarnessToolResult> {
+    const base = { callId: call.id, toolName: 'bash' };
+
+    if (call.name !== 'bash') {
+      return {
+        ...base,
+        status: 'error',
+        error: { code: 'unknown_tool', message: `Unknown tool: ${call.name}` },
+      };
+    }
+
+    const { command } = call.input;
+    if (typeof command !== 'string') {
+      return {
+        ...base,
+        status: 'error',
+        error: { code: 'invalid_input', message: 'input.command must be a string' },
+      };
+    }
+
+    const firstToken = command.trim().split(/\s+/)[0];
+    if (!firstToken || !this.config.allowedCommands.includes(firstToken)) {
+      return {
+        ...base,
+        status: 'error',
+        error: {
+          code: 'command_not_allowed',
+          message: `Command '${firstToken}' is not allowed. Permitted first-token commands: ${this.config.allowedCommands.join(', ')}`,
+        },
+      };
+    }
+
+    return new Promise<HarnessToolResult>((resolve) => {
+      const spawnFn = this.config.spawnImpl;
+      const mergedEnv = { ...process.env, ...(this.config.env ?? {}) };
+
+      const child = spawnFn(command, {
+        shell: true,
+        cwd: this.config.cwd,
+        env: mergedEnv,
+      });
+
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+      let truncated = false;
+      const maxBytes = this.config.maxOutputBytes;
+
+      const onData = (chunk: Buffer | string) => {
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        if (truncated) return;
+        const remaining = maxBytes - totalBytes;
+        if (buf.length <= remaining) {
+          chunks.push(buf);
+          totalBytes += buf.length;
+        } else {
+          chunks.push(buf.subarray(0, remaining));
+          totalBytes = maxBytes;
+          truncated = true;
+        }
+      };
+
+      child.stdout?.on('data', onData);
+      child.stderr?.on('data', onData);
+
+      const getOutput = (): string => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        return truncated ? `${raw}\n[output truncated to ${maxBytes} bytes]` : raw;
+      };
+
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL');
+        resolve({
+          ...base,
+          status: 'error',
+          error: {
+            code: 'timeout',
+            message: `Command timed out after ${this.config.timeoutMs}ms`,
+            retryable: true,
+          },
+        });
+      }, this.config.timeoutMs);
+
+      child.on('error', (err: Error) => {
+        clearTimeout(timer);
+        resolve({
+          ...base,
+          status: 'error',
+          error: { code: 'spawn_error', message: err.message },
+        });
+      });
+
+      child.on('close', (code: number | null) => {
+        clearTimeout(timer);
+        const output = getOutput();
+        if (code === 0) {
+          resolve({ ...base, status: 'success', output });
+        } else {
+          const tail = output.slice(-500);
+          resolve({
+            ...base,
+            status: 'error',
+            error: {
+              code: 'nonzero_exit',
+              message: `Command exited with code ${code}. Output tail: ${tail}`,
+              retryable: false,
+            },
+          });
+        }
+      });
+    });
+  }
+}
+
+export function createBashToolRegistry(config: BashToolConfig): HarnessToolRegistry {
+  return new BashToolRegistry(config);
+}


### PR DESCRIPTION
## Summary
- Add OpenRouterModelAdapter (a HarnessModelAdapter) with tool-call support — distinct from the existing no-tool OpenRouterExecutionAdapter proof slice.
- Add BashToolRegistry (a HarnessToolRegistry) exposing a single allowlist-gated bash tool, designed to drive CLI primitives like sage-vfs.
- Bump @agent-assistant/harness patch version.

## Why
Sage Slack handler currently uses a plan-then-synthesize path that produces \"Let me search...\" prose without executing tools. Migrating Slack to drive a real harness loop with a Bash tool against sage-vfs eliminates that bug class structurally. This PR ships the harness-side primitives; sage wiring lands in a follow-up PR.

## Validation
- npm test -w @agent-assistant/harness: pass
- npm test --workspaces --if-present: pass
- npm run build -w @agent-assistant/harness: type-clean

## Notes
Publish manually after merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
