### PR TITLE
chore(workflows): harness primitives + tiered router agent-relay workflows

### DIFF
--- a/scripts/run-build-harness-primitives.sh
+++ b/scripts/run-build-harness-primitives.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Wrapper for the harness-primitives migration.
+#
+# Creates a git worktree off agent-assistant/main, copies the workflow files
+# in, installs deps, then runs the master workflow which fans out to the
+# adapter + bash-tool builds (parallel) and the integrate-and-PR step.
+#
+# Usage:
+#   bash scripts/run-build-harness-primitives.sh
+#
+# Env:
+#   REPO  override agent-assistant repo path (defaults to /Users/khaliqgant/Projects/AgentWorkforce/agent-assistant)
+
+set -euo pipefail
+
+REPO="${REPO:-/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant}"
+TS="$(date +%Y%m%d%H%M%S)"
+BRANCH="harness/openrouter-bash-${TS}"
+WORKTREE="${REPO}-wt-${TS}"
+
+WORKFLOWS=(
+  master-build-harness-primitives.ts
+  build-harness-openrouter-model-adapter.ts
+  build-harness-bash-tool-registry.ts
+  integrate-harness-primitives-and-pr.ts
+)
+
+if [ ! -d "$REPO" ]; then
+  echo "Repo not found at $REPO — set REPO env var" >&2
+  exit 1
+fi
+
+for w in "${WORKFLOWS[@]}"; do
+  if [ ! -f "$REPO/workflows/$w" ]; then
+    echo "Missing workflow file: $REPO/workflows/$w" >&2
+    exit 1
+  fi
+done
+
+if ! command -v agent-relay >/dev/null; then
+  echo "agent-relay CLI not on PATH" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null; then
+  echo "gh CLI not on PATH" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh not authenticated — run 'gh auth login' first" >&2
+  exit 1
+fi
+
+echo "==> Creating worktree: $WORKTREE on branch $BRANCH"
+git -C "$REPO" worktree add -b "$BRANCH" "$WORKTREE" main
+
+trap 'echo; echo "==> Wrapper failed. Worktree preserved at $WORKTREE for inspection."; echo "    To remove: git -C $REPO worktree remove --force $WORKTREE && git -C $REPO branch -D $BRANCH"' ERR
+
+echo "==> Copying workflow files into worktree"
+mkdir -p "$WORKTREE/workflows"
+for w in "${WORKFLOWS[@]}"; do
+  cp "$REPO/workflows/$w" "$WORKTREE/workflows/$w"
+done
+
+cd "$WORKTREE"
+
+echo "==> Installing deps in worktree (this may take a minute)"
+npm install --no-audit --no-fund 2>&1 | tail -10
+
+echo "==> Running master workflow"
+agent-relay run workflows/master-build-harness-primitives.ts
+
+trap - ERR
+
+echo
+echo "==> Done."
+echo "    Worktree: $WORKTREE"
+echo "    Branch: $BRANCH"
+echo "    The integration workflow opened a PR — check 'gh pr view' inside the worktree for the URL."
+echo "    Cleanup after merge: git -C $REPO worktree remove $WORKTREE && git -C $REPO branch -d $BRANCH"

--- a/scripts/run-build-tiered-router.sh
+++ b/scripts/run-build-tiered-router.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Wrapper for the tiered-router primitive build.
+#
+# Creates a git worktree off agent-assistant/main, copies the workflow files
+# in, installs deps, then runs the master workflow which fans out to:
+#   wave 1: types + SingleShotAdapter
+#   wave 2: createTieredRunner
+#   wave 3: integrate-and-PR
+#
+# Usage:
+#   bash scripts/run-build-tiered-router.sh
+#
+# Env:
+#   REPO  override agent-assistant repo path (defaults to /Users/khaliqgant/Projects/AgentWorkforce/agent-assistant)
+
+set -euo pipefail
+
+REPO="${REPO:-/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant}"
+TS="$(date +%Y%m%d%H%M%S)"
+BRANCH="harness/tiered-router-${TS}"
+WORKTREE="${REPO}-wt-${TS}"
+
+WORKFLOWS=(
+  master-build-tiered-router.ts
+  build-router-types-and-singleshot.ts
+  build-tiered-runner.ts
+  integrate-tiered-router-and-pr.ts
+)
+
+if [ ! -d "$REPO" ]; then
+  echo "Repo not found at $REPO — set REPO env var" >&2
+  exit 1
+fi
+
+for w in "${WORKFLOWS[@]}"; do
+  if [ ! -f "$REPO/workflows/$w" ]; then
+    echo "Missing workflow file: $REPO/workflows/$w" >&2
+    exit 1
+  fi
+done
+
+if ! command -v agent-relay >/dev/null; then
+  echo "agent-relay CLI not on PATH" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null; then
+  echo "gh CLI not on PATH" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh not authenticated — run 'gh auth login' first" >&2
+  exit 1
+fi
+
+echo "==> Creating worktree: $WORKTREE on branch $BRANCH"
+git -C "$REPO" worktree add -b "$BRANCH" "$WORKTREE" main
+
+trap 'echo; echo "==> Wrapper failed. Worktree preserved at $WORKTREE for inspection."; echo "    To remove: git -C $REPO worktree remove --force $WORKTREE && git -C $REPO branch -D $BRANCH"' ERR
+
+echo "==> Copying workflow files into worktree"
+mkdir -p "$WORKTREE/workflows"
+for w in "${WORKFLOWS[@]}"; do
+  cp "$REPO/workflows/$w" "$WORKTREE/workflows/$w"
+done
+
+cd "$WORKTREE"
+
+echo "==> Installing deps in worktree (this may take a minute)"
+npm install --no-audit --no-fund 2>&1 | tail -10
+
+echo "==> Running master workflow"
+agent-relay run workflows/master-build-tiered-router.ts
+
+trap - ERR
+
+echo
+echo "==> Done."
+echo "    Worktree: $WORKTREE"
+echo "    Branch: $BRANCH"
+echo "    The integration workflow opened a PR — check 'gh pr view' inside the worktree for the URL."
+echo "    Cleanup after merge: git -C $REPO worktree remove $WORKTREE && git -C $REPO branch -d $BRANCH"

