### PR TITLE
fix(specialists): bump coordination + vfs pins to ^0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -312,7 +312,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3452,7 +3451,8 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.1.0",
+      "version": "0.2.6",
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
       },
@@ -3463,7 +3463,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "dependencies": {
         "@agent-assistant/harness": "^0.1.3"
       },
@@ -3490,9 +3490,10 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.1.0",
+      "version": "0.2.6",
+      "license": "MIT",
       "dependencies": {
-        "@agent-assistant/connectivity": "file:../connectivity",
+        "@agent-assistant/connectivity": "^0.2.6",
         "nanoid": "^5.1.6"
       },
       "devDependencies": {
@@ -3503,7 +3504,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3523,10 +3524,10 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "dependencies": {
-        "@agent-assistant/connectivity": "file:../connectivity",
-        "@agent-assistant/coordination": "file:../coordination",
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/core": "^0.1.3",
         "@agent-assistant/traits": "^0.2.0",
         "@agent-assistant/turn-context": "^0.2.0",
@@ -3548,7 +3549,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4336,7 +4337,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4348,7 +4349,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -5128,7 +5129,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.7"
@@ -5149,7 +5150,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -5166,7 +5167,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5174,10 +5175,10 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.1.0",
+      "version": "0.2.6",
       "dependencies": {
-        "@agent-assistant/coordination": "^0.1.0",
-        "@agent-assistant/vfs": "^0.2.2",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/vfs": "^0.2.6",
         "@relayfile/adapter-github": "^0.1.6",
         "@relayfile/adapter-linear": "^0.1.7"
       },
@@ -5188,7 +5189,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5196,7 +5197,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5205,7 +5206,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.1.3",
@@ -5250,7 +5251,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.2",
+      "version": "0.2.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -18,8 +18,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agent-assistant/coordination": "^0.1.0",
-    "@agent-assistant/vfs": "^0.2.2",
+    "@agent-assistant/coordination": "^0.2.6",
+    "@agent-assistant/vfs": "^0.2.6",
     "@relayfile/adapter-github": "^0.1.6",
     "@relayfile/adapter-linear": "^0.1.7"
   },


### PR DESCRIPTION
## Summary
`@agent-assistant/specialists` source still pins stale versions from the initial scaffold:

\`\`\`diff
  "dependencies": {
-   "@agent-assistant/coordination": "^0.1.0",
-   "@agent-assistant/vfs":          "^0.2.2",
+   "@agent-assistant/coordination": "^0.2.6",
+   "@agent-assistant/vfs":          "^0.2.6",
    "@relayfile/adapter-github":     "^0.1.6",
    "@relayfile/adapter-linear":     "^0.1.7"
  }
\`\`\`

The publish workflow's `file:` → semver rewrite only fires on `file:` specs (`publish.yml:241`), so hardcoded pins stay frozen across publishes. As a result, every `specialists@0.2.x` tarball still requested `coordination@^0.1.0`, which only satisfies `coordination@0.1.0` — the broken pre-rewrite version with the dead `file:../connectivity` dep.

Downstream effect: Sage had to keep an `overrides` workaround in its `package.json` forcing `coordination` + `connectivity` to `^0.2.6`. After this bump republishes, Sage can drop the overrides entirely.

## Convention
Per decision: hardcoded semver pins in specialists source, manually bumped on each publish. This matches how some other packages declare deps (sdk, turn-context) rather than the `file:`-and-rewrite pattern used by coordination/harness.

## Test plan
- [ ] After next `runtime-core` publish, verify `npm view @agent-assistant/specialists dependencies` shows `coordination: ^0.2.x` (not `^0.1.0`)
- [ ] Verify Sage `npm ci` succeeds without the `overrides` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
