### PR TITLE
fix(publish): add license + repository + publishConfig to connectivity and coordination

### DIFF
--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -26,5 +26,13 @@
   "devDependencies": {
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/agent-assistant"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/coordination/package.json
+++ b/packages/coordination/package.json
@@ -29,5 +29,13 @@
     "@agent-assistant/routing": "file:../routing",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/agent-assistant"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
Both `packages/connectivity/package.json` and `packages/coordination/package.json` are missing the standard metadata block that every other `@agent-assistant/*` publishable package ships with (vfs, harness, sdk, memory, etc.).

The next `runtime-core` publish — which PR #15 adds both packages to — fails npm's provenance verification:

\`\`\`
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@agent-assistant%2fconnectivity
npm error Error verifying sigstore provenance bundle: Failed to validate repository information:
npm error package.json: "repository.url" is "",
npm error expected to match "https://github.com/AgentWorkforce/agent-assistant" from provenance
\`\`\`

## Fix
Mirror the metadata tail that sibling packages use:

\`\`\`json
"license": "MIT",
"repository": {
  "type": "git",
  "url": "https://github.com/AgentWorkforce/agent-assistant"
},
"publishConfig": {
  "access": "public"
}
\`\`\`

`publishConfig.access: public` is required because the workflow invokes `npm publish --provenance --access public` and provenance publishes must be public.

## Relationship to PR #15
This is the second half of unblocking `runtime-core` publishes for `connectivity` + `coordination`. Merge order doesn't matter:
- PR #15 adds both to the matrix + build ORDER
- This PR gives them the metadata the provenance publish step requires

Both need to land before the next publish can succeed.

## Test plan
- [ ] After merge of both PRs, re-run the `runtime-core` publish; verify `connectivity` and `coordination` publish without E422
- [ ] Verify `npm view @agent-assistant/coordination repository.url` returns the monorepo URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