--- a/workflows/build-harness-bash-tool-registry.ts
+++ b/workflows/build-harness-bash-tool-registry.ts
@@ -1,0 +1,199 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels } from '@agent-relay/config';
+
+async function runWorkflow() {
+  const result = await workflow('build-harness-bash-tool-registry')
+    .description(
+      'Implement BashToolRegistry (HarnessToolRegistry exposing one allowlist-gated bash tool) plus its vitest suite. Leaves changes uncommitted; integration workflow handles wiring, version bump, and PR.',
+    )
+    .pattern('dag')
+    .channel('wf-build-bash-tool-registry')
+    .maxConcurrency(2)
+    .timeout(1_800_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Implements the Bash tool registry and its vitest suite. Reads contract types from packages/harness/src/types.ts.',
+      retries: 2,
+    })
+
+    .step('read-context', {
+      type: 'deterministic',
+      command: [
+        'echo "===== HARNESS TYPES ====="',
+        'cat packages/harness/src/types.ts',
+        'echo "" && echo "===== HARNESS RUNTIME (tool execution loop) ====="',
+        'cat packages/harness/src/harness.ts',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-tool-registry', {
+      agent: 'impl',
+      dependsOn: ['read-context'],
+      task: `Create file: packages/harness/src/tools/bash-tool-registry.ts (create the tools/ directory if needed).
+
+Implement BashToolRegistry — a HarnessToolRegistry that exposes a single 'bash' tool to the model with a first-token allowlist.
+
+Contract (from packages/harness/src/types.ts):
+
+  interface HarnessToolRegistry {
+    listAvailable(input: HarnessToolAvailabilityInput): Promise<HarnessToolDefinition[]>;
+    execute(call: HarnessToolCall, context: HarnessToolExecutionContext): Promise<HarnessToolResult>;
+  }
+
+  interface HarnessToolDefinition { name; description; inputSchema?; requiresApproval? }
+  interface HarnessToolCall { id; name; input: Record<string,unknown> }
+  interface HarnessToolResult {
+    callId; toolName;
+    status: 'success' | 'error';
+    output?: string;
+    error?: { code: string; message: string; retryable?: boolean };
+  }
+
+Required exports:
+  - export interface BashToolConfig {
+      allowedCommands: string[];      // first-token allowlist, e.g. ['sage-vfs']
+      cwd?: string;
+      env?: Record<string, string>;   // merged onto process.env
+      timeoutMs?: number;             // default 30_000
+      maxOutputBytes?: number;        // default 65_536
+      spawnImpl?: typeof import('node:child_process').spawn;
+    }
+  - export class BashToolRegistry implements HarnessToolRegistry
+  - export function createBashToolRegistry(config: BashToolConfig): HarnessToolRegistry
+
+listAvailable returns exactly one tool:
+  {
+    name: 'bash',
+    description: \`Execute a shell command. Only the following first-token commands are permitted: \${allowedCommands.join(', ')}. Provide the full command line as input.command.\`,
+    inputSchema: {
+      type: 'object',
+      properties: { command: { type: 'string', description: 'Full command line to execute' } },
+      required: ['command'],
+    },
+  }
+
+execute behavior:
+  - call.name !== 'bash' → error code 'unknown_tool'
+  - typeof input.command !== 'string' → error code 'invalid_input'
+  - first token (after trim, split on whitespace) not in allowedCommands → error code 'command_not_allowed', message names the rejected token + allowlist
+  - Spawn with shell:true, cwd, env merged with process.env. Use spawnImpl ?? spawn from 'node:child_process'.
+  - Capture combined stdout+stderr up to maxOutputBytes; truncate with marker '\\n[output truncated to N bytes]'.
+  - Timeout: setTimeout → child.kill('SIGKILL') → error code 'timeout', retryable:true
+  - Exit 0 → status 'success', output = captured
+  - Non-zero exit → error code 'nonzero_exit', message includes exit code and tail of output, retryable:false
+  - Spawn 'error' event → error code 'spawn_error', message from error
+  - All results carry callId: call.id, toolName: 'bash'
+
+Use ESM. import { spawn } from 'node:child_process' (only for default; spawnImpl override takes precedence).
+
+Do NOT modify any other files. Write to disk. End with BASH_TOOL_REGISTRY_IMPLEMENTED.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/tools/bash-tool-registry.ts',
+      },
+    })
+
+    .step('write-test', {
+      agent: 'impl',
+      dependsOn: ['implement-tool-registry'],
+      task: `Create file: packages/harness/src/tools/bash-tool-registry.test.ts
+
+Use vitest. Inject spawnImpl (vi.fn returning a fake ChildProcess: EventEmitter with stdout, stderr (also EventEmitters), kill()).
+
+Required cases:
+  1. listAvailable returns exactly one tool with correct schema
+  2. unknown tool name → 'unknown_tool'
+  3. non-string command → 'invalid_input'
+  4. command first-token not in allowlist → 'command_not_allowed', message includes rejected token
+  5. success path: emit stdout 'hello\\n', close 0 → status 'success', output contains 'hello'
+  6. non-zero exit: emit stderr 'oops', close 2 → 'nonzero_exit', message includes '2'
+  7. timeout: never close, timeoutMs 50 → 'timeout', kill('SIGKILL') was called
+  8. output truncation: large stdout > maxOutputBytes → output bounded, contains truncation marker
+  9. allowlist names appear in tool description
+  10. spawn 'error' event → 'spawn_error'
+
+Use Node EventEmitter to build fakes. End with BASH_TOOL_REGISTRY_TEST_WRITTEN.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/tools/bash-tool-registry.test.ts',
+      },
+    })
+
+    .step('run-tests-first-pass', {
+      type: 'deterministic',
+      dependsOn: ['write-test'],
+      command:
+        'npx vitest run packages/harness/src/tools/bash-tool-registry.test.ts 2>&1 | tail -80',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-test-failures', {
+      agent: 'impl',
+      dependsOn: ['run-tests-first-pass'],
+      task: `Fix failures until all BashToolRegistry tests pass.
+
+Test output:
+{{steps.run-tests-first-pass.output}}
+
+If green, do nothing.
+Otherwise: read test + source, fix in source (unless test is wrong), re-run:
+  npx vitest run packages/harness/src/tools/bash-tool-registry.test.ts
+Iterate. End with TESTS_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-test-failures'],
+      command:
+        'npx vitest run packages/harness/src/tools/bash-tool-registry.test.ts 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('build-check', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1 | tail -40; echo "EXIT: $?"',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-build-errors', {
+      agent: 'impl',
+      dependsOn: ['build-check'],
+      task: `Fix any tsc errors caused by this change.
+
+Build output:
+{{steps.build-check.output}}
+
+If exit 0, do nothing. Else fix in source, re-run:
+  npm run build -w @agent-assistant/harness
+End with BUILD_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('build-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-build-errors'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/build-harness-openrouter-model-adapter.ts
+++ b/workflows/build-harness-openrouter-model-adapter.ts
@@ -1,0 +1,192 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels } from '@agent-relay/config';
+
+async function runWorkflow() {
+  const result = await workflow('build-harness-openrouter-model-adapter')
+    .description(
+      'Implement OpenRouterModelAdapter (HarnessModelAdapter with tool-call support) plus its vitest suite. Leaves changes uncommitted; integration workflow handles wiring, version bump, and PR.',
+    )
+    .pattern('dag')
+    .channel('wf-build-openrouter-model-adapter')
+    .maxConcurrency(2)
+    .timeout(1_800_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Implements the OpenRouter HarnessModelAdapter and its vitest suite. Reads contract types from packages/harness/src/types.ts.',
+      retries: 2,
+    })
+
+    .step('read-context', {
+      type: 'deterministic',
+      command: [
+        'echo "===== HARNESS TYPES ====="',
+        'cat packages/harness/src/types.ts',
+        'echo "" && echo "===== EXISTING OPENROUTER EXECUTION ADAPTER (no-tool proof, do NOT modify) ====="',
+        'cat packages/harness/src/adapter/openrouter-adapter.ts',
+        'echo "" && echo "===== ADAPTER INDEX ====="',
+        'cat packages/harness/src/adapter/index.ts',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-adapter', {
+      agent: 'impl',
+      dependsOn: ['read-context'],
+      task: `Create file: packages/harness/src/adapter/openrouter-model-adapter.ts
+
+Implement OpenRouterModelAdapter — a HarnessModelAdapter (NOT the existing ExecutionAdapter). The existing OpenRouterExecutionAdapter at packages/harness/src/adapter/openrouter-adapter.ts is a no-tool proof slice; do NOT modify it.
+
+Contract (from packages/harness/src/types.ts):
+
+  interface HarnessModelAdapter {
+    nextStep(input: HarnessModelInput): Promise<HarnessModelOutput>;
+  }
+
+  type HarnessModelOutput =
+    | { type: 'final_answer'; text: string; usage?: HarnessUsage; metadata?: ... }
+    | { type: 'tool_request'; calls: HarnessToolCall[]; usage?: HarnessUsage; metadata?: ... }
+    | { type: 'clarification'; question: string; usage?: HarnessUsage; metadata?: ... }
+    | { type: 'approval_request'; request: HarnessApprovalRequest; usage?: HarnessUsage; metadata?: ... }
+    | { type: 'refusal'; reason: string; usage?: HarnessUsage; metadata?: ... }
+    | { type: 'invalid'; reason: string; raw?: unknown; usage?: HarnessUsage }
+
+  interface HarnessToolCall { id: string; name: string; input: Record<string, unknown> }
+
+Read packages/harness/src/types.ts for HarnessModelInput, HarnessTranscriptItem, HarnessToolDefinition, and HarnessUsage exact shapes — match precisely.
+
+Required exports:
+  - export interface OpenRouterModelAdapterConfig {
+      apiKey?: string;
+      model?: string;                  // default 'anthropic/claude-sonnet-4-6'
+      baseUrl?: string;                // default 'https://openrouter.ai/api/v1/chat/completions'
+      fetchImpl?: typeof fetch;
+      timeoutMs?: number;              // default 60_000
+      defaultTemperature?: number;
+    }
+  - export class OpenRouterModelAdapter implements HarnessModelAdapter
+  - export function createOpenRouterModelAdapter(config?): HarnessModelAdapter
+
+nextStep behavior:
+  - Build OpenAI-style request body: model, messages (system from instructions.systemPrompt, optional second system from developerPrompt, mapped transcript, then user message), tools mapped from availableTools (omit when empty), tool_choice 'auto' when tools present, temperature only if defined.
+  - POST to baseUrl with Authorization Bearer apiKey, Content-Type application/json. AbortController with timeoutMs.
+  - Response parsing:
+      * choices[0].message.tool_calls non-empty → { type:'tool_request', calls: [{ id, name, input: JSON.parse(arguments) }], usage }
+      * Else → { type:'final_answer', text: choices[0].message.content, usage }
+  - Error mapping (return invalid, never throw):
+      * Missing apiKey → { type:'invalid', reason:'OpenRouter API key is not configured.' }
+      * HTTP non-ok → { type:'invalid', reason: error.message ?? \`HTTP \${status}\`, raw: body }
+      * AbortError → { type:'invalid', reason:'timeout' }
+      * tool_call arguments JSON parse fails → { type:'invalid', reason:'tool_call arguments are not valid JSON', raw: body }
+  - Map usage from body.usage (prompt_tokens, completion_tokens, total_tokens) into HarnessUsage shape (verify field names from types.ts).
+
+Style: match openrouter-adapter.ts. ESM imports with .js extensions. fetchImpl ?? fetch fallback.
+
+Do NOT modify any other files. Write to disk. End with OPENROUTER_MODEL_ADAPTER_IMPLEMENTED.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/adapter/openrouter-model-adapter.ts',
+      },
+    })
+
+    .step('write-test', {
+      agent: 'impl',
+      dependsOn: ['implement-adapter'],
+      task: `Create file: packages/harness/src/adapter/openrouter-model-adapter.test.ts
+
+Use vitest. Test OpenRouterModelAdapter via fetchImpl injection (vi.fn).
+
+Required cases:
+  1. final_answer when response has no tool_calls
+  2. tool_request when response has tool_calls (id, name, parsed input)
+  3. availableTools forwarded as OpenAI tool descriptors (assert request body)
+  4. system + developerPrompt + transcript map to messages array correctly
+  5. HTTP error returns { type:'invalid', reason } with the API error message
+  6. timeout via never-resolving fetchImpl returns { type:'invalid', reason:'timeout' } (timeoutMs:50)
+  7. usage mapped from body.usage (prompt_tokens, completion_tokens, total_tokens)
+  8. Missing apiKey returns { type:'invalid', reason: includes 'API key' }
+  9. Malformed tool_call arguments returns { type:'invalid', reason: includes 'JSON' }
+
+Parse fetchImpl.mock.calls[0][1].body as JSON for assertions. End with OPENROUTER_MODEL_ADAPTER_TEST_WRITTEN.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/adapter/openrouter-model-adapter.test.ts',
+      },
+    })
+
+    .step('run-tests-first-pass', {
+      type: 'deterministic',
+      dependsOn: ['write-test'],
+      command:
+        'npx vitest run packages/harness/src/adapter/openrouter-model-adapter.test.ts 2>&1 | tail -80',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-test-failures', {
+      agent: 'impl',
+      dependsOn: ['run-tests-first-pass'],
+      task: `Fix failures until all OpenRouterModelAdapter tests pass.
+
+Test output:
+{{steps.run-tests-first-pass.output}}
+
+If green, do nothing.
+Otherwise: read the test + source, fix in source (unless test is wrong), re-run:
+  npx vitest run packages/harness/src/adapter/openrouter-model-adapter.test.ts
+Iterate until green. Do NOT modify openrouter-adapter.ts. End with TESTS_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-test-failures'],
+      command:
+        'npx vitest run packages/harness/src/adapter/openrouter-model-adapter.test.ts 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('build-check', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1 | tail -40; echo "EXIT: $?"',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-build-errors', {
+      agent: 'impl',
+      dependsOn: ['build-check'],
+      task: `Fix any tsc errors in @agent-assistant/harness from this change.
+
+Build output:
+{{steps.build-check.output}}
+
+If exit 0, do nothing. Else fix in source (do NOT modify openrouter-adapter.ts), re-run:
+  npm run build -w @agent-assistant/harness
+End with BUILD_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('build-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-build-errors'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/build-router-types-and-singleshot.ts
+++ b/workflows/build-router-types-and-singleshot.ts
@@ -1,0 +1,278 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels } from '@agent-relay/config';
+
+async function runWorkflow() {
+  const result = await workflow('build-router-types-and-singleshot')
+    .description(
+      'Adds Router / SingleShotAdapter / TieredRunner type interfaces in @agent-assistant/harness, plus a concrete OpenRouterSingleShotAdapter implementation and vitest suite. No exports are wired in this step; the integrate workflow handles that.',
+    )
+    .pattern('dag')
+    .channel('wf-build-router-types-and-singleshot')
+    .maxConcurrency(2)
+    .timeout(2_400_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Implements the routing types and the OpenRouter single-shot adapter plus its tests.',
+      retries: 2,
+    })
+
+    .step('read-context', {
+      type: 'deterministic',
+      command: [
+        'echo "===== HARNESS TYPES ====="',
+        'cat packages/harness/src/types.ts',
+        'echo "" && echo "===== EXISTING OPENROUTER MODEL ADAPTER (reference) ====="',
+        'cat packages/harness/src/adapter/openrouter-model-adapter.ts',
+        'echo "" && echo "===== EXISTING OPENROUTER EXECUTION ADAPTER (do NOT touch) ====="',
+        'sed -n "1,40p" packages/harness/src/adapter/openrouter-adapter.ts',
+        'echo "" && echo "===== HARNESS INDEX (reference for export style) ====="',
+        'cat packages/harness/src/index.ts',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Step 1: routing type interfaces ───────────────────────────────
+    .step('implement-router-types', {
+      agent: 'impl',
+      dependsOn: ['read-context'],
+      task: `Create file: packages/harness/src/router/types.ts
+
+Define provider-neutral interfaces for tiered routing on top of the existing harness types. Imports must use .js extensions and reference '../types.js' for HarnessUserMessage / HarnessPreparedContext / HarnessUsage / HarnessTurnInput / HarnessRuntime / HarnessResult.
+
+Required exports:
+
+  export type RoutingTier = 'fast' | 'harness' | 'reject';
+
+  export interface RoutingDecision {
+    tier: RoutingTier;
+    reason?: string;
+    metadata?: Record<string, unknown>;
+  }
+
+  export interface RouterInput {
+    message: HarnessUserMessage;
+    context?: HarnessPreparedContext;
+    threadHistory?: Array<{ role: 'user' | 'assistant'; content: string }>;
+    metadata?: Record<string, unknown>;
+  }
+
+  export interface Router {
+    route(input: RouterInput): Promise<RoutingDecision>;
+  }
+
+  export interface SingleShotInput {
+    message: HarnessUserMessage;
+    instructions: { systemPrompt: string; developerPrompt?: string };
+    context?: HarnessPreparedContext;
+    threadHistory?: Array<{ role: 'user' | 'assistant'; content: string }>;
+    metadata?: Record<string, unknown>;
+  }
+
+  export interface SingleShotResult {
+    text: string;
+    usage?: HarnessUsage;
+    metadata?: Record<string, unknown>;
+  }
+
+  export interface SingleShotAdapter {
+    generate(input: SingleShotInput): Promise<SingleShotResult>;
+  }
+
+  export interface TieredRunner {
+    runTurn(input: HarnessTurnInput): Promise<TieredRunnerResult>;
+  }
+
+  export type TieredRunnerResult =
+    | TieredRunnerFastResult
+    | TieredRunnerHarnessResult
+    | TieredRunnerRejectedResult;
+
+  export interface TieredRunnerFastResult {
+    tier: 'fast';
+    routingDecision: RoutingDecision;
+    text: string;
+    usage?: HarnessUsage;
+    singleShot: SingleShotResult;
+  }
+
+  export interface TieredRunnerHarnessResult {
+    tier: 'harness';
+    routingDecision: RoutingDecision;
+    harnessResult: HarnessResult;
+    text?: string;
+  }
+
+  export interface TieredRunnerRejectedResult {
+    tier: 'rejected';
+    routingDecision: RoutingDecision;
+    text: string;
+  }
+
+Style:
+  - ESM imports with .js suffixes (import type { HarnessUserMessage } from '../types.js')
+  - Strict TS, exported types only — no implementation logic in this file
+  - No comments unless the WHY is non-obvious
+
+End with ROUTER_TYPES_IMPLEMENTED. Only create this one file.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/router/types.ts',
+      },
+    })
+
+    // ── Step 2: OpenRouter single-shot adapter ────────────────────────
+    .step('implement-singleshot-adapter', {
+      agent: 'impl',
+      dependsOn: ['implement-router-types'],
+      task: `Create file: packages/harness/src/router/openrouter-singleshot-adapter.ts
+
+Implement OpenRouterSingleShotAdapter — a SingleShotAdapter (from ../router/types.js) that calls OpenRouter once, no tools, no loop. This is the cheap "one-shot reply" path used when the Router decides a request doesn't need tools.
+
+Reference the existing packages/harness/src/adapter/openrouter-model-adapter.ts for style and conventions (fetchImpl injection, AbortController timeout, error mapping). Do NOT modify it.
+
+Required exports:
+
+  export interface OpenRouterSingleShotAdapterConfig {
+    apiKey?: string;
+    model?: string;                  // default 'anthropic/claude-haiku-4-5'
+    baseUrl?: string;                // default 'https://openrouter.ai/api/v1/chat/completions'
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;              // default 30_000
+    defaultTemperature?: number;
+  }
+
+  export class OpenRouterSingleShotAdapter implements SingleShotAdapter
+  export function createOpenRouterSingleShotAdapter(config?: OpenRouterSingleShotAdapterConfig): SingleShotAdapter
+
+generate(input) behavior:
+  - Build OpenAI-style request body:
+      model: config.model ?? 'anthropic/claude-haiku-4-5'
+      messages: [
+        { role: 'system', content: input.instructions.systemPrompt },
+        ...optional second system message from developerPrompt if present,
+        ...threadHistory mapped to { role, content },
+        { role: 'user', content: input.message.text },
+      ]
+      temperature: config.defaultTemperature, only if defined
+      // NO tools — this is the no-tool fast path
+  - POST to baseUrl with Authorization Bearer apiKey + Content-Type application/json. AbortController with timeoutMs (default 30_000).
+  - Parse response choices[0].message.content → return { text, usage }
+  - Map usage from body.usage (prompt_tokens, completion_tokens, total_tokens) into HarnessUsage shape (verify field names from packages/harness/src/types.ts — likely promptTokens/completionTokens/totalTokens).
+  - On missing apiKey → throw new Error('OpenRouter API key is not configured.') (consumers should pre-check; unlike the model adapter we don't return a placeholder result here because there is no HarnessModelOutput discriminated union to use).
+  - On HTTP non-ok → throw new Error including response error.message and status
+  - On AbortError → throw new Error('OpenRouter single-shot request timed out')
+  - On missing content → throw new Error('OpenRouter response did not include assistant content')
+
+Style: ESM imports, .js extensions. fetchImpl ?? fetch fallback for testability.
+
+Only create this one file: packages/harness/src/router/openrouter-singleshot-adapter.ts. End with SINGLESHOT_ADAPTER_IMPLEMENTED.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/router/openrouter-singleshot-adapter.ts',
+      },
+    })
+
+    // ── Step 3: tests ─────────────────────────────────────────────────
+    .step('write-singleshot-test', {
+      agent: 'impl',
+      dependsOn: ['implement-singleshot-adapter'],
+      task: `Create file: packages/harness/src/router/openrouter-singleshot-adapter.test.ts
+
+Use vitest. Test OpenRouterSingleShotAdapter via fetchImpl injection (vi.fn).
+
+Required cases:
+  1. "returns text from choices[0].message.content" — fetchImpl returns { ok:true, status:200, json:async()=>({ choices:[{ message:{ content:'hi there' }}] }) }. Assert generate(...) resolves with { text: 'hi there' }.
+  2. "request body has no tools field" — assert the body sent to fetchImpl does NOT include a 'tools' key (parse fetchImpl.mock.calls[0][1].body and assert).
+  3. "system prompt + threadHistory + user message map correctly" — pass instructions.systemPrompt='SYS', threadHistory of two messages, user message 'hi'. Assert messages array order is [system, history0, history1, user-message].
+  4. "developerPrompt produces a second system message" — assert when present, messages[1].role === 'system'.
+  5. "throws on HTTP error including status" — fetchImpl returns { ok:false, status:500, json:async()=>({ error:{ message:'boom' }}) }. Assert promise rejects with Error containing 'boom' and '500'.
+  6. "throws on timeout" — fetchImpl returns a never-resolving Promise; pass timeoutMs:50. Assert promise rejects with Error matching /timed out/i.
+  7. "throws when apiKey missing" — instantiate without apiKey, assert generate(...) rejects with Error containing 'API key'.
+  8. "maps usage when present" — body.usage:{ prompt_tokens:10, completion_tokens:5, total_tokens:15 }. Assert returned usage matches HarnessUsage field names (verify field names from src/types.ts).
+  9. "throws when message content missing" — choices[0].message has no content. Assert rejects with Error matching /content/i.
+
+Use vitest vi.fn() for fetchImpl. Parse fetchImpl.mock.calls[0][1].body as JSON for body-shape assertions. End with SINGLESHOT_ADAPTER_TEST_WRITTEN. Only create this one file.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/router/openrouter-singleshot-adapter.test.ts',
+      },
+    })
+
+    // ── Step 4: test-fix-rerun loop ───────────────────────────────────
+    .step('run-tests-first-pass', {
+      type: 'deterministic',
+      dependsOn: ['write-singleshot-test'],
+      command:
+        'npx vitest run packages/harness/src/router/openrouter-singleshot-adapter.test.ts 2>&1 | tail -100',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-test-failures', {
+      agent: 'impl',
+      dependsOn: ['run-tests-first-pass'],
+      task: `Fix failures until all OpenRouterSingleShotAdapter tests pass.
+
+Output:
+{{steps.run-tests-first-pass.output}}
+
+If green, do nothing. Else: read test + source, fix in source (unless test is wrong), re-run:
+  npx vitest run packages/harness/src/router/openrouter-singleshot-adapter.test.ts
+End with TESTS_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-test-failures'],
+      command:
+        'npx vitest run packages/harness/src/router/openrouter-singleshot-adapter.test.ts 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Step 5: build check ───────────────────────────────────────────
+    .step('build-check', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1 | tail -40; echo "EXIT: $?"',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-build-errors', {
+      agent: 'impl',
+      dependsOn: ['build-check'],
+      task: `Fix any tsc errors caused by these new files.
+
+Output:
+{{steps.build-check.output}}
+
+If exit 0, do nothing. Else fix in source, re-run:
+  npm run build -w @agent-assistant/harness
+End with BUILD_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('build-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-build-errors'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/build-tiered-runner.ts
+++ b/workflows/build-tiered-runner.ts
@@ -1,0 +1,221 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels } from '@agent-relay/config';
+
+async function runWorkflow() {
+  const result = await workflow('build-tiered-runner')
+    .description(
+      'Adds createTieredRunner implementation in @agent-assistant/harness — composes a Router + SingleShotAdapter + HarnessRuntime to produce a tiered execution pipeline (fast path bypasses tools; harness path drives the full loop). Includes vitest suite that proves both branches.',
+    )
+    .pattern('dag')
+    .channel('wf-build-tiered-runner')
+    .maxConcurrency(2)
+    .timeout(2_400_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Implements the createTieredRunner factory and its vitest suite, composing the new router types + SingleShotAdapter + HarnessRuntime.',
+      retries: 2,
+    })
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'test -f packages/harness/src/router/types.ts || (echo "MISSING router types — run build-router-types-and-singleshot first"; exit 1)',
+        'test -f packages/harness/src/router/openrouter-singleshot-adapter.ts || (echo "MISSING singleshot adapter"; exit 1)',
+        'echo "Preflight OK"',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('read-context', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: [
+        'echo "===== ROUTER TYPES ====="',
+        'cat packages/harness/src/router/types.ts',
+        'echo "" && echo "===== HARNESS RUNTIME ====="',
+        'cat packages/harness/src/harness.ts',
+        'echo "" && echo "===== HARNESS TYPES (for HarnessTurnInput / HarnessResult shapes) ====="',
+        'sed -n "1,250p" packages/harness/src/types.ts',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-tiered-runner', {
+      agent: 'impl',
+      dependsOn: ['read-context'],
+      task: `Create file: packages/harness/src/router/tiered-runner.ts
+
+Implement createTieredRunner — composes Router + SingleShotAdapter + HarnessRuntime to produce a TieredRunner.
+
+Required exports:
+
+  export interface TieredRunnerConfig {
+    router: Router;
+    fast: SingleShotAdapter;
+    harness: HarnessRuntime;
+    rejectMessage?: string;       // default "I can't help with that request."
+  }
+
+  export function createTieredRunner(config: TieredRunnerConfig): TieredRunner
+
+runTurn(input: HarnessTurnInput) behavior:
+
+  1. Build a RouterInput from input:
+       message: input.message
+       context: input.context
+       threadHistory: extract from input.context.blocks where label is 'user' | 'assistant' (best effort) — if shape doesn't match, pass undefined
+       metadata: input.metadata
+     Then: const decision = await config.router.route(routerInput);
+
+  2. Branch on decision.tier:
+       'fast'     → call config.fast.generate({ message, instructions: input.instructions, context: input.context, threadHistory: same as above, metadata: input.metadata })
+                    → return { tier: 'fast', routingDecision: decision, text: result.text, usage: result.usage, singleShot: result }
+       'harness'  → call config.harness.runTurn(input)
+                    → return { tier: 'harness', routingDecision: decision, harnessResult: result, text: <best-effort extract from result> }
+                    → To extract text: try result.outcome === 'completed' && result.finalAnswer?.text; otherwise undefined. Read packages/harness/src/types.ts for the actual HarnessResult shape and adjust field paths.
+       'reject'   → return { tier: 'rejected', routingDecision: decision, text: config.rejectMessage ?? "I can't help with that request." }
+       (Any other value should also map to 'rejected' with a warning, defensively.)
+
+  3. Errors propagate — do not swallow. Caller decides.
+
+Imports:
+  import type {
+    Router,
+    RouterInput,
+    SingleShotAdapter,
+    TieredRunner,
+    TieredRunnerResult,
+  } from './types.js';
+  import type { HarnessRuntime, HarnessTurnInput, HarnessResult } from '../types.js';
+
+No new comments unless WHY is non-obvious.
+
+End with TIERED_RUNNER_IMPLEMENTED. Only create this one file.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/router/tiered-runner.ts',
+      },
+    })
+
+    .step('write-test', {
+      agent: 'impl',
+      dependsOn: ['implement-tiered-runner'],
+      task: `Create file: packages/harness/src/router/tiered-runner.test.ts
+
+Use vitest. Test createTieredRunner with three mocks:
+  - router: a Router whose route() returns whatever the test sets
+  - fast: a SingleShotAdapter whose generate() returns a stubbed text
+  - harness: a HarnessRuntime whose runTurn() returns a stubbed HarnessResult
+
+Required cases:
+
+1. "fast tier → calls fast.generate, returns tier:'fast'" —
+   router returns { tier:'fast', reason:'no tools needed' }
+   fast.generate returns { text:'hello back', usage:{ promptTokens:5, completionTokens:2, totalTokens:7 } }
+   Assert harness.runTurn was NOT called. Assert result.tier === 'fast', result.text === 'hello back', result.routingDecision.reason === 'no tools needed'.
+
+2. "harness tier → calls harness.runTurn, returns tier:'harness' with text extracted" —
+   router returns { tier:'harness' }
+   harness.runTurn returns a completed HarnessResult with finalAnswer text 'tool-driven answer' (build the full HarnessResult shape — read packages/harness/src/types.ts to get it right)
+   Assert fast.generate was NOT called. Assert result.tier === 'harness', result.text === 'tool-driven answer', result.harnessResult is the same object.
+
+3. "harness tier with non-completed outcome → text is undefined but result still surfaces" —
+   harness.runTurn returns a HarnessResult with outcome 'failed' (or 'awaiting_approval' etc.)
+   Assert result.tier === 'harness', result.text is undefined, result.harnessResult is the failed result. No throw.
+
+4. "reject tier → returns tier:'rejected' with rejectMessage" —
+   router returns { tier:'reject', reason:'out of scope' }
+   Assert neither fast nor harness was called. Assert result.tier === 'rejected', result.text === default message, result.routingDecision.reason === 'out of scope'.
+
+5. "custom rejectMessage is respected" — pass rejectMessage:'Sorry, no.' in config. Assert result.text === 'Sorry, no.'.
+
+6. "router error propagates" — router.route() throws. Assert createTieredRunner(...).runTurn(...) rejects.
+
+7. "fast adapter error propagates" — fast.generate throws. Assert runTurn rejects.
+
+8. "harness error propagates" — harness.runTurn throws. Assert runTurn rejects.
+
+9. "router input is built from HarnessTurnInput correctly" — router.route is a vi.fn. After runTurn, assert the routerInput passed had message === turnInput.message and context === turnInput.context.
+
+Use vi.fn() for all three mocks. Build minimal HarnessTurnInput / HarnessResult fixtures locally — no need for full adapters.
+
+End with TIERED_RUNNER_TEST_WRITTEN. Only create this one file.`,
+      verification: {
+        type: 'file_exists',
+        value: 'packages/harness/src/router/tiered-runner.test.ts',
+      },
+    })
+
+    .step('run-tests-first-pass', {
+      type: 'deterministic',
+      dependsOn: ['write-test'],
+      command:
+        'npx vitest run packages/harness/src/router/tiered-runner.test.ts 2>&1 | tail -100',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-test-failures', {
+      agent: 'impl',
+      dependsOn: ['run-tests-first-pass'],
+      task: `Fix failures until all tiered-runner tests pass.
+
+Output:
+{{steps.run-tests-first-pass.output}}
+
+If green, do nothing. Else fix in source (unless test is wrong), re-run:
+  npx vitest run packages/harness/src/router/tiered-runner.test.ts
+End with TESTS_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-test-failures'],
+      command:
+        'npx vitest run packages/harness/src/router/tiered-runner.test.ts 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('build-check', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1 | tail -40; echo "EXIT: $?"',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-build-errors', {
+      agent: 'impl',
+      dependsOn: ['build-check'],
+      task: `Fix any tsc errors. Output:
+{{steps.build-check.output}}
+
+If exit 0, do nothing. Else fix and re-run: npm run build -w @agent-assistant/harness. End with BUILD_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('build-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-build-errors'],
+      command: 'npm run build -w @agent-assistant/harness 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/integrate-harness-primitives-and-pr.ts
+++ b/workflows/integrate-harness-primitives-and-pr.ts
@@ -1,0 +1,195 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels } from '@agent-relay/config';
+
+async function runWorkflow() {
+  const result = await workflow('integrate-harness-primitives-and-pr')
+    .description(
+      'Wire OpenRouterModelAdapter and BashToolRegistry into @agent-assistant/harness exports, run full regression across the workspace, bump patch version, commit, push branch, open PR.',
+    )
+    .pattern('dag')
+    .channel('wf-integrate-harness-primitives')
+    .maxConcurrency(2)
+    .timeout(1_800_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Wires exports and resolves any final type/test issues from the integration.',
+      retries: 2,
+    })
+
+    // Sanity: both new files must already exist before we start
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'test -f packages/harness/src/adapter/openrouter-model-adapter.ts || (echo "MISSING openrouter-model-adapter.ts — run build-harness-openrouter-model-adapter workflow first"; exit 1)',
+        'test -f packages/harness/src/tools/bash-tool-registry.ts || (echo "MISSING bash-tool-registry.ts — run build-harness-bash-tool-registry workflow first"; exit 1)',
+        'echo "Preflight OK"',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('read-current-index', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: 'cat packages/harness/src/index.ts',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('wire-exports', {
+      agent: 'impl',
+      dependsOn: ['read-current-index'],
+      task: `Update packages/harness/src/index.ts. Add these re-exports (preserve all existing exports — do NOT remove or reorder them):
+
+  export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/openrouter-model-adapter.js';
+  export type { OpenRouterModelAdapterConfig } from './adapter/openrouter-model-adapter.js';
+  export { BashToolRegistry, createBashToolRegistry } from './tools/bash-tool-registry.js';
+  export type { BashToolConfig } from './tools/bash-tool-registry.js';
+
+Current index.ts:
+{{steps.read-current-index.output}}
+
+Do NOT touch adapter/index.ts (the new model adapter is exported from package root, separate from ExecutionAdapter exports).
+
+End with EXPORTS_WIRED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('verify-exports', {
+      type: 'deterministic',
+      dependsOn: ['wire-exports'],
+      command:
+        'grep -E "createOpenRouterModelAdapter|createBashToolRegistry" packages/harness/src/index.ts >/dev/null && echo "EXPORTS OK" || (echo "MISSING EXPORTS"; exit 1)',
+      failOnError: true,
+      captureOutput: true,
+    })
+
+    // Full harness suite (catches any export/typing issue introduced by wiring)
+    .step('harness-suite', {
+      type: 'deterministic',
+      dependsOn: ['verify-exports'],
+      command: 'npm test -w @agent-assistant/harness 2>&1 | tail -60',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-harness-suite', {
+      agent: 'impl',
+      dependsOn: ['harness-suite'],
+      task: `If the harness test suite has failures, fix them.
+
+Output:
+{{steps.harness-suite.output}}
+
+If green, do nothing. Else fix and re-run:
+  npm test -w @agent-assistant/harness
+End with HARNESS_SUITE_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('harness-suite-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-harness-suite'],
+      command: 'npm test -w @agent-assistant/harness 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // Workspace-wide regression — catch breakage in dependents
+    .step('workspace-regression', {
+      type: 'deterministic',
+      dependsOn: ['harness-suite-final'],
+      command: 'npm test --workspaces --if-present 2>&1 | tail -120',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-workspace-regression', {
+      agent: 'impl',
+      dependsOn: ['workspace-regression'],
+      task: `If workspace-wide tests broke (a dependent package importing from @agent-assistant/harness), fix.
+
+Output:
+{{steps.workspace-regression.output}}
+
+If green, do nothing.
+Common cause: a dependent expected the old harness exports unchanged. We added exports without removing — most regressions will be unrelated and pre-existing. If a regression IS caused by our change, fix the root cause in @agent-assistant/harness, not the dependent. Re-run:
+  npm test --workspaces --if-present
+End with WORKSPACE_REGRESSION_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('workspace-regression-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-workspace-regression'],
+      command: 'npm test --workspaces --if-present 2>&1 | tail -40',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // Bump patch version on @agent-assistant/harness
+    .step('bump-version', {
+      type: 'deterministic',
+      dependsOn: ['workspace-regression-final'],
+      command:
+        'node -e "const fs=require(\'node:fs\'); const path=\'packages/harness/package.json\'; const p=JSON.parse(fs.readFileSync(path,\'utf8\')); const [a,b,c]=p.version.split(\'.\'); const n=[a,b,Number(c)+1].join(\'.\'); console.log(\'Bumping \'+p.version+\' -> \'+n); p.version=n; fs.writeFileSync(path, JSON.stringify(p,null,2)+\'\\n\');"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('verify-changes', {
+      type: 'deterministic',
+      dependsOn: ['bump-version'],
+      command: 'git status --short && echo "--- DIFF SUMMARY ---" && git diff --stat',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('commit', {
+      type: 'deterministic',
+      dependsOn: ['verify-changes'],
+      command:
+        'git add packages/harness/src/adapter/openrouter-model-adapter.ts packages/harness/src/adapter/openrouter-model-adapter.test.ts packages/harness/src/tools/bash-tool-registry.ts packages/harness/src/tools/bash-tool-registry.test.ts packages/harness/src/index.ts packages/harness/package.json && git commit -m "feat(harness): add OpenRouter model adapter and Bash tool registry"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('push-branch', {
+      type: 'deterministic',
+      dependsOn: ['commit'],
+      command:
+        'BRANCH=$(git rev-parse --abbrev-ref HEAD) && echo "Pushing $BRANCH" && git push -u origin "$BRANCH" 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('open-pr', {
+      type: 'deterministic',
+      dependsOn: ['push-branch'],
+      command:
+        'gh pr create --title "feat(harness): OpenRouter model adapter + Bash tool registry" --body "$(printf \'%s\\n\' \'## Summary\' \'- Add OpenRouterModelAdapter (a HarnessModelAdapter) with tool-call support — distinct from the existing no-tool OpenRouterExecutionAdapter proof slice.\' \'- Add BashToolRegistry (a HarnessToolRegistry) exposing a single allowlist-gated bash tool, designed to drive CLI primitives like sage-vfs.\' \'- Bump @agent-assistant/harness patch version.\' \'\' \'## Why\' \'Sage Slack handler currently uses a plan-then-synthesize path that produces \\"Let me search...\\" prose without executing tools. Migrating Slack to drive a real harness loop with a Bash tool against sage-vfs eliminates that bug class structurally. This PR ships the harness-side primitives; sage wiring lands in a follow-up PR.\' \'\' \'## Validation\' \'- npm test -w @agent-assistant/harness: pass\' \'- npm test --workspaces --if-present: pass\' \'- npm run build -w @agent-assistant/harness: type-clean\' \'\' \'## Notes\' \'Publish manually after merge.\')"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('print-pr-url', {
+      type: 'deterministic',
+      dependsOn: ['open-pr'],
+      command: 'gh pr view --json url --jq .url',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/integrate-tiered-router-and-pr.ts
+++ b/workflows/integrate-tiered-router-and-pr.ts
@@ -1,0 +1,206 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels } from '@agent-relay/config';
+
+async function runWorkflow() {
+  const result = await workflow('integrate-tiered-router-and-pr')
+    .description(
+      'Wire the new tiered routing exports into @agent-assistant/harness root index, run the full harness suite plus workspace regression, bump patch version, commit, push branch, open PR.',
+    )
+    .pattern('dag')
+    .channel('wf-integrate-tiered-router-and-pr')
+    .maxConcurrency(2)
+    .timeout(2_400_000)
+
+    .agent('impl', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Wires exports and resolves any final type/test issues from the integration.',
+      retries: 2,
+    })
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'test -f packages/harness/src/router/types.ts || (echo "MISSING router types"; exit 1)',
+        'test -f packages/harness/src/router/openrouter-singleshot-adapter.ts || (echo "MISSING singleshot adapter"; exit 1)',
+        'test -f packages/harness/src/router/tiered-runner.ts || (echo "MISSING tiered runner"; exit 1)',
+        'echo "Preflight OK"',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('read-current-index', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: 'cat packages/harness/src/index.ts',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('wire-exports', {
+      agent: 'impl',
+      dependsOn: ['read-current-index'],
+      task: `Update packages/harness/src/index.ts. Preserve all existing exports — do NOT remove or reorder.
+
+Add these new exports (group near the existing OpenRouterModelAdapter / BashToolRegistry block):
+
+  export { OpenRouterSingleShotAdapter, createOpenRouterSingleShotAdapter } from './router/openrouter-singleshot-adapter.js';
+  export type { OpenRouterSingleShotAdapterConfig } from './router/openrouter-singleshot-adapter.js';
+  export { createTieredRunner } from './router/tiered-runner.js';
+  export type { TieredRunnerConfig } from './router/tiered-runner.js';
+  export type {
+    Router,
+    RouterInput,
+    RoutingDecision,
+    RoutingTier,
+    SingleShotAdapter,
+    SingleShotInput,
+    SingleShotResult,
+    TieredRunner,
+    TieredRunnerResult,
+    TieredRunnerFastResult,
+    TieredRunnerHarnessResult,
+    TieredRunnerRejectedResult,
+  } from './router/types.js';
+
+Current index.ts:
+{{steps.read-current-index.output}}
+
+End with EXPORTS_WIRED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('verify-exports', {
+      type: 'deterministic',
+      dependsOn: ['wire-exports'],
+      command:
+        'grep -E "createOpenRouterSingleShotAdapter|createTieredRunner|RoutingDecision" packages/harness/src/index.ts >/dev/null && echo "EXPORTS OK" || (echo "MISSING EXPORTS"; exit 1)',
+      failOnError: true,
+      captureOutput: true,
+    })
+
+    .step('harness-suite', {
+      type: 'deterministic',
+      dependsOn: ['verify-exports'],
+      command: 'npm test -w @agent-assistant/harness 2>&1 | tail -60',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-harness-suite', {
+      agent: 'impl',
+      dependsOn: ['harness-suite'],
+      task: `Fix any harness test suite failures.
+
+Output:
+{{steps.harness-suite.output}}
+
+If green, do nothing. Else fix and re-run:
+  npm test -w @agent-assistant/harness
+End with HARNESS_SUITE_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('harness-suite-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-harness-suite'],
+      command: 'npm test -w @agent-assistant/harness 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('workspace-regression', {
+      type: 'deterministic',
+      dependsOn: ['harness-suite-final'],
+      command: 'npm test --workspaces --if-present 2>&1 | tail -120',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('fix-workspace-regression', {
+      agent: 'impl',
+      dependsOn: ['workspace-regression'],
+      task: `Fix any workspace-wide test regressions caused by these changes.
+
+Output:
+{{steps.workspace-regression.output}}
+
+If green, do nothing.
+We added new exports without removing — most regressions will be unrelated. If a regression IS caused by our change, fix the root cause in @agent-assistant/harness, not the dependent. Re-run:
+  npm test --workspaces --if-present
+End with WORKSPACE_REGRESSION_FIXED.`,
+      verification: { type: 'exit_code' },
+    })
+
+    .step('workspace-regression-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-workspace-regression'],
+      command: 'npm test --workspaces --if-present 2>&1 | tail -40',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('bump-version', {
+      type: 'deterministic',
+      dependsOn: ['workspace-regression-final'],
+      command:
+        'node -e "const fs=require(\'node:fs\'); const path=\'packages/harness/package.json\'; const p=JSON.parse(fs.readFileSync(path,\'utf8\')); const [a,b,c]=p.version.split(\'.\'); const n=[a,b,Number(c)+1].join(\'.\'); console.log(\'Bumping \'+p.version+\' -> \'+n); p.version=n; fs.writeFileSync(path, JSON.stringify(p,null,2)+\'\\n\');"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('verify-changes', {
+      type: 'deterministic',
+      dependsOn: ['bump-version'],
+      command: 'git status --short && echo "--- DIFF SUMMARY ---" && git diff --stat',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .step('commit', {
+      type: 'deterministic',
+      dependsOn: ['verify-changes'],
+      command:
+        'git add packages/harness/src/router/types.ts packages/harness/src/router/openrouter-singleshot-adapter.ts packages/harness/src/router/openrouter-singleshot-adapter.test.ts packages/harness/src/router/tiered-runner.ts packages/harness/src/router/tiered-runner.test.ts packages/harness/src/index.ts packages/harness/package.json && git commit -m "feat(harness): add tiered router (Router, SingleShotAdapter, createTieredRunner)"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('push-branch', {
+      type: 'deterministic',
+      dependsOn: ['commit'],
+      command:
+        'BRANCH=$(git rev-parse --abbrev-ref HEAD) && echo "Pushing $BRANCH" && git push -u origin "$BRANCH" 2>&1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('open-pr', {
+      type: 'deterministic',
+      dependsOn: ['push-branch'],
+      command:
+        'gh pr create --title "feat(harness): tiered router (Router + SingleShotAdapter + createTieredRunner)" --body "$(printf \'%s\\n\' \'## Summary\' \'- Add Router / RoutingDecision / RoutingTier interfaces — provider-neutral classifier contract.\' \'- Add SingleShotAdapter interface + OpenRouterSingleShotAdapter implementation — cheap one-shot model call with no tool loop, defaults to claude-haiku-4-5.\' \'- Add createTieredRunner that composes Router + SingleShotAdapter + HarnessRuntime to produce tiered execution (fast path bypasses tools; harness path drives the full loop; reject path returns a canned message).\' \'- Bump @agent-assistant/harness patch version.\' \'\' \'## Why\' \'The existing harness loop ships every request through the full model->tools->model iteration which is more expensive than the legacy plan-then-synthesize pattern by 3-5x. A tiered runner with a cheap classifier in front recovers the cost savings for the majority of casual or non-tool messages while keeping the harness for requests that genuinely need tool use. Concrete consumer (sage Slack handler) lands in a follow-up PR.\' \'\' \'## Validation\' \'- npm test -w @agent-assistant/harness: pass\' \'- npm test --workspaces --if-present: pass\' \'- npm run build -w @agent-assistant/harness: type-clean\' \'\' \'## Notes\' \'Publish manually after merge.\')"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('print-pr-url', {
+      type: 'deterministic',
+      dependsOn: ['open-pr'],
+      command: 'gh pr view --json url --jq .url',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/master-build-harness-primitives.ts
+++ b/workflows/master-build-harness-primitives.ts
@@ -1,0 +1,83 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+
+// Master executor:
+//   Wave 1 (parallel): build OpenRouter model adapter + Bash tool registry
+//   Wave 2: integrate (wire exports, regression, version bump, commit, PR)
+//
+// Each sub-workflow operates on the same cwd so file changes accumulate
+// in the worktree across waves.
+
+async function runWorkflow() {
+  const result = await workflow('master-build-harness-primitives')
+    .description(
+      'Master executor: builds the OpenRouter model adapter and Bash tool registry in parallel (wave 1), then integrates and opens a PR (wave 2). All sub-workflows operate in the same cwd.',
+    )
+    .pattern('dag')
+    .channel('wf-master-build-harness-primitives')
+    .maxConcurrency(2)
+    .timeout(7_200_000)
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'echo "Master executor starting in $(pwd)"',
+        'test -f packages/harness/package.json || (echo "Not in agent-assistant repo root"; exit 1)',
+        'test -f workflows/build-harness-openrouter-model-adapter.ts || (echo "Missing wave 1a workflow file"; exit 1)',
+        'test -f workflows/build-harness-bash-tool-registry.ts || (echo "Missing wave 1b workflow file"; exit 1)',
+        'test -f workflows/integrate-harness-primitives-and-pr.ts || (echo "Missing wave 2 workflow file"; exit 1)',
+        'command -v agent-relay >/dev/null || (echo "agent-relay CLI not on PATH"; exit 1)',
+        'command -v gh >/dev/null || (echo "gh CLI not on PATH"; exit 1)',
+        'echo "Preflight OK"',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Wave 1 (parallel): two independent builds ────────────────────
+    .step('wave1-openrouter-model-adapter', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command:
+        'LOG=$(mktemp) && agent-relay run workflows/build-harness-openrouter-model-adapter.ts > "$LOG" 2>&1; STATUS=$?; tail -200 "$LOG"; if [ "$STATUS" -ne 0 ] || grep -q "Workflow status: failed" "$LOG"; then echo "WAVE 1A FAILED"; exit 1; fi; echo "WAVE 1A OK"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('wave1-bash-tool-registry', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command:
+        'LOG=$(mktemp) && agent-relay run workflows/build-harness-bash-tool-registry.ts > "$LOG" 2>&1; STATUS=$?; tail -200 "$LOG"; if [ "$STATUS" -ne 0 ] || grep -q "Workflow status: failed" "$LOG"; then echo "WAVE 1B FAILED"; exit 1; fi; echo "WAVE 1B OK"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Wave 2: integration + PR ─────────────────────────────────────
+    .step('wave2-integrate-and-pr', {
+      type: 'deterministic',
+      dependsOn: ['wave1-openrouter-model-adapter', 'wave1-bash-tool-registry'],
+      command:
+        'LOG=$(mktemp) && agent-relay run workflows/integrate-harness-primitives-and-pr.ts > "$LOG" 2>&1; STATUS=$?; tail -300 "$LOG"; if [ "$STATUS" -ne 0 ] || grep -q "Workflow status: failed" "$LOG"; then echo "WAVE 2 FAILED"; exit 1; fi; echo "WAVE 2 OK"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('summary', {
+      type: 'deterministic',
+      dependsOn: ['wave2-integrate-and-pr'],
+      command:
+        'echo "=== HARNESS PRIMITIVES MIGRATION COMPLETE ===" && echo "PR:" && gh pr view --json url --jq .url 2>&1 || echo "(PR URL unavailable)"',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .onError('fail-fast')
+    .run({ cwd: process.cwd() });
+
+  console.log('Master workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/master-build-tiered-router.ts
+++ b/workflows/master-build-tiered-router.ts
@@ -1,0 +1,82 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+
+// Master executor for tiered router primitives:
+//   Wave 1: types + SingleShotAdapter (must complete before tiered-runner)
+//   Wave 2: createTieredRunner (depends on wave 1's types)
+//   Wave 3: integrate exports + regression + version bump + PR
+//
+// Each sub-workflow runs in the same cwd so file changes accumulate
+// in the worktree across waves.
+
+async function runWorkflow() {
+  const result = await workflow('master-build-tiered-router')
+    .description(
+      'Master executor: builds Router/SingleShotAdapter types + OpenRouterSingleShotAdapter (wave 1), then createTieredRunner (wave 2, depends on wave 1 types), then integrates and opens a PR (wave 3).',
+    )
+    .pattern('dag')
+    .channel('wf-master-build-tiered-router')
+    .maxConcurrency(2)
+    .timeout(7_200_000)
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'echo "Master executor starting in $(pwd)"',
+        'test -f packages/harness/package.json || (echo "Not in agent-assistant repo root"; exit 1)',
+        'test -f workflows/build-router-types-and-singleshot.ts || (echo "Missing wave 1 workflow"; exit 1)',
+        'test -f workflows/build-tiered-runner.ts || (echo "Missing wave 2 workflow"; exit 1)',
+        'test -f workflows/integrate-tiered-router-and-pr.ts || (echo "Missing wave 3 workflow"; exit 1)',
+        'command -v agent-relay >/dev/null || (echo "agent-relay CLI not on PATH"; exit 1)',
+        'command -v gh >/dev/null || (echo "gh CLI not on PATH"; exit 1)',
+        'echo "Preflight OK"',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('wave1-router-types-and-singleshot', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command:
+        'LOG=$(mktemp) && agent-relay run workflows/build-router-types-and-singleshot.ts > "$LOG" 2>&1; STATUS=$?; tail -300 "$LOG"; if [ "$STATUS" -ne 0 ] || grep -q "Workflow status: failed" "$LOG"; then echo "WAVE 1 FAILED"; exit 1; fi; echo "WAVE 1 OK"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('wave2-tiered-runner', {
+      type: 'deterministic',
+      dependsOn: ['wave1-router-types-and-singleshot'],
+      command:
+        'LOG=$(mktemp) && agent-relay run workflows/build-tiered-runner.ts > "$LOG" 2>&1; STATUS=$?; tail -300 "$LOG"; if [ "$STATUS" -ne 0 ] || grep -q "Workflow status: failed" "$LOG"; then echo "WAVE 2 FAILED"; exit 1; fi; echo "WAVE 2 OK"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('wave3-integrate-and-pr', {
+      type: 'deterministic',
+      dependsOn: ['wave2-tiered-runner'],
+      command:
+        'LOG=$(mktemp) && agent-relay run workflows/integrate-tiered-router-and-pr.ts > "$LOG" 2>&1; STATUS=$?; tail -300 "$LOG"; if [ "$STATUS" -ne 0 ] || grep -q "Workflow status: failed" "$LOG"; then echo "WAVE 3 FAILED"; exit 1; fi; echo "WAVE 3 OK"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('summary', {
+      type: 'deterministic',
+      dependsOn: ['wave3-integrate-and-pr'],
+      command:
+        'echo "=== TIERED ROUTER MIGRATION COMPLETE ===" && echo "PR:" && gh pr view --json url --jq .url 2>&1 || echo "(PR URL unavailable)"',
+      captureOutput: true,
+      failOnError: false,
+    })
+
+    .onError('fail-fast')
+    .run({ cwd: process.cwd() });
+
+  console.log('Master workflow status:', result.status);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds the agent-relay workflow files used to build, integrate, and PR two distinct sets of `@agent-assistant/harness` primitives. Authored alongside the actual primitive PRs but never tracked in main; this PR commits them so they can be re-run, audited, and evolved over time.

## Two sets

### Set 1 — harness primitives (already shipped via PR #19)
- `workflows/build-harness-openrouter-model-adapter.ts` — OpenRouter `HarnessModelAdapter` with tool-call support (distinct from the no-tool `OpenRouterExecutionAdapter` proof slice)
- `workflows/build-harness-bash-tool-registry.ts` — `HarnessToolRegistry` exposing one allowlist-gated `bash` tool
- `workflows/integrate-harness-primitives-and-pr.ts` — wires exports, runs regression, bumps version, opens PR
- `workflows/master-build-harness-primitives.ts` — orchestrates the three sub-workflows in waves
- `scripts/run-build-harness-primitives.sh` — worktree wrapper

### Set 2 — tiered router (ready to run)
- `workflows/build-router-types-and-singleshot.ts` — `Router` / `SingleShotAdapter` / `TieredRunner` type interfaces + `OpenRouterSingleShotAdapter` implementation
- `workflows/build-tiered-runner.ts` — `createTieredRunner` factory composing Router + SingleShotAdapter + HarnessRuntime
- `workflows/integrate-tiered-router-and-pr.ts` — wires exports, regression, bump, PR
- `workflows/master-build-tiered-router.ts` — orchestrates the three sub-workflows
- `scripts/run-build-tiered-router.sh` — worktree wrapper

## Why tiered router

The harness loop costs ~3-5x more per request than the legacy plan-then-synthesize path. A tiered runner with a cheap classifier in front recovers the cost savings for casual messages while keeping the harness on requests that genuinely need tool use. The sage Slack handler is the first concrete consumer; landing in a follow-up PR.

## Notes

- All masters wrap sub-workflow invocations with a tempfile-capture pattern that explicitly checks both the `agent-relay run` exit status AND grep for `"Workflow status: failed"`. Without this, sub-workflow failures get silently masked because `agent-relay run` returns 0 even on failure (hit this bug on the first sage Wave 2 run — the master reported success while the inner workflow had skipped all its work).
- The verify-installed steps use dynamic `import()` because `@agent-assistant/harness` only exposes ESM exports — `require()` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Validation

- `agent-relay run --dry-run` passes on all four workflows (no errors, no warnings)
- The harness-primitives set was already exercised live and produced #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
