### PR TITLE
fix(harness): classify empty OpenRouter responses explicitly

### DIFF
--- a/packages/harness/src/adapter/openrouter-model-adapter.test.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.test.ts
@@ -230,4 +230,32 @@ describe('OpenRouterModelAdapter', () => {
       expect(result.reason.toUpperCase()).toContain('JSON');
     }
   });
+
+  it('case 10: missing response message returns invalid with explicit reason', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({ choices: [{}] }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('invalid');
+    if (result.type === 'invalid') {
+      expect(result.reason).toContain('did not include a message choice');
+    }
+  });
+
+  it('case 11: empty assistant content returns invalid with explicit reason', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: '   ' } }],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    const result = await adapter.nextStep(makeInput());
+
+    expect(result.type).toBe('invalid');
+    if (result.type === 'invalid') {
+      expect(result.reason).toContain('usable assistant content');
+    }
+  });
 });

--- a/packages/harness/src/adapter/openrouter-model-adapter.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.ts
@@ -183,6 +183,15 @@ function mapUsage(raw: OpenRouterResponseBody['usage']): HarnessUsage | undefine
   return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
+function normalizeFinalAnswerText(content: string | null | undefined): string | null {
+  if (typeof content !== 'string') {
+    return null;
+  }
+
+  const trimmed = content.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export class OpenRouterModelAdapter implements HarnessModelAdapter {
   private readonly apiKey?: string;
   private readonly model: string;
@@ -234,8 +243,18 @@ export class OpenRouterModelAdapter implements HarnessModelAdapter {
       }
 
       const usage = mapUsage(body.usage);
-      const message = body.choices?.[0]?.message;
+      const choice = body.choices?.[0];
+      const message = choice?.message;
       const rawToolCalls = message?.tool_calls;
+
+      if (!choice || !message) {
+        return {
+          type: 'invalid',
+          reason: 'OpenRouter response did not include a message choice',
+          raw: body,
+          ...(usage ? { usage } : {}),
+        };
+      }
 
       if (rawToolCalls && rawToolCalls.length > 0) {
         const calls: HarnessToolCall[] = [];
@@ -251,7 +270,16 @@ export class OpenRouterModelAdapter implements HarnessModelAdapter {
         return { type: 'tool_request', calls, ...(usage ? { usage } : {}) };
       }
 
-      const text = message?.content ?? '';
+      const text = normalizeFinalAnswerText(message.content);
+      if (!text) {
+        return {
+          type: 'invalid',
+          reason: 'OpenRouter response did not include usable assistant content',
+          raw: body,
+          ...(usage ? { usage } : {}),
+        };
+      }
+
       return { type: 'final_answer', text, ...(usage ? { usage } : {}) };
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -251,6 +251,7 @@ describe('harness runtime', () => {
     const result = await harness.runTurn(createInput());
     expect(result.outcome).toBe('failed');
     expect(result.stopReason).toBe('model_invalid_response');
+    expect(result.metadata?.reason).toBe('still bad');
   });
 
   it('defers when max iterations is reached', async () => {


### PR DESCRIPTION
## Summary
- classify missing OpenRouter message choices as explicit invalid outputs
- classify blank assistant content as explicit invalid outputs
- preserve clearer invalid-response reasons through harness regression coverage

## Testing
- npx vitest run packages/harness/src/adapter/openrouter-model-adapter.test.ts packages/harness/src/harness.test.ts

## Notes
- full `npm run build -w @agent-assistant/harness` in this clean worktree still hits pre-existing proof-package workspace resolution issues unrelated to this patch