### PR TITLE
fix(harness): move proof exports off runtime surface

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./proof": {
+      "import": "./dist/proof.js",
+      "types": "./dist/proof.d.ts"
     }
   },
   "files": [

--- a/packages/harness/src/adapter/index.ts
+++ b/packages/harness/src/adapter/index.ts
@@ -1,16 +1,6 @@
 export { ClaudeCodeExecutionAdapter, createClaudeCodeAdapter } from './claude-code-adapter.js';
 export { OpenRouterExecutionAdapter, createOpenRouterAdapter } from './openrouter-adapter.js';
-export { createAgentRelayProofTransport, runByohLocalProof } from './proof/byoh-local-proof.js';
-export { createValidationSpecialist } from './proof/validation-specialist.js';
 
-export type {
-  ByohLocalProofConfig,
-  ByohLocalProofResult,
-  ByohProofScenario,
-  ProofTurnContextAssembler,
-  ProofRelayTransport,
-} from './proof/byoh-local-proof.js';
-export type { ValidationSpecialistConfig } from './proof/validation-specialist.js';
 export type {
   ExecutionAdapter,
   ExecutionCapabilities,

--- a/packages/harness/src/proof.ts
+++ b/packages/harness/src/proof.ts
@@ -1,0 +1,11 @@
+export { createAgentRelayProofTransport, runByohLocalProof } from './adapter/proof/byoh-local-proof.js';
+export { createValidationSpecialist } from './adapter/proof/validation-specialist.js';
+
+export type {
+  ByohLocalProofConfig,
+  ByohLocalProofResult,
+  ByohProofScenario,
+  ProofTurnContextAssembler,
+  ProofRelayTransport,
+} from './adapter/proof/byoh-local-proof.js';
+export type { ValidationSpecialistConfig } from './adapter/proof/validation-specialist.js';


### PR DESCRIPTION
## Summary\n- keep the root  export surface runtime-safe\n- restore proof utilities behind a dedicated  subpath\n- avoid pulling worker-incompatible proof modules into downstream worker bundles while preserving internal proof/dev functionality\n\n## Validation\n- npm --prefix packages/routing run build\n- npm --prefix packages/connectivity run build\n- npm --prefix packages/coordination run build\n- npm run build -w @agent-assistant/traits\n- npm run build -w @agent-assistant/turn-context\n- npx vitest run packages/harness/src/harness.test.ts packages/harness/src/adapter/claude-code-adapter.test.ts packages/harness/src/adapter/openrouter-adapter.test.ts packages/harness/src/router/tiered-runner.test.ts\n- npm run build -w @agent-assistant/harness\n\n## Export shape\n- runtime-safe root surface: \n- proof/dev surface: \n\n## Why this matters\nThis preserves proof capabilities without leaving worker-incompatible proof modules on the main runtime export path that downstream worker bundles consume.