### PR TITLE
feat(harness): serialize HarnessContext.blocks in OpenRouter model adapter

### DIFF
--- a/packages/harness/src/adapter/openrouter-model-adapter.test.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.test.ts
@@ -259,3 +259,116 @@ describe('OpenRouterModelAdapter', () => {
     }
   });
 });
+
+describe('OpenRouterModelAdapter context request mapping', () => {
+  it('includes every context block label and body text in a system message', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    await adapter.nextStep(
+      makeInput({
+        instructions: {
+          systemPrompt: 'You are a bot.',
+          developerPrompt: 'Use the supplied context.',
+        },
+        context: {
+          blocks: [
+            { id: 'b1', label: 'customer-profile', content: 'Customer prefers concise replies.' },
+            { id: 'b2', label: 'recent-ticket', content: 'The last ticket mentioned Slack sync.' },
+          ],
+        },
+        message: { id: 'm1', text: 'What should I do next?', receivedAt: '2024-01-01T00:00:00Z' },
+      }),
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    const messages: Array<{ role: string; content: string }> = body.messages;
+    const developerPromptIndex = messages.findIndex(
+      (message) => message.role === 'system' && message.content === 'Use the supplied context.',
+    );
+    const contextMessageIndex = messages.findIndex(
+      (message) => message.role === 'system' && message.content.includes('Conversation context:'),
+    );
+    const userMessageIndex = messages.findIndex(
+      (message) => message.role === 'user' && message.content === 'What should I do next?',
+    );
+
+    expect(contextMessageIndex).toBeGreaterThan(developerPromptIndex);
+    expect(contextMessageIndex).toBeLessThan(userMessageIndex);
+    expect(messages[contextMessageIndex].content).toContain('customer-profile');
+    expect(messages[contextMessageIndex].content).toContain('Customer prefers concise replies.');
+    expect(messages[contextMessageIndex].content).toContain('recent-ticket');
+    expect(messages[contextMessageIndex].content).toContain('The last ticket mentioned Slack sync.');
+  });
+
+  it('does not add a context system message when input.context is undefined', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    await adapter.nextStep(
+      makeInput({
+        instructions: {
+          systemPrompt: 'You are a bot.',
+          developerPrompt: 'Be concise.',
+        },
+      }),
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    const messages: Array<{ role: string; content: string }> = body.messages;
+    const systemMessages = messages.filter((message) => message.role === 'system');
+
+    expect(systemMessages).toHaveLength(2);
+    expect(systemMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: 'You are a bot.' }),
+        expect.objectContaining({ content: 'Be concise.' }),
+      ]),
+    );
+    expect(systemMessages.some((message) => message.content.includes('Conversation context:'))).toBe(
+      false,
+    );
+    expect(systemMessages.some((message) => message.content.includes('Structured context:'))).toBe(
+      false,
+    );
+  });
+
+  it('includes serialized structured context JSON in a system message', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeOkResponse({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    );
+    const structured = {
+      customer: { tier: 'enterprise', region: 'us-east' },
+      flags: ['slack-sync', 'priority'],
+    };
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+    await adapter.nextStep(
+      makeInput({
+        context: {
+          blocks: [],
+          structured,
+        },
+      }),
+    );
+
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    const messages: Array<{ role: string; content: string }> = body.messages;
+    const structuredMessage = messages.find(
+      (message) => message.role === 'system' && message.content.includes('Structured context:'),
+    );
+
+    expect(structuredMessage).toBeDefined();
+    expect(structuredMessage?.content).toContain(JSON.stringify(structured, null, 2));
+  });
+});

--- a/packages/harness/src/adapter/openrouter-model-adapter.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.ts
@@ -146,6 +146,30 @@ function buildTranscriptMessages(transcript: HarnessTranscriptItem[]): ChatMessa
   return messages;
 }
 
+function renderContext(ctx: HarnessModelInput['context']): string | null {
+  if (!ctx) {
+    return null;
+  }
+
+  const sections: string[] = [];
+  const blocks = ctx.blocks ?? [];
+
+  if (blocks.length > 0) {
+    const lines = blocks.map((block) => {
+      const label = block.label ? `[${block.label}] ` : '';
+      const body = block.content ?? '';
+      return `- ${label}${body}`;
+    });
+    sections.push(`Conversation context:\n${lines.join('\n')}`);
+  }
+
+  if (ctx.structured && Object.keys(ctx.structured).length > 0) {
+    sections.push(`Structured context:\n${JSON.stringify(ctx.structured, null, 2)}`);
+  }
+
+  return sections.length > 0 ? sections.join('\n\n') : null;
+}
+
 function buildRequestBody(
   input: HarnessModelInput,
   model: string,
@@ -157,6 +181,11 @@ function buildRequestBody(
 
   if (input.instructions.developerPrompt?.trim()) {
     messages.push({ role: 'system', content: input.instructions.developerPrompt });
+  }
+
+  const contextText = renderContext(input.context);
+  if (contextText) {
+    messages.push({ role: 'system', content: contextText });
   }
 
   messages.push(...buildTranscriptMessages(input.transcript));


### PR DESCRIPTION
## Summary
- OpenRouterModelAdapter previously built (system + developerPrompt + transcript + user.text) and dropped input.context.blocks on the floor.
- Surfaces that encoded conversation history as context blocks — notably Sage slack-runner — never reached the model.
- This renders blocks (and structured context) into a system message placed after developerPrompt and before the transcript.

## Validation
- New unit tests cover the blocks path, the empty-context path, and structured context.
- Full @agent-assistant/harness vitest suite passes.
- Validated end-to-end against sage via file: link in the sage worktree.

## Release
This PR is source + tests only. Trigger the Publish Packages workflow (workflow_dispatch, package_group=runtime-core, version=patch) after merge to ship @agent-assistant/harness@0.2.12.

🤖 Generated with workflow sage-slack-fix/01-harness-context-blocks.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
