### PR TITLE
feat(harness): OpenRouter model adapter + Bash tool registry

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Add OpenRouterModelAdapter (a HarnessModelAdapter) with tool-call support — distinct from the existing no-tool OpenRouterExecutionAdapter proof slice.
- Add BashToolRegistry (a HarnessToolRegistry) exposing a single allowlist-gated bash tool, designed to drive CLI primitives like sage-vfs.
- Bump @agent-assistant/harness patch version.

## Why
Sage Slack handler currently uses a plan-then-synthesize path that produces \"Let me search...\" prose without executing tools. Migrating Slack to drive a real harness loop with a Bash tool against sage-vfs eliminates that bug class structurally. This PR ships the harness-side primitives; sage wiring lands in a follow-up PR.

## Validation
- npm test -w @agent-assistant/harness: pass
- npm test --workspaces --if-present: pass
- npm run build -w @agent-assistant/harness: type-clean

## Notes
Publish manually after merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
