### PR TITLE
feat(surfaces): add Slack ingress classifier

### DIFF
--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -33,3 +33,9 @@ export type {
   ThreadGateDropReason,
   ThreadGateEvent,
 } from "./slack-thread-gate.js";
+
+export { classifySlackIngressEvent } from "./slack-ingress.js";
+export type {
+  SlackIngressClassification,
+  SlackIngressKind,
+} from "./slack-ingress.js";

--- a/packages/surfaces/src/slack-ingress.test.ts
+++ b/packages/surfaces/src/slack-ingress.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifySlackIngressEvent } from './slack-ingress.js';
+
+describe('classifySlackIngressEvent', () => {
+  it('classifies app mentions', () => {
+    expect(
+      classifySlackIngressEvent({
+        type: 'event_callback',
+        team_id: 'T1',
+        event: { type: 'app_mention', channel: 'C1', user: 'U1', text: '<@U_SAGE> hi', ts: '1.1' },
+      }),
+    ).toMatchObject({ kind: 'mention', channel: 'C1', userId: 'U1', teamId: 'T1', ts: '1.1' });
+  });
+
+  it('classifies direct messages', () => {
+    expect(
+      classifySlackIngressEvent({
+        type: 'event_callback',
+        team_id: 'T1',
+        event: { type: 'message', channel_type: 'im', channel: 'D1', user: 'U1', text: 'hi', ts: '2.1' },
+      }),
+    ).toMatchObject({ kind: 'direct_message', channel: 'D1', userId: 'U1' });
+  });
+
+  it('classifies thread replies', () => {
+    expect(
+      classifySlackIngressEvent({
+        type: 'event_callback',
+        team_id: 'T1',
+        event: { type: 'message', channel: 'C1', user: 'U1', text: 'follow up', ts: '3.2', thread_ts: '3.1' },
+      }),
+    ).toMatchObject({ kind: 'thread_reply', channel: 'C1', threadTs: '3.1' });
+  });
+
+  it('ignores bot messages', () => {
+    expect(
+      classifySlackIngressEvent({
+        type: 'event_callback',
+        event: { type: 'message', subtype: 'bot_message', channel: 'C1', text: 'hi' },
+      }),
+    ).toMatchObject({ kind: 'ignore' });
+  });
+});

--- a/packages/surfaces/src/slack-ingress.ts
+++ b/packages/surfaces/src/slack-ingress.ts
@@ -1,0 +1,66 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+export type SlackIngressKind = 'mention' | 'direct_message' | 'thread_reply' | 'channel_message' | 'ignore';
+
+export interface SlackIngressClassification {
+  kind: SlackIngressKind;
+  channel?: string;
+  userId?: string;
+  teamId?: string;
+  threadTs?: string;
+  ts?: string;
+  text?: string;
+}
+
+export function classifySlackIngressEvent(payload: unknown): SlackIngressClassification {
+  if (!isRecord(payload) || payload.type !== 'event_callback' || !isRecord(payload.event)) {
+    return { kind: 'ignore' };
+  }
+
+  const event = payload.event;
+  const eventType = asString(event.type);
+  const subtype = asString(event.subtype);
+  const channelType = asString(event.channel_type);
+  const ts = asString(event.ts);
+  const threadTs = asString(event.thread_ts);
+  const base = {
+    channel: asString(event.channel),
+    userId: asString(event.user),
+    teamId: asString(payload.team_id) ?? asString(event.team),
+    threadTs,
+    ts,
+    text: asString(event.text),
+  };
+
+  if (subtype === 'bot_message' || subtype === 'message_changed' || subtype === 'message_deleted') {
+    return { kind: 'ignore', ...base };
+  }
+
+  if ((typeof event.bot_id === 'string' && event.bot_id.length > 0) || isRecord(event.bot_profile)) {
+    return { kind: 'ignore', ...base };
+  }
+
+  if (eventType === 'app_mention') {
+    return { kind: 'mention', ...base };
+  }
+
+  if (eventType === 'message' && channelType === 'im' && !subtype) {
+    return { kind: 'direct_message', ...base };
+  }
+
+  if (eventType === 'message' && threadTs && !subtype) {
+    return { kind: 'thread_reply', ...base };
+  }
+
+  if (eventType === 'message' && !threadTs && !subtype) {
+    return { kind: 'channel_message', ...base };
+  }
+
+  return { kind: 'ignore', ...base };
+}


### PR DESCRIPTION
## Summary\n- add a reusable Slack ingress classifier to @agent-assistant/surfaces\n- classify mentions, direct messages, thread replies, channel messages, and ignored events\n- keep product policy separate from classification while aligning with SlackThreadGate\n\n## Validation\n- npx vitest run packages/surfaces/src/slack-thread-gate.test.ts packages/surfaces/src/slack-ingress.test.ts