### PR TITLE
feat(byoh): add reusable local harness primitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -317,6 +317,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3456,7 +3457,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3468,34 +3469,18 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "dependencies": {
-        "@agent-assistant/harness": "^0.1.3"
+        "@agent-assistant/harness": "^0.3.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
     },
-    "packages/continuation/node_modules/@agent-assistant/core": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.1.5.tgz",
-      "integrity": "sha512-Y4Wbo4Qwls1a8Xl+jpjCclTCPsSeT3snZhxnMVUj/9sC0Em4WNYNv0QooNZs9lPDph+cJXw+pE18lfGmqle43w==",
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/continuation/node_modules/@agent-assistant/harness": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.1.5.tgz",
-      "integrity": "sha512-Fd/2WHf7+8Ru1hq7AliyxERZkgiP25qNqxKuymMktdqNp8dj5G8xn5dewgVxY3aIyk/3/Uxbb22hriJOMhB3yA==",
-      "dependencies": {
-        "@agent-assistant/core": "^0.1.3"
-      }
-    },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3509,7 +3494,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3529,7 +3514,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.2.12",
+      "version": "0.3.2",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3554,7 +3539,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4342,7 +4327,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4354,7 +4339,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -5134,7 +5119,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.7"
@@ -5155,7 +5140,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -5172,7 +5157,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5180,7 +5165,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.2.11",
+      "version": "0.3.1",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -5194,7 +5179,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5202,9 +5187,9 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
-        "@agent-assistant/harness": "^0.2.11"
+        "@agent-assistant/harness": "^0.3.0"
       },
       "devDependencies": {
         "@types/node": "^24.6.0",
@@ -5214,7 +5199,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5223,32 +5208,16 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.11",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
-        "@agent-assistant/harness": "^0.1.3",
+        "@agent-assistant/harness": "^0.3.0",
         "@agent-assistant/memory": "^0.1.0",
         "@agent-assistant/traits": "^0.1.3"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/core": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.1.5.tgz",
-      "integrity": "sha512-Y4Wbo4Qwls1a8Xl+jpjCclTCPsSeT3snZhxnMVUj/9sC0Em4WNYNv0QooNZs9lPDph+cJXw+pE18lfGmqle43w==",
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/harness": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.1.5.tgz",
-      "integrity": "sha512-Fd/2WHf7+8Ru1hq7AliyxERZkgiP25qNqxKuymMktdqNp8dj5G8xn5dewgVxY3aIyk/3/Uxbb22hriJOMhB3yA==",
-      "dependencies": {
-        "@agent-assistant/core": "^0.1.3"
       }
     },
     "packages/turn-context/node_modules/@agent-assistant/memory": {
@@ -5268,7 +5237,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.11",
+      "version": "0.2.13",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -182,13 +182,59 @@ Do **not** treat it as a replacement for:
 - Relay-native collaboration
 - future tool-capable hosted execution work
 
+## Local command execution adapter
+
+The harness package also exposes a reusable `LocalCommandExecutionAdapter` for BYOH/local
+CLI execution. It is product-neutral: products keep assistant identity, policy, memory, and
+turn-context assembly, while the adapter owns only local process invocation and result
+normalization.
+
+Use it when a local harness can be represented as:
+- a command to spawn
+- an argv builder from `ExecutionRequest`
+- an output parser into normalized assistant output
+- declared `ExecutionCapabilities`
+
+```ts
+import {
+  LocalCommandExecutionAdapter,
+  type ExecutionRequest,
+} from '@agent-assistant/harness';
+
+const adapter = new LocalCommandExecutionAdapter({
+  backendId: 'my-local-harness',
+  command: 'my-harness',
+  capabilities: {
+    toolUse: 'adapter-mediated',
+    structuredToolCalls: true,
+    continuationSupport: 'none',
+    approvalInterrupts: 'none',
+    traceDepth: 'minimal',
+    attachments: false,
+  },
+  buildArgs(request: ExecutionRequest) {
+    return ['--json', '--prompt', request.message.text];
+  },
+  parseOutput(stdout) {
+    const parsed = JSON.parse(stdout) as { text?: string };
+    return parsed.text ? { text: parsed.text } : null;
+  },
+});
+```
+
+`ClaudeCodeExecutionAdapter` is now a preset over this same local-command primitive. That keeps
+Claude Code support intact while allowing other local harnesses to use the same
+`ExecutionAdapter` contract.
+
 ## Public API
 
 ```ts
 import {
   HarnessConfigError,
+  LocalCommandExecutionAdapter,
   OpenRouterExecutionAdapter,
   createHarness,
+  createLocalCommandAdapter,
   createOpenRouterAdapter,
   type ExecutionAdapter,
   type ExecutionRequest,

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -226,13 +226,40 @@ const adapter = new LocalCommandExecutionAdapter({
 Claude Code support intact while allowing other local harnesses to use the same
 `ExecutionAdapter` contract.
 
+## Agent Relay execution adapter
+
+For long-lived local harnesses, `AgentRelayExecutionAdapter` uses Agent Relay as the local
+control plane. It publishes a typed execution request to a Relay worker and waits for a typed
+execution result on the same thread.
+
+```ts
+import {
+  AgentRelayExecutionAdapter,
+} from '@agent-assistant/harness';
+
+const adapter = new AgentRelayExecutionAdapter({
+  cwd: process.cwd(),
+  channelId: 'nightcto-local-byoh',
+  workerName: 'nightcto-local-harness',
+  orchestratorName: 'nightcto-local-chat',
+});
+```
+
+The request message body is JSON with type `agent-assistant.execution-request.v1`.
+Workers reply with JSON type `agent-assistant.execution-result.v1` and an `executionResult`
+that follows the normal `ExecutionResult` contract. This keeps Claude Code, Codex, OpenCode,
+or a custom local worker behind Relay instead of baking provider-specific CLI argv into the
+product.
+
 ## Public API
 
 ```ts
 import {
+  AgentRelayExecutionAdapter,
   HarnessConfigError,
   LocalCommandExecutionAdapter,
   OpenRouterExecutionAdapter,
+  createAgentRelayExecutionAdapter,
   createHarness,
   createLocalCommandAdapter,
   createOpenRouterAdapter,

--- a/packages/harness/dist/harness.js
+++ b/packages/harness/dist/harness.js
@@ -87,6 +87,7 @@ async function runTurn(config, input) {
             ? await config.tools.listAvailable({
                 assistantId: input.assistantId,
                 turnId: input.turnId,
+                workspaceId: input.workspaceId,
                 sessionId: input.sessionId,
                 userId: input.userId,
                 allowedToolNames: input.allowedToolNames,
@@ -102,6 +103,7 @@ async function runTurn(config, input) {
             const modelInput = {
                 assistantId: input.assistantId,
                 turnId: input.turnId,
+                workspaceId: input.workspaceId,
                 sessionId: input.sessionId,
                 userId: input.userId,
                 threadId: input.threadId,
@@ -175,6 +177,7 @@ async function runTurn(config, input) {
                         ? await config.approvals.prepareRequest({
                             assistantId: input.assistantId,
                             turnId: input.turnId,
+                            workspaceId: input.workspaceId,
                             sessionId: input.sessionId,
                             userId: input.userId,
                             request: output.request,
@@ -234,6 +237,7 @@ async function runTurn(config, input) {
                         const result = await config.tools.execute(call, {
                             assistantId: input.assistantId,
                             turnId: input.turnId,
+                            workspaceId: input.workspaceId,
                             sessionId: input.sessionId,
                             userId: input.userId,
                             threadId: input.threadId,
@@ -368,6 +372,7 @@ function executionState(input, state, startedAt, config) {
     return {
         assistantId: input.assistantId,
         turnId: input.turnId,
+        workspaceId: input.workspaceId,
         sessionId: input.sessionId,
         userId: input.userId,
         threadId: input.threadId,
@@ -479,6 +484,7 @@ async function emit(config, input, state, partial) {
         timestamp: config.clock.nowIso(),
         assistantId: input.assistantId,
         turnId: input.turnId,
+        workspaceId: input.workspaceId,
         sessionId: input.sessionId,
         iteration: state.iteration,
         toolCallCount: state.toolCallCount,
@@ -499,6 +505,7 @@ async function emitFinishedSafely(config, input, state, result) {
             timestamp: config.clock.nowIso(),
             assistantId: input.assistantId,
             turnId: input.turnId,
+            workspaceId: input.workspaceId,
             sessionId: input.sessionId,
             iteration: state.iteration,
             toolCallCount: state.toolCallCount,

--- a/packages/harness/dist/types.d.ts
+++ b/packages/harness/dist/types.d.ts
@@ -20,6 +20,7 @@ export interface HarnessLimits {
 export interface HarnessTurnInput {
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     userId?: string;
     threadId?: string;
@@ -67,6 +68,7 @@ export interface HarnessModelAdapter {
 export interface HarnessModelInput {
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     userId?: string;
     threadId?: string;
@@ -126,6 +128,7 @@ export interface HarnessToolRegistry {
 export interface HarnessToolAvailabilityInput {
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     userId?: string;
     allowedToolNames?: string[];
@@ -145,6 +148,7 @@ export interface HarnessToolCall {
 export interface HarnessToolExecutionContext {
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     userId?: string;
     threadId?: string;
@@ -173,6 +177,7 @@ export interface HarnessApprovalAdapter {
 export interface HarnessApprovalRequestInput {
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     userId?: string;
     request: HarnessApprovalRequest;
@@ -267,6 +272,7 @@ export interface HarnessBaseTraceEvent {
     timestamp: string;
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     iteration?: number;
     toolCallCount?: number;
@@ -325,6 +331,7 @@ export interface HarnessHooks {
 export interface HarnessExecutionState {
     assistantId: string;
     turnId: string;
+    workspaceId?: string;
     sessionId?: string;
     userId?: string;
     threadId?: string;

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/adapter/agent-relay-adapter.test.ts
+++ b/packages/harness/src/adapter/agent-relay-adapter.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest';
+import type { BrokerEvent, RelaySpawnRequest, SendMessageInput } from '@agent-relay/sdk';
+
+import {
+  AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+  AGENT_RELAY_EXECUTION_RESULT_TYPE,
+  AgentRelayExecutionAdapter,
+} from './agent-relay-adapter.js';
+import type { AgentRelayExecutionTransport } from './agent-relay-adapter.js';
+import type { ExecutionRequest, ExecutionResult } from './types.js';
+
+function baseRequest(): ExecutionRequest {
+  return {
+    assistantId: 'assistant-1',
+    turnId: 'turn-1',
+    threadId: 'thread-1',
+    message: {
+      id: 'msg-1',
+      text: 'Inspect local deployment state.',
+      receivedAt: '2026-04-21T10:00:00.000Z',
+    },
+    instructions: {
+      systemPrompt: 'You are Sage.',
+      developerPrompt: 'Use the local harness.',
+    },
+    tools: [{ name: 'Bash(git status:*)', description: 'Inspect repo status.' }],
+    requirements: {
+      toolUse: 'allowed',
+      structuredToolCalls: 'preferred',
+      traceDepth: 'standard',
+      attachments: 'forbidden',
+    },
+  };
+}
+
+class FakeRelayTransport implements AgentRelayExecutionTransport {
+  started = false;
+  sent: SendMessageInput[] = [];
+  spawned: RelaySpawnRequest[] = [];
+  agents: Array<{ name: string }> = [];
+  private listeners: Array<(event: BrokerEvent) => void> = [];
+
+  constructor(private readonly options: {
+    respond?: boolean;
+    failSend?: boolean;
+    failSpawn?: boolean;
+  } = {}) {}
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+
+  async sendMessage(input: SendMessageInput): Promise<{ event_id: string; targets: string[] }> {
+    if (this.options.failSend) {
+      throw new Error('publish failed');
+    }
+
+    this.sent.push(input);
+    if (this.options.respond ?? true) {
+      const requestMessage = JSON.parse(input.text) as { turnId: string; threadId: string };
+      queueMicrotask(() => {
+        this.emit({
+          kind: 'relay_inbound',
+          event_id: 'evt-result-1',
+          from: 'local-worker',
+          target: input.from ?? 'agent-assistant',
+          thread_id: input.threadId,
+          body: JSON.stringify({
+            type: AGENT_RELAY_EXECUTION_RESULT_TYPE,
+            turnId: requestMessage.turnId,
+            threadId: requestMessage.threadId,
+            executionResult: {
+              backendId: 'worker-backend',
+              status: 'completed',
+              output: {
+                text: 'Relay worker completed the turn.',
+              },
+            } satisfies ExecutionResult,
+          }),
+        });
+      });
+    }
+
+    return { event_id: 'evt-request-1', targets: [input.to] };
+  }
+
+  onEvent(listener: (event: BrokerEvent) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index >= 0) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  async listAgents(): Promise<Array<{ name: string }>> {
+    return this.agents;
+  }
+
+  async spawn(request: RelaySpawnRequest): Promise<{ success: boolean; name: string }> {
+    if (this.options.failSpawn) {
+      return { success: false, name: request.name };
+    }
+
+    this.spawned.push(request);
+    this.agents.push({ name: request.name });
+    return { success: true, name: request.name };
+  }
+
+  emit(event: BrokerEvent): void {
+    for (const listener of [...this.listeners]) {
+      listener(event);
+    }
+  }
+}
+
+describe('AgentRelayExecutionAdapter', () => {
+  it('publishes a typed execution request and maps a typed Relay result', async () => {
+    const relay = new FakeRelayTransport();
+    const adapter = new AgentRelayExecutionAdapter({
+      relay,
+      workerName: 'local-worker',
+      orchestratorName: 'nightcto',
+      channelId: 'nightcto-local',
+      now: () => new Date('2026-04-21T10:00:00.000Z').getTime(),
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(relay.started).toBe(true);
+    expect(relay.sent).toHaveLength(1);
+    expect(relay.sent[0]).toMatchObject({
+      to: 'local-worker',
+      from: 'nightcto',
+      threadId: 'thread-1',
+      data: {
+        type: AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+        turnId: 'turn-1',
+        threadId: 'thread-1',
+      },
+    });
+    expect(JSON.parse(relay.sent[0]!.text)).toMatchObject({
+      type: AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+      turnId: 'turn-1',
+      threadId: 'thread-1',
+      request: {
+        assistantId: 'assistant-1',
+        message: { text: 'Inspect local deployment state.' },
+      },
+      replyTo: {
+        agentId: 'nightcto',
+        channelId: 'nightcto-local',
+      },
+    });
+    expect(result).toMatchObject({
+      backendId: 'agent-relay',
+      status: 'completed',
+      output: {
+        text: 'Relay worker completed the turn.',
+      },
+      metadata: {
+        relay: {
+          workerBackendId: 'worker-backend',
+          channelId: 'nightcto-local',
+          target: 'local-worker',
+        },
+      },
+    });
+  });
+
+  it('auto-spawns the configured worker before publishing when requested', async () => {
+    const relay = new FakeRelayTransport();
+    const adapter = new AgentRelayExecutionAdapter({
+      relay,
+      workerName: 'local-worker',
+      spawnWorker: {
+        enabled: true,
+        cli: 'claude',
+        model: 'sonnet',
+      },
+    });
+
+    await adapter.execute(baseRequest());
+
+    expect(relay.spawned).toHaveLength(1);
+    expect(relay.spawned[0]).toMatchObject({
+      name: 'local-worker',
+      cli: 'claude',
+      model: 'sonnet',
+      includeWorkflowConventions: true,
+    });
+  });
+
+  it('maps Relay publish failures to retryable backend execution errors', async () => {
+    const adapter = new AgentRelayExecutionAdapter({
+      relay: new FakeRelayTransport({ failSend: true }),
+      timeoutMs: 50,
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('backend_execution_error');
+    expect(result.error?.retryable).toBe(true);
+  });
+
+  it('maps worker spawn failures to retryable backend execution errors', async () => {
+    const adapter = new AgentRelayExecutionAdapter({
+      relay: new FakeRelayTransport({ failSpawn: true }),
+      workerName: 'local-worker',
+      spawnWorker: {
+        enabled: true,
+        cli: 'claude',
+      },
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('backend_execution_error');
+    expect(result.error?.retryable).toBe(true);
+  });
+
+  it('times out when no matching execution result arrives', async () => {
+    const adapter = new AgentRelayExecutionAdapter({
+      relay: new FakeRelayTransport({ respond: false }),
+      timeoutMs: 5,
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('timeout');
+    expect(result.error?.retryable).toBe(true);
+  });
+
+  it('reports unsupported negotiation for attachment-required turns', () => {
+    const adapter = new AgentRelayExecutionAdapter();
+    const negotiation = adapter.negotiate({
+      ...baseRequest(),
+      message: {
+        ...baseRequest().message,
+        attachments: [{ id: 'att-1', type: 'image/png' }],
+      },
+      requirements: {
+        attachments: 'required',
+      },
+    });
+
+    expect(negotiation.supported).toBe(false);
+    expect(negotiation.reasons[0]?.code).toBe('attachments_unsupported');
+  });
+});

--- a/packages/harness/src/adapter/agent-relay-adapter.ts
+++ b/packages/harness/src/adapter/agent-relay-adapter.ts
@@ -1,0 +1,614 @@
+import { RelayAdapter } from '@agent-relay/sdk';
+import type {
+  BrokerEvent,
+  RelaySpawnRequest,
+  SendMessageInput,
+} from '@agent-relay/sdk';
+
+import type {
+  ExecutionAdapter,
+  ExecutionCapabilities,
+  ExecutionNegotiation,
+  ExecutionNegotiationReason,
+  ExecutionRequest,
+  ExecutionResult,
+  ExecutionTrace,
+  ExecutionTraceEvent,
+} from './types.js';
+
+export const AGENT_RELAY_EXECUTION_REQUEST_TYPE = 'agent-assistant.execution-request.v1';
+export const AGENT_RELAY_EXECUTION_RESULT_TYPE = 'agent-assistant.execution-result.v1';
+
+const DEFAULT_CHANNEL_ID = 'agent-assistant-execution';
+const DEFAULT_ORCHESTRATOR_NAME = 'agent-assistant';
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+const DEFAULT_CAPABILITIES: ExecutionCapabilities = {
+  toolUse: 'adapter-mediated',
+  structuredToolCalls: true,
+  continuationSupport: 'none',
+  approvalInterrupts: 'none',
+  traceDepth: 'standard',
+  attachments: false,
+  maxContextStrategy: 'large',
+  notes: [
+    'Relay-mediated local execution through a BYOH worker.',
+    'The worker owns model/tool iteration and returns a typed ExecutionResult.',
+  ],
+};
+
+const TRACE_DEPTH_ORDER: Record<ExecutionCapabilities['traceDepth'], number> = {
+  minimal: 0,
+  standard: 1,
+  detailed: 2,
+};
+
+export interface AgentRelayExecutionRequestMessage {
+  type: typeof AGENT_RELAY_EXECUTION_REQUEST_TYPE;
+  turnId: string;
+  threadId: string;
+  request: ExecutionRequest;
+  replyTo: {
+    agentId: string;
+    channelId: string;
+  };
+  sentAt: string;
+}
+
+export interface AgentRelayExecutionResultMessage {
+  type: typeof AGENT_RELAY_EXECUTION_RESULT_TYPE | 'execution-result';
+  turnId: string;
+  threadId: string;
+  executionResult?: ExecutionResult;
+  result?: ExecutionResult;
+}
+
+export interface AgentRelayExecutionTransport {
+  start(): Promise<void>;
+  sendMessage(input: SendMessageInput): Promise<{ event_id: string; targets: string[] }>;
+  onEvent(listener: (event: BrokerEvent) => void): () => void;
+  listAgents?(): Promise<Array<{ name: string }>>;
+  spawn?(request: RelaySpawnRequest): Promise<{ success: boolean; name: string; error?: string }>;
+  shutdown?(): Promise<void>;
+}
+
+export interface AgentRelayWorkerSpawnConfig {
+  enabled?: boolean;
+  name?: string;
+  cli: string;
+  task?: string;
+  model?: string;
+  cwd?: string;
+  team?: string;
+  includeWorkflowConventions?: boolean;
+}
+
+export interface AgentRelayExecutionAdapterConfig {
+  backendId?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  binaryPath?: string;
+  channelId?: string;
+  workerName?: string;
+  orchestratorName?: string;
+  workspaceId?: string;
+  timeoutMs?: number;
+  capabilities?: ExecutionCapabilities;
+  relay?: AgentRelayExecutionTransport;
+  spawnWorker?: AgentRelayWorkerSpawnConfig;
+  now?: () => number;
+  shutdownAfterExecute?: boolean;
+}
+
+function cloneCapabilities(capabilities: ExecutionCapabilities): ExecutionCapabilities {
+  return {
+    ...capabilities,
+    ...(capabilities.notes ? { notes: [...capabilities.notes] } : {}),
+  };
+}
+
+function requiredUnsupported(
+  code: ExecutionNegotiationReason['code'],
+  message: string,
+): ExecutionNegotiationReason {
+  return { code, message, severity: 'blocking' };
+}
+
+function preferredDegradation(
+  code: ExecutionNegotiationReason['code'],
+  message: string,
+): ExecutionNegotiationReason {
+  return { code, message, severity: 'warning' };
+}
+
+function isTraceDepthReduced(
+  requested: NonNullable<ExecutionRequest['requirements']>['traceDepth'],
+  available: ExecutionCapabilities['traceDepth'],
+): boolean {
+  if (!requested) {
+    return false;
+  }
+
+  return TRACE_DEPTH_ORDER[requested] > TRACE_DEPTH_ORDER[available];
+}
+
+function negotiateRequest(
+  request: ExecutionRequest,
+  capabilities: ExecutionCapabilities,
+): ExecutionNegotiation {
+  const reasons: ExecutionNegotiationReason[] = [];
+  const requirements = request.requirements;
+  const hasTools = (request.tools?.length ?? 0) > 0;
+  const hasAttachments = (request.message.attachments?.length ?? 0) > 0;
+
+  if (hasTools && requirements?.toolUse === 'forbidden') {
+    reasons.push(requiredUnsupported('tool_use_unsupported', 'Request forbids tool use but tools were supplied.'));
+  }
+
+  if ((hasTools || requirements?.toolUse === 'required') && capabilities.toolUse === 'none') {
+    reasons.push(requiredUnsupported('tool_use_unsupported', 'Backend does not support tool use.'));
+  }
+
+  if (requirements?.structuredToolCalls === 'required' && !capabilities.structuredToolCalls) {
+    reasons.push(
+      requiredUnsupported(
+        'structured_tool_calls_unsupported',
+        'Structured tool calls are required but unsupported.',
+      ),
+    );
+  } else if (requirements?.structuredToolCalls === 'preferred' && !capabilities.structuredToolCalls) {
+    reasons.push(
+      preferredDegradation(
+        'structured_tool_calls_unsupported',
+        'Structured tool calls are preferred but unsupported.',
+      ),
+    );
+  }
+
+  if (requirements?.continuationSupport === 'required' && capabilities.continuationSupport === 'none') {
+    reasons.push(
+      requiredUnsupported(
+        'continuation_unsupported',
+        'Structured continuation support is required but unavailable.',
+      ),
+    );
+  } else if (requirements?.continuationSupport === 'preferred' && capabilities.continuationSupport === 'none') {
+    reasons.push(
+      preferredDegradation(
+        'continuation_unsupported',
+        'Continuation support is preferred but unavailable.',
+      ),
+    );
+  }
+
+  if (requirements?.approvalInterrupts === 'required' && capabilities.approvalInterrupts === 'none') {
+    reasons.push(
+      requiredUnsupported(
+        'approval_interrupt_unsupported',
+        'Approval interrupts are required but unsupported.',
+      ),
+    );
+  } else if (requirements?.approvalInterrupts === 'preferred' && capabilities.approvalInterrupts === 'none') {
+    reasons.push(
+      preferredDegradation(
+        'approval_interrupt_unsupported',
+        'Approval interrupts are preferred but unavailable.',
+      ),
+    );
+  }
+
+  if ((hasAttachments || requirements?.attachments === 'required') && !capabilities.attachments) {
+    reasons.push(
+      requiredUnsupported(
+        'attachments_unsupported',
+        'Attachments are required by the request but unsupported by this adapter path.',
+      ),
+    );
+  }
+
+  if (isTraceDepthReduced(requirements?.traceDepth, capabilities.traceDepth)) {
+    reasons.push(
+      preferredDegradation(
+        'trace_depth_reduced',
+        `${requirements?.traceDepth ?? 'Requested'} trace depth was requested but only ${
+          capabilities.traceDepth
+        } trace facts are available.`,
+      ),
+    );
+  }
+
+  const supported = !reasons.some((reason) => reason.severity === 'blocking');
+  const degraded = reasons.some((reason) => reason.severity !== 'blocking');
+
+  return {
+    supported,
+    degraded,
+    reasons,
+    effectiveCapabilities: cloneCapabilities(capabilities),
+  };
+}
+
+function toIso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function buildTrace(
+  startedAt: number,
+  completedAt: number,
+  degraded: boolean,
+  events?: ExecutionTraceEvent[],
+): ExecutionTrace {
+  return {
+    summary: {
+      startedAt: toIso(startedAt),
+      completedAt: toIso(completedAt),
+      stepCount: 1,
+      degraded,
+    },
+    ...(events && events.length > 0 ? { events } : {}),
+  };
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isExecutionResult(value: unknown): value is ExecutionResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const candidate = value as Partial<ExecutionResult>;
+
+  return typeof candidate.backendId === 'string' && typeof candidate.status === 'string';
+}
+
+function parseResultMessage(raw: string): AgentRelayExecutionResultMessage | null {
+  const record = parseJsonObject(raw);
+
+  if (!record) {
+    return null;
+  }
+
+  if (record.type !== AGENT_RELAY_EXECUTION_RESULT_TYPE && record.type !== 'execution-result') {
+    return null;
+  }
+
+  const result = record.executionResult ?? record.result;
+
+  if (!isExecutionResult(result)) {
+    return null;
+  }
+
+  const turnId = typeof record.turnId === 'string' ? record.turnId : undefined;
+  const threadId = typeof record.threadId === 'string' ? record.threadId : undefined;
+
+  if (!turnId || !threadId) {
+    return null;
+  }
+
+  return {
+    type: record.type,
+    turnId,
+    threadId,
+    executionResult: result,
+  } as AgentRelayExecutionResultMessage;
+}
+
+function buildDefaultWorkerTask(input: {
+  orchestratorName: string;
+  channelId: string;
+}): string {
+  return [
+    'You are an Agent Assistant local execution worker connected through Agent Relay.',
+    `Wait for Relay messages from ${input.orchestratorName} containing JSON with type "${AGENT_RELAY_EXECUTION_REQUEST_TYPE}".`,
+    'For each request, preserve the assistant identity and instructions inside request.instructions.',
+    'Use only the tools described by request.tools and respect read-only metadata.',
+    'Send the result back to the sender on the same thread using Relay messaging.',
+    `The response body must be JSON with type "${AGENT_RELAY_EXECUTION_RESULT_TYPE}", the same turnId/threadId, and executionResult shaped like Agent Assistant ExecutionResult.`,
+    `Default channel: ${input.channelId}.`,
+  ].join('\n');
+}
+
+function relayInbound(event: BrokerEvent): Extract<BrokerEvent, { kind: 'relay_inbound' }> | null {
+  return event.kind === 'relay_inbound' ? event : null;
+}
+
+export class AgentRelayExecutionAdapter implements ExecutionAdapter {
+  readonly backendId: string;
+
+  private readonly relay: AgentRelayExecutionTransport;
+  private readonly channelId: string;
+  private readonly workerName?: string;
+  private readonly orchestratorName: string;
+  private readonly workspaceId?: string;
+  private readonly timeoutMs: number;
+  private readonly capabilities: ExecutionCapabilities;
+  private readonly spawnWorker?: AgentRelayWorkerSpawnConfig;
+  private readonly now: () => number;
+  private readonly shutdownAfterExecute: boolean;
+
+  constructor(config: AgentRelayExecutionAdapterConfig = {}) {
+    this.backendId = config.backendId ?? 'agent-relay';
+    this.channelId = config.channelId ?? DEFAULT_CHANNEL_ID;
+    this.workerName = config.workerName;
+    this.orchestratorName = config.orchestratorName ?? DEFAULT_ORCHESTRATOR_NAME;
+    this.workspaceId = config.workspaceId;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.capabilities = cloneCapabilities(config.capabilities ?? DEFAULT_CAPABILITIES);
+    this.spawnWorker = config.spawnWorker;
+    this.now = config.now ?? Date.now;
+    this.shutdownAfterExecute = config.shutdownAfterExecute ?? false;
+    this.relay =
+      config.relay ??
+      new RelayAdapter({
+        cwd: config.cwd ?? process.cwd(),
+        channels: [this.channelId],
+        binaryPath: config.binaryPath,
+        env: config.env,
+      });
+  }
+
+  describeCapabilities(): ExecutionCapabilities {
+    return cloneCapabilities(this.capabilities);
+  }
+
+  negotiate(request: ExecutionRequest): ExecutionNegotiation {
+    return negotiateRequest(request, this.capabilities);
+  }
+
+  async execute(request: ExecutionRequest): Promise<ExecutionResult> {
+    const negotiation = this.negotiate(request);
+    if (!negotiation.supported) {
+      return {
+        backendId: this.backendId,
+        status: 'unsupported',
+        error: {
+          code: 'unsupported_capability',
+          message: negotiation.reasons.map((reason) => reason.message).join(' '),
+        },
+        degradation: negotiation.reasons,
+        trace: {
+          summary: {
+            degraded: false,
+          },
+        },
+      };
+    }
+
+    const startedAt = this.now();
+    const threadId = request.threadId ?? request.turnId;
+    const target = this.workerName ?? this.channelId;
+    const degraded = negotiation.degraded;
+
+    let unsubscribe: (() => void) | undefined;
+    let settled = false;
+
+    const finish = (result: ExecutionResult): ExecutionResult => ({
+      ...result,
+      backendId: this.backendId,
+      degradation: negotiation.degraded
+        ? [...(result.degradation ?? []), ...negotiation.reasons]
+        : result.degradation,
+      metadata: {
+        ...(result.metadata ?? {}),
+        relay: {
+          adapterBackendId: this.backendId,
+          workerBackendId: result.backendId,
+          channelId: this.channelId,
+          target,
+          threadId,
+        },
+      },
+    });
+
+    try {
+      await this.relay.start();
+      await this.ensureWorker();
+
+      return await new Promise<ExecutionResult>((resolve) => {
+        const complete = (result: ExecutionResult) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          unsubscribe?.();
+          resolve(result);
+        };
+
+        const timeout = setTimeout(() => {
+          const completedAt = this.now();
+          complete({
+            backendId: this.backendId,
+            status: 'failed',
+            error: {
+              code: 'timeout',
+              message: `Timed out waiting for Relay execution result after ${this.timeoutMs}ms.`,
+              retryable: true,
+              metadata: { channelId: this.channelId, target, threadId },
+            },
+            trace: buildTrace(startedAt, completedAt, degraded, [
+              {
+                type: 'failure',
+                at: toIso(completedAt),
+                data: { channelId: this.channelId, target, threadId },
+              },
+            ]),
+            degradation: negotiation.degraded ? negotiation.reasons : undefined,
+          });
+        }, this.timeoutMs);
+
+        const completeAndClear = (result: ExecutionResult) => {
+          clearTimeout(timeout);
+          complete(result);
+        };
+
+        unsubscribe = this.relay.onEvent((event) => {
+          const inbound = relayInbound(event);
+          if (!inbound) {
+            return;
+          }
+
+          if (this.workerName && inbound.from !== this.workerName) {
+            return;
+          }
+
+          const parsed = parseResultMessage(inbound.body);
+          if (!parsed || parsed.turnId !== request.turnId || parsed.threadId !== threadId) {
+            return;
+          }
+
+          const completedAt = this.now();
+          const executionResult = parsed.executionResult ?? parsed.result;
+          if (!executionResult) {
+            return;
+          }
+
+          completeAndClear(
+            finish({
+              ...executionResult,
+              trace:
+                executionResult.trace ??
+                buildTrace(startedAt, completedAt, degraded, [
+                  { type: 'model_started', at: toIso(startedAt) },
+                  {
+                    type: 'model_completed',
+                    at: toIso(completedAt),
+                    data: {
+                      channelId: this.channelId,
+                      target,
+                      eventId: inbound.event_id,
+                    },
+                  },
+                ]),
+            }),
+          );
+        });
+
+        const message: AgentRelayExecutionRequestMessage = {
+          type: AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+          turnId: request.turnId,
+          threadId,
+          request,
+          replyTo: {
+            agentId: this.orchestratorName,
+            channelId: this.channelId,
+          },
+          sentAt: toIso(startedAt),
+        };
+
+        void this.relay
+          .sendMessage({
+            to: target,
+            text: JSON.stringify(message),
+            from: this.orchestratorName,
+            threadId,
+            ...(this.workspaceId ? { workspaceId: this.workspaceId } : {}),
+            data: {
+              type: AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+              turnId: request.turnId,
+              threadId,
+            },
+          })
+          .catch((error) => {
+            const completedAt = this.now();
+            completeAndClear({
+              backendId: this.backendId,
+              status: 'failed',
+              error: {
+                code: 'backend_execution_error',
+                message: error instanceof Error ? error.message : 'Failed to publish Relay execution request.',
+                retryable: true,
+              },
+              trace: buildTrace(startedAt, completedAt, degraded, [
+                {
+                  type: 'failure',
+                  at: toIso(completedAt),
+                  data: { channelId: this.channelId, target },
+                },
+              ]),
+              degradation: negotiation.degraded ? negotiation.reasons : undefined,
+            });
+          });
+      });
+    } catch (error) {
+      const completedAt = this.now();
+      return {
+        backendId: this.backendId,
+        status: 'failed',
+        error: {
+          code: 'backend_execution_error',
+          message: error instanceof Error ? error.message : 'Agent Relay execution failed.',
+          retryable: true,
+        },
+        trace: buildTrace(startedAt, completedAt, degraded, [
+          {
+            type: 'failure',
+            at: toIso(completedAt),
+            data: { channelId: this.channelId, target, threadId },
+          },
+        ]),
+        degradation: negotiation.degraded ? negotiation.reasons : undefined,
+      };
+    } finally {
+      if (this.shutdownAfterExecute && this.relay.shutdown) {
+        await this.relay.shutdown();
+      }
+    }
+  }
+
+  private async ensureWorker(): Promise<void> {
+    if (!this.spawnWorker?.enabled) {
+      return;
+    }
+
+    const workerName = this.spawnWorker.name ?? this.workerName;
+    if (!workerName) {
+      throw new Error('Agent Relay worker auto-spawn requires workerName or spawnWorker.name.');
+    }
+
+    if (!this.relay.spawn) {
+      throw new Error('Configured Agent Relay transport does not support worker spawning.');
+    }
+
+    if (this.relay.listAgents) {
+      const agents = await this.relay.listAgents();
+      if (agents.some((agent) => agent.name === workerName)) {
+        return;
+      }
+    }
+
+    const result = await this.relay.spawn({
+      name: workerName,
+      cli: this.spawnWorker.cli,
+      task:
+        this.spawnWorker.task ??
+        buildDefaultWorkerTask({
+          orchestratorName: this.orchestratorName,
+          channelId: this.channelId,
+        }),
+      model: this.spawnWorker.model,
+      cwd: this.spawnWorker.cwd,
+      team: this.spawnWorker.team,
+      includeWorkflowConventions: this.spawnWorker.includeWorkflowConventions ?? true,
+    });
+
+    if (!result.success) {
+      throw new Error(result.error ?? `Failed to spawn Agent Relay worker "${workerName}".`);
+    }
+  }
+}
+
+export function createAgentRelayExecutionAdapter(
+  config: AgentRelayExecutionAdapterConfig = {},
+): ExecutionAdapter {
+  return new AgentRelayExecutionAdapter(config);
+}

--- a/packages/harness/src/adapter/claude-code-adapter.ts
+++ b/packages/harness/src/adapter/claude-code-adapter.ts
@@ -1,16 +1,13 @@
-import { spawn } from 'node:child_process';
-import { EventEmitter } from 'node:events';
-
 import type {
   ExecutionAdapter,
   ExecutionCapabilities,
-  ExecutionNegotiation,
-  ExecutionNegotiationReason,
   ExecutionRequest,
-  ExecutionResult,
-  ExecutionTrace,
-  ExecutionTraceEvent,
 } from './types.js';
+import {
+  LocalCommandExecutionAdapter,
+  type LocalCommandSpawnFn,
+  type ParsedLocalCommandOutput,
+} from './local-command-adapter.js';
 
 const CLAUDE_CODE_CAPABILITIES: ExecutionCapabilities = {
   toolUse: 'native-iterative',
@@ -23,37 +20,13 @@ const CLAUDE_CODE_CAPABILITIES: ExecutionCapabilities = {
   notes: ['Bounded local CLI invocation only', 'No cloud routing or continuation resume ownership'],
 };
 
-interface ChildLike extends EventEmitter {
-  stdout?: EventEmitter & { setEncoding?(encoding: BufferEncoding): void };
-  stderr?: EventEmitter & { setEncoding?(encoding: BufferEncoding): void };
-  kill?(signal?: NodeJS.Signals | number): boolean;
-}
-
 export interface ClaudeCodeAdapterConfig {
   cliBinary?: string;
   timeoutMs?: number;
   cwd?: string;
   env?: Record<string, string>;
-  spawnProcess?: (
-    command: string,
-    args: string[],
-    options: {
-      cwd?: string;
-      env: NodeJS.ProcessEnv;
-      stdio: 'pipe';
-    },
-  ) => ChildLike;
+  spawnProcess?: LocalCommandSpawnFn;
   now?: () => number;
-}
-
-interface ParsedClaudeOutput {
-  text?: string;
-  structured?: Record<string, unknown>;
-  toolCalls?: unknown[];
-}
-
-function toIso(timestamp: number): string {
-  return new Date(timestamp).toISOString();
 }
 
 function buildPrompt(request: ExecutionRequest): string {
@@ -93,24 +66,6 @@ function buildArgs(request: ExecutionRequest): string[] {
   return args;
 }
 
-function buildTrace(
-  startedAt: number,
-  completedAt: number,
-  toolCallCount: number,
-  events?: ExecutionTraceEvent[],
-): ExecutionTrace {
-  return {
-    summary: {
-      startedAt: toIso(startedAt),
-      completedAt: toIso(completedAt),
-      stepCount: 1,
-      toolCallCount,
-      degraded: false,
-    },
-    ...(events && events.length > 0 ? { events } : {}),
-  };
-}
-
 function parseStructuredRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
@@ -119,7 +74,7 @@ function parseStructuredRecord(value: unknown): Record<string, unknown> | undefi
   return value as Record<string, unknown>;
 }
 
-function parseClaudeOutput(raw: string): ParsedClaudeOutput | null {
+function parseClaudeOutput(raw: string): ParsedLocalCommandOutput | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -159,324 +114,39 @@ function parseClaudeOutput(raw: string): ParsedClaudeOutput | null {
   return { text, structured, toolCalls };
 }
 
-function requiredUnsupported(
-  code: ExecutionNegotiationReason['code'],
-  message: string,
-): ExecutionNegotiationReason {
-  return { code, message, severity: 'blocking' };
-}
-
-function preferredDegradation(
-  code: ExecutionNegotiationReason['code'],
-  message: string,
-): ExecutionNegotiationReason {
-  return { code, message, severity: 'warning' };
-}
-
-function negotiateRequest(request: ExecutionRequest): ExecutionNegotiation {
-  const reasons: ExecutionNegotiationReason[] = [];
-  const requirements = request.requirements;
-
-  if ((request.tools?.length ?? 0) > 0 && requirements?.toolUse === 'forbidden') {
-    reasons.push(requiredUnsupported('tool_use_unsupported', 'Request forbids tool use but tools were supplied.'));
-  }
-
-  if (requirements?.toolUse === 'required' && CLAUDE_CODE_CAPABILITIES.toolUse === 'none') {
-    reasons.push(requiredUnsupported('tool_use_unsupported', 'Backend does not support tool use.'));
-  }
-
-  if (requirements?.structuredToolCalls === 'required' && !CLAUDE_CODE_CAPABILITIES.structuredToolCalls) {
-    reasons.push(
-      requiredUnsupported(
-        'structured_tool_calls_unsupported',
-        'Structured tool calls are required but unsupported.',
-      ),
-    );
-  }
-
-  if (requirements?.continuationSupport === 'required') {
-    reasons.push(
-      requiredUnsupported(
-        'continuation_unsupported',
-        'Claude Code CLI cannot resume structured continuations in this proof slice.',
-      ),
-    );
-  } else if (requirements?.continuationSupport === 'preferred') {
-    reasons.push(
-      preferredDegradation(
-        'continuation_unsupported',
-        'Continuation support is preferred but not available in this proof slice.',
-      ),
-    );
-  }
-
-  if (requirements?.approvalInterrupts === 'required') {
-    reasons.push(
-      requiredUnsupported(
-        'approval_interrupt_unsupported',
-        'Approval interrupts are required but unsupported in non-interactive CLI execution.',
-      ),
-    );
-  } else if (requirements?.approvalInterrupts === 'preferred') {
-    reasons.push(
-      preferredDegradation(
-        'approval_interrupt_unsupported',
-        'Approval interrupts are preferred but unavailable in this proof slice.',
-      ),
-    );
-  }
-
-  if ((request.message.attachments?.length ?? 0) > 0 || requirements?.attachments === 'required') {
-    if (!CLAUDE_CODE_CAPABILITIES.attachments) {
-      reasons.push(
-        requiredUnsupported(
-          'attachments_unsupported',
-          'Attachments are required by the request but unsupported by this adapter path.',
-        ),
-      );
-    }
-  }
-
-  if (requirements?.traceDepth === 'detailed') {
-    reasons.push(
-      preferredDegradation(
-        'trace_depth_reduced',
-        'Detailed trace depth was requested but only minimal CLI trace facts are available.',
-      ),
-    );
-  } else if (requirements?.traceDepth === 'standard' && CLAUDE_CODE_CAPABILITIES.traceDepth === 'minimal') {
-    reasons.push(
-      preferredDegradation(
-        'trace_depth_reduced',
-        'Standard trace depth was requested but only minimal CLI trace facts are available.',
-      ),
-    );
-  }
-
-  const supported = !reasons.some((reason) => reason.severity === 'blocking');
-  const degraded = reasons.some((reason) => reason.severity !== 'blocking');
-
-  return {
-    supported,
-    degraded,
-    reasons,
-    effectiveCapabilities: CLAUDE_CODE_CAPABILITIES,
-  };
-}
-
 export class ClaudeCodeExecutionAdapter implements ExecutionAdapter {
   readonly backendId = 'claude-code';
 
-  private readonly cliBinary: string;
-  private readonly timeoutMs: number;
-  private readonly cwd?: string;
-  private readonly env?: Record<string, string>;
-  private readonly spawnProcess: NonNullable<ClaudeCodeAdapterConfig['spawnProcess']>;
-  private readonly now: NonNullable<ClaudeCodeAdapterConfig['now']>;
+  private readonly adapter: LocalCommandExecutionAdapter;
 
   constructor(config: ClaudeCodeAdapterConfig = {}) {
-    this.cliBinary = config.cliBinary ?? 'claude';
-    this.timeoutMs = config.timeoutMs ?? 60_000;
-    this.cwd = config.cwd;
-    this.env = config.env;
-    this.spawnProcess =
-      config.spawnProcess ??
-      ((command, args, options) =>
-        spawn(command, args, {
-          cwd: options.cwd,
-          env: options.env,
-          stdio: options.stdio,
-        }) as ChildLike);
-    this.now = config.now ?? Date.now;
+    this.adapter = new LocalCommandExecutionAdapter({
+      backendId: this.backendId,
+      command: config.cliBinary ?? 'claude',
+      buildArgs,
+      parseOutput: parseClaudeOutput,
+      capabilities: CLAUDE_CODE_CAPABILITIES,
+      timeoutMs: config.timeoutMs,
+      cwd: config.cwd,
+      env: config.env,
+      spawnProcess: config.spawnProcess,
+      now: config.now,
+      commandLabel: 'Claude Code CLI',
+      traceDegradedFromNegotiation: false,
+      isNonZeroExitRetryable: ({ code }) => code !== 2,
+    });
   }
 
   describeCapabilities(): ExecutionCapabilities {
-    return {
-      ...CLAUDE_CODE_CAPABILITIES,
-      ...(CLAUDE_CODE_CAPABILITIES.notes ? { notes: [...CLAUDE_CODE_CAPABILITIES.notes] } : {}),
-    };
+    return this.adapter.describeCapabilities();
   }
 
-  negotiate(request: ExecutionRequest): ExecutionNegotiation {
-    return negotiateRequest(request);
+  negotiate(request: ExecutionRequest) {
+    return this.adapter.negotiate(request);
   }
 
-  async execute(request: ExecutionRequest): Promise<ExecutionResult> {
-    const negotiation = this.negotiate(request);
-    if (!negotiation.supported) {
-      return {
-        backendId: this.backendId,
-        status: 'unsupported',
-        error: {
-          code: 'unsupported_capability',
-          message: negotiation.reasons.map((reason) => reason.message).join(' '),
-        },
-        degradation: negotiation.reasons,
-        trace: {
-          summary: {
-            degraded: false,
-          },
-        },
-      };
-    }
-
-    const startedAt = this.now();
-    const args = buildArgs(request);
-    const child = this.spawnProcess(this.cliBinary, args, {
-      cwd: this.cwd,
-      env: { ...process.env, ...this.env },
-      stdio: 'pipe',
-    });
-
-    let stdout = '';
-    let stderr = '';
-
-    child.stdout?.setEncoding?.('utf8');
-    child.stderr?.setEncoding?.('utf8');
-    child.stdout?.on('data', (chunk) => {
-      stdout += String(chunk);
-    });
-    child.stderr?.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-
-    return await new Promise<ExecutionResult>((resolve) => {
-      let settled = false;
-      const timer = setTimeout(() => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        child.kill?.('SIGTERM');
-        const completedAt = this.now();
-        resolve({
-          backendId: this.backendId,
-          status: 'failed',
-          error: {
-            code: 'timeout',
-            message: `Claude Code CLI timed out after ${this.timeoutMs}ms.`,
-            retryable: true,
-          },
-          trace: buildTrace(startedAt, completedAt, 0, [
-            {
-              type: 'failure',
-              at: toIso(completedAt),
-              data: { stderr, timeoutMs: this.timeoutMs },
-            },
-          ]),
-          degradation: negotiation.degraded ? negotiation.reasons : undefined,
-        });
-      }, this.timeoutMs);
-
-      const finalize = (result: ExecutionResult): void => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        clearTimeout(timer);
-        resolve(result);
-      };
-
-      child.once('error', (error) => {
-        const completedAt = this.now();
-        finalize({
-          backendId: this.backendId,
-          status: 'failed',
-          error: {
-            code: 'backend_execution_error',
-            message: error instanceof Error ? error.message : 'Unknown Claude Code execution error.',
-            retryable: true,
-          },
-          trace: buildTrace(startedAt, completedAt, 0, [
-            {
-              type: 'failure',
-              at: toIso(completedAt),
-              data: { stderr },
-            },
-          ]),
-          degradation: negotiation.degraded ? negotiation.reasons : undefined,
-        });
-      });
-
-      child.once('close', (code, signal) => {
-        const completedAt = this.now();
-
-        if (code !== 0) {
-          finalize({
-            backendId: this.backendId,
-            status: 'failed',
-            error: {
-              code: 'backend_execution_error',
-              message: `Claude Code CLI exited with code ${code ?? 'unknown'}${signal ? ` (signal ${signal})` : ''}.`,
-              retryable: code !== 2,
-              metadata: stderr ? { stderr } : undefined,
-            },
-            trace: buildTrace(startedAt, completedAt, 0, [
-              {
-                type: 'failure',
-                at: toIso(completedAt),
-                data: { code, signal, stderr },
-              },
-            ]),
-            degradation: negotiation.degraded ? negotiation.reasons : undefined,
-          });
-          return;
-        }
-
-        const parsed = parseClaudeOutput(stdout.trim());
-        if (!parsed) {
-          finalize({
-            backendId: this.backendId,
-            status: 'failed',
-            error: {
-              code: 'invalid_backend_output',
-              message: 'Claude Code CLI returned malformed JSON output.',
-              metadata: { stdout, stderr },
-            },
-            trace: buildTrace(startedAt, completedAt, 0, [
-              {
-                type: 'failure',
-                at: toIso(completedAt),
-                data: { stdoutPreview: stdout.slice(0, 200), stderr },
-              },
-            ]),
-            degradation: negotiation.degraded ? negotiation.reasons : undefined,
-          });
-          return;
-        }
-
-        const toolCallCount = parsed.toolCalls?.length ?? 0;
-        finalize({
-          backendId: this.backendId,
-          status: 'completed',
-          output: {
-            ...(parsed.text !== undefined ? { text: parsed.text } : {}),
-            ...(parsed.structured !== undefined
-              ? {
-                  structured: {
-                    ...parsed.structured,
-                    ...(parsed.toolCalls !== undefined ? { toolCalls: parsed.toolCalls } : {}),
-                  },
-                }
-              : parsed.toolCalls !== undefined
-                ? { structured: { toolCalls: parsed.toolCalls } }
-                : {}),
-          },
-          trace: buildTrace(startedAt, completedAt, toolCallCount, [
-            { type: 'model_started', at: toIso(startedAt) },
-            {
-              type: 'model_completed',
-              at: toIso(completedAt),
-              data: { toolCallCount },
-            },
-          ]),
-          degradation: negotiation.degraded ? negotiation.reasons : undefined,
-          metadata: stderr ? { stderr } : undefined,
-        });
-      });
-    });
+  execute(request: ExecutionRequest) {
+    return this.adapter.execute(request);
   }
 }
 

--- a/packages/harness/src/adapter/index.ts
+++ b/packages/harness/src/adapter/index.ts
@@ -1,7 +1,20 @@
 export { ClaudeCodeExecutionAdapter, createClaudeCodeAdapter } from './claude-code-adapter.js';
+export {
+  AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+  AGENT_RELAY_EXECUTION_RESULT_TYPE,
+  AgentRelayExecutionAdapter,
+  createAgentRelayExecutionAdapter,
+} from './agent-relay-adapter.js';
 export { LocalCommandExecutionAdapter, createLocalCommandAdapter } from './local-command-adapter.js';
 export { OpenRouterExecutionAdapter, createOpenRouterAdapter } from './openrouter-adapter.js';
 
+export type {
+  AgentRelayExecutionAdapterConfig,
+  AgentRelayExecutionRequestMessage,
+  AgentRelayExecutionResultMessage,
+  AgentRelayExecutionTransport,
+  AgentRelayWorkerSpawnConfig,
+} from './agent-relay-adapter.js';
 export type {
   ClaudeCodeAdapterConfig,
 } from './claude-code-adapter.js';

--- a/packages/harness/src/adapter/index.ts
+++ b/packages/harness/src/adapter/index.ts
@@ -1,6 +1,16 @@
 export { ClaudeCodeExecutionAdapter, createClaudeCodeAdapter } from './claude-code-adapter.js';
+export { LocalCommandExecutionAdapter, createLocalCommandAdapter } from './local-command-adapter.js';
 export { OpenRouterExecutionAdapter, createOpenRouterAdapter } from './openrouter-adapter.js';
 
+export type {
+  ClaudeCodeAdapterConfig,
+} from './claude-code-adapter.js';
+export type {
+  LocalCommandAdapterConfig,
+  LocalCommandChildProcess,
+  LocalCommandSpawnFn,
+  ParsedLocalCommandOutput,
+} from './local-command-adapter.js';
 export type {
   ExecutionAdapter,
   ExecutionCapabilities,

--- a/packages/harness/src/adapter/local-command-adapter.test.ts
+++ b/packages/harness/src/adapter/local-command-adapter.test.ts
@@ -1,0 +1,237 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, it } from 'vitest';
+
+import { LocalCommandExecutionAdapter } from './local-command-adapter.js';
+import type {
+  ExecutionCapabilities,
+  ExecutionRequest,
+} from './types.js';
+
+class MockStream extends EventEmitter {
+  setEncoding(): void {}
+}
+
+class MockChild extends EventEmitter {
+  stdout = new MockStream();
+  stderr = new MockStream();
+  killed = false;
+
+  kill(): boolean {
+    this.killed = true;
+    this.emit('close', null, 'SIGTERM');
+    return true;
+  }
+}
+
+const CAPABILITIES: ExecutionCapabilities = {
+  toolUse: 'adapter-mediated',
+  structuredToolCalls: true,
+  continuationSupport: 'none',
+  approvalInterrupts: 'none',
+  traceDepth: 'minimal',
+  attachments: false,
+  maxContextStrategy: 'medium',
+  notes: ['test local command'],
+};
+
+function baseRequest(): ExecutionRequest {
+  return {
+    assistantId: 'assistant-1',
+    turnId: 'turn-1',
+    threadId: 'thread-1',
+    message: {
+      id: 'msg-1',
+      text: 'Summarize the local command proof',
+      receivedAt: '2026-04-20T12:00:00.000Z',
+    },
+    instructions: {
+      systemPrompt: 'You are Sage.',
+      developerPrompt: 'Be direct.',
+    },
+    context: {
+      blocks: [
+        {
+          id: 'ctx-1',
+          label: 'Scope',
+          text: 'Only generic local commands are in scope.',
+          category: 'workspace',
+        },
+      ],
+    },
+  };
+}
+
+function createAdapter(options: {
+  capabilities?: ExecutionCapabilities;
+  onSpawn?: (child: MockChild, args: string[], request: ExecutionRequest) => void;
+  timeoutMs?: number;
+}) {
+  let lastRequest: ExecutionRequest | undefined;
+  const adapter = new LocalCommandExecutionAdapter({
+    backendId: 'fake-local-command',
+    command: 'fake-command',
+    capabilities: options.capabilities ?? CAPABILITIES,
+    timeoutMs: options.timeoutMs ?? 50,
+    buildArgs: (request) => {
+      lastRequest = request;
+      return [
+        '--message',
+        request.message.text,
+        '--tools',
+        (request.tools ?? []).map((tool) => tool.name).join(','),
+      ];
+    },
+    parseOutput: (stdout) => {
+      const parsed = JSON.parse(stdout) as {
+        text?: string;
+        structured?: Record<string, unknown>;
+        toolCalls?: unknown[];
+      };
+      return parsed;
+    },
+    spawnProcess: (_command, args) => {
+      const child = new MockChild();
+      options.onSpawn?.(child, args, lastRequest ?? baseRequest());
+      return child;
+    },
+  });
+
+  return adapter;
+}
+
+describe('LocalCommandExecutionAdapter', () => {
+  it('describes declared command capabilities without sharing mutable notes', () => {
+    const adapter = createAdapter({});
+    const first = adapter.describeCapabilities();
+    first.notes?.push('mutated');
+
+    expect(adapter.describeCapabilities().notes).toEqual(['test local command']);
+  });
+
+  it('executes a successful local command response', async () => {
+    const adapter = createAdapter({
+      onSpawn: (child, args) => {
+        expect(args).toContain('--message');
+        queueMicrotask(() => {
+          child.stdout.emit(
+            'data',
+            JSON.stringify({
+              text: 'Proof complete.',
+              structured: { backend: 'fake' },
+            }),
+          );
+          child.emit('close', 0, null);
+        });
+      },
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('completed');
+    expect(result.backendId).toBe('fake-local-command');
+    expect(result.output?.text).toBe('Proof complete.');
+    expect(result.output?.structured).toEqual({ backend: 'fake' });
+  });
+
+  it('passes tool descriptors into buildArgs and preserves parsed tool calls', async () => {
+    const adapter = createAdapter({
+      onSpawn: (child, args, request) => {
+        expect(args).toContain('relay_lookup');
+        expect(request.tools?.[0]?.description).toBe('Lookup relay evidence');
+        queueMicrotask(() => {
+          child.stdout.emit(
+            'data',
+            JSON.stringify({
+              text: 'Used relay lookup.',
+              toolCalls: [{ name: 'relay_lookup', result: 'ok' }],
+            }),
+          );
+          child.emit('close', 0, null);
+        });
+      },
+    });
+
+    const result = await adapter.execute({
+      ...baseRequest(),
+      tools: [{ name: 'relay_lookup', description: 'Lookup relay evidence' }],
+    });
+
+    expect(result.status).toBe('completed');
+    expect(result.output?.structured?.toolCalls).toEqual([{ name: 'relay_lookup', result: 'ok' }]);
+    expect(result.trace?.summary.toolCallCount).toBe(1);
+  });
+
+  it('maps malformed local output to invalid_backend_output', async () => {
+    const adapter = createAdapter({
+      onSpawn: (child) => {
+        queueMicrotask(() => {
+          child.stdout.emit('data', 'not-json');
+          child.emit('close', 0, null);
+        });
+      },
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('invalid_backend_output');
+  });
+
+  it('maps non-zero command exits to failed results', async () => {
+    const adapter = createAdapter({
+      onSpawn: (child) => {
+        queueMicrotask(() => {
+          child.stderr.emit('data', 'permission denied');
+          child.emit('close', 2, null);
+        });
+      },
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('backend_execution_error');
+    expect(result.error?.metadata).toEqual({ stderr: 'permission denied' });
+  });
+
+  it('maps command timeouts to retryable timeout failures', async () => {
+    const adapter = createAdapter({
+      timeoutMs: 5,
+      onSpawn: () => {
+        // Intentionally never closes.
+      },
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('failed');
+    expect(result.error?.code).toBe('timeout');
+    expect(result.error?.retryable).toBe(true);
+  });
+
+  it('reports unsupported and degraded requirements from declared capabilities', () => {
+    const adapter = createAdapter({
+      capabilities: {
+        ...CAPABILITIES,
+        toolUse: 'none',
+        structuredToolCalls: false,
+      },
+    });
+
+    const unsupported = adapter.negotiate({
+      ...baseRequest(),
+      tools: [{ name: 'relay_lookup' }],
+    });
+    const degraded = adapter.negotiate({
+      ...baseRequest(),
+      requirements: { structuredToolCalls: 'preferred' },
+    });
+
+    expect(unsupported.supported).toBe(false);
+    expect(unsupported.reasons[0]?.code).toBe('tool_use_unsupported');
+    expect(degraded.supported).toBe(true);
+    expect(degraded.degraded).toBe(true);
+    expect(degraded.reasons[0]?.code).toBe('structured_tool_calls_unsupported');
+  });
+});

--- a/packages/harness/src/adapter/local-command-adapter.ts
+++ b/packages/harness/src/adapter/local-command-adapter.ts
@@ -1,0 +1,464 @@
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+
+import type {
+  ExecutionAdapter,
+  ExecutionCapabilities,
+  ExecutionNegotiation,
+  ExecutionNegotiationReason,
+  ExecutionRequest,
+  ExecutionResult,
+  ExecutionTrace,
+  ExecutionTraceEvent,
+} from './types.js';
+
+export interface LocalCommandChildProcess extends EventEmitter {
+  stdout?: EventEmitter & { setEncoding?(encoding: BufferEncoding): void };
+  stderr?: EventEmitter & { setEncoding?(encoding: BufferEncoding): void };
+  kill?(signal?: NodeJS.Signals | number): boolean;
+}
+
+export type LocalCommandSpawnFn = (
+  command: string,
+  args: string[],
+  options: {
+    cwd?: string;
+    env: NodeJS.ProcessEnv;
+    stdio: 'pipe';
+  },
+) => LocalCommandChildProcess;
+
+export interface ParsedLocalCommandOutput {
+  text?: string;
+  attachments?: NonNullable<ExecutionResult['output']>['attachments'];
+  structured?: Record<string, unknown>;
+  toolCalls?: unknown[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface LocalCommandAdapterConfig {
+  backendId: string;
+  command: string;
+  buildArgs: (request: ExecutionRequest) => string[];
+  parseOutput: (stdout: string) => ParsedLocalCommandOutput | null;
+  capabilities: ExecutionCapabilities;
+  timeoutMs?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+  spawnProcess?: LocalCommandSpawnFn;
+  now?: () => number;
+  commandLabel?: string;
+  traceDegradedFromNegotiation?: boolean;
+  isNonZeroExitRetryable?: (exit: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }) => boolean;
+}
+
+const TRACE_DEPTH_ORDER: Record<ExecutionCapabilities['traceDepth'], number> = {
+  minimal: 0,
+  standard: 1,
+  detailed: 2,
+};
+
+function toIso(timestamp: number): string {
+  return new Date(timestamp).toISOString();
+}
+
+function cloneCapabilities(capabilities: ExecutionCapabilities): ExecutionCapabilities {
+  return {
+    ...capabilities,
+    ...(capabilities.notes ? { notes: [...capabilities.notes] } : {}),
+  };
+}
+
+function requiredUnsupported(
+  code: ExecutionNegotiationReason['code'],
+  message: string,
+): ExecutionNegotiationReason {
+  return { code, message, severity: 'blocking' };
+}
+
+function preferredDegradation(
+  code: ExecutionNegotiationReason['code'],
+  message: string,
+): ExecutionNegotiationReason {
+  return { code, message, severity: 'warning' };
+}
+
+function isTraceDepthReduced(
+  requested: NonNullable<ExecutionRequest['requirements']>['traceDepth'],
+  available: ExecutionCapabilities['traceDepth'],
+): boolean {
+  if (!requested) {
+    return false;
+  }
+
+  return TRACE_DEPTH_ORDER[requested] > TRACE_DEPTH_ORDER[available];
+}
+
+function negotiateRequest(
+  request: ExecutionRequest,
+  capabilities: ExecutionCapabilities,
+): ExecutionNegotiation {
+  const reasons: ExecutionNegotiationReason[] = [];
+  const requirements = request.requirements;
+  const hasTools = (request.tools?.length ?? 0) > 0;
+  const hasAttachments = (request.message.attachments?.length ?? 0) > 0;
+
+  if (hasTools && requirements?.toolUse === 'forbidden') {
+    reasons.push(requiredUnsupported('tool_use_unsupported', 'Request forbids tool use but tools were supplied.'));
+  }
+
+  if ((hasTools || requirements?.toolUse === 'required') && capabilities.toolUse === 'none') {
+    reasons.push(requiredUnsupported('tool_use_unsupported', 'Backend does not support tool use.'));
+  }
+
+  if (requirements?.structuredToolCalls === 'required' && !capabilities.structuredToolCalls) {
+    reasons.push(
+      requiredUnsupported(
+        'structured_tool_calls_unsupported',
+        'Structured tool calls are required but unsupported.',
+      ),
+    );
+  } else if (requirements?.structuredToolCalls === 'preferred' && !capabilities.structuredToolCalls) {
+    reasons.push(
+      preferredDegradation(
+        'structured_tool_calls_unsupported',
+        'Structured tool calls are preferred but unsupported.',
+      ),
+    );
+  }
+
+  if (requirements?.continuationSupport === 'required' && capabilities.continuationSupport === 'none') {
+    reasons.push(
+      requiredUnsupported(
+        'continuation_unsupported',
+        'Structured continuation support is required but unavailable.',
+      ),
+    );
+  } else if (requirements?.continuationSupport === 'preferred' && capabilities.continuationSupport === 'none') {
+    reasons.push(
+      preferredDegradation(
+        'continuation_unsupported',
+        'Continuation support is preferred but unavailable.',
+      ),
+    );
+  }
+
+  if (requirements?.approvalInterrupts === 'required' && capabilities.approvalInterrupts === 'none') {
+    reasons.push(
+      requiredUnsupported(
+        'approval_interrupt_unsupported',
+        'Approval interrupts are required but unsupported.',
+      ),
+    );
+  } else if (requirements?.approvalInterrupts === 'preferred' && capabilities.approvalInterrupts === 'none') {
+    reasons.push(
+      preferredDegradation(
+        'approval_interrupt_unsupported',
+        'Approval interrupts are preferred but unavailable.',
+      ),
+    );
+  }
+
+  if ((hasAttachments || requirements?.attachments === 'required') && !capabilities.attachments) {
+    reasons.push(
+      requiredUnsupported(
+        'attachments_unsupported',
+        'Attachments are required by the request but unsupported by this adapter path.',
+      ),
+    );
+  }
+
+  if (isTraceDepthReduced(requirements?.traceDepth, capabilities.traceDepth)) {
+    reasons.push(
+      preferredDegradation(
+        'trace_depth_reduced',
+        `${requirements?.traceDepth ?? 'Requested'} trace depth was requested but only ${
+          capabilities.traceDepth
+        } trace facts are available.`,
+      ),
+    );
+  }
+
+  const supported = !reasons.some((reason) => reason.severity === 'blocking');
+  const degraded = reasons.some((reason) => reason.severity !== 'blocking');
+
+  return {
+    supported,
+    degraded,
+    reasons,
+    effectiveCapabilities: cloneCapabilities(capabilities),
+  };
+}
+
+function buildTrace(
+  startedAt: number,
+  completedAt: number,
+  toolCallCount: number,
+  degraded: boolean,
+  events?: ExecutionTraceEvent[],
+): ExecutionTrace {
+  return {
+    summary: {
+      startedAt: toIso(startedAt),
+      completedAt: toIso(completedAt),
+      stepCount: 1,
+      toolCallCount,
+      degraded,
+    },
+    ...(events && events.length > 0 ? { events } : {}),
+  };
+}
+
+function buildOutput(parsed: ParsedLocalCommandOutput): NonNullable<ExecutionResult['output']> {
+  return {
+    ...(parsed.text !== undefined ? { text: parsed.text } : {}),
+    ...(parsed.attachments !== undefined ? { attachments: parsed.attachments } : {}),
+    ...(parsed.structured !== undefined
+      ? {
+          structured: {
+            ...parsed.structured,
+            ...(parsed.toolCalls !== undefined ? { toolCalls: parsed.toolCalls } : {}),
+          },
+        }
+      : parsed.toolCalls !== undefined
+        ? { structured: { toolCalls: parsed.toolCalls } }
+        : {}),
+  };
+}
+
+export class LocalCommandExecutionAdapter implements ExecutionAdapter {
+  readonly backendId: string;
+
+  private readonly command: string;
+  private readonly buildArgs: LocalCommandAdapterConfig['buildArgs'];
+  private readonly parseOutput: LocalCommandAdapterConfig['parseOutput'];
+  private readonly capabilities: ExecutionCapabilities;
+  private readonly timeoutMs: number;
+  private readonly cwd?: string;
+  private readonly env?: Record<string, string>;
+  private readonly spawnProcess: LocalCommandSpawnFn;
+  private readonly now: NonNullable<LocalCommandAdapterConfig['now']>;
+  private readonly commandLabel: string;
+  private readonly traceDegradedFromNegotiation: boolean;
+  private readonly isNonZeroExitRetryable: NonNullable<LocalCommandAdapterConfig['isNonZeroExitRetryable']>;
+
+  constructor(config: LocalCommandAdapterConfig) {
+    this.backendId = config.backendId;
+    this.command = config.command;
+    this.buildArgs = config.buildArgs;
+    this.parseOutput = config.parseOutput;
+    this.capabilities = cloneCapabilities(config.capabilities);
+    this.timeoutMs = config.timeoutMs ?? 60_000;
+    this.cwd = config.cwd;
+    this.env = config.env;
+    this.spawnProcess =
+      config.spawnProcess ??
+      ((command, args, options) =>
+        spawn(command, args, {
+          cwd: options.cwd,
+          env: options.env,
+          stdio: options.stdio,
+        }) as LocalCommandChildProcess);
+    this.now = config.now ?? Date.now;
+    this.commandLabel = config.commandLabel ?? `${config.backendId} command`;
+    this.traceDegradedFromNegotiation = config.traceDegradedFromNegotiation ?? true;
+    this.isNonZeroExitRetryable = config.isNonZeroExitRetryable ?? (() => true);
+  }
+
+  describeCapabilities(): ExecutionCapabilities {
+    return cloneCapabilities(this.capabilities);
+  }
+
+  negotiate(request: ExecutionRequest): ExecutionNegotiation {
+    return negotiateRequest(request, this.capabilities);
+  }
+
+  async execute(request: ExecutionRequest): Promise<ExecutionResult> {
+    const negotiation = this.negotiate(request);
+    if (!negotiation.supported) {
+      return {
+        backendId: this.backendId,
+        status: 'unsupported',
+        error: {
+          code: 'unsupported_capability',
+          message: negotiation.reasons.map((reason) => reason.message).join(' '),
+        },
+        degradation: negotiation.reasons,
+        trace: {
+          summary: {
+            degraded: false,
+          },
+        },
+      };
+    }
+
+    const startedAt = this.now();
+    const degraded = this.traceDegradedFromNegotiation ? negotiation.degraded : false;
+    const child = this.spawnProcess(this.command, this.buildArgs(request), {
+      cwd: this.cwd,
+      env: { ...process.env, ...this.env },
+      stdio: 'pipe',
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.setEncoding?.('utf8');
+    child.stderr?.setEncoding?.('utf8');
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    return await new Promise<ExecutionResult>((resolve) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        child.kill?.('SIGTERM');
+        const completedAt = this.now();
+        resolve({
+          backendId: this.backendId,
+          status: 'failed',
+          error: {
+            code: 'timeout',
+            message: `${this.commandLabel} timed out after ${this.timeoutMs}ms.`,
+            retryable: true,
+          },
+          trace: buildTrace(startedAt, completedAt, 0, degraded, [
+            {
+              type: 'failure',
+              at: toIso(completedAt),
+              data: { stderr, timeoutMs: this.timeoutMs },
+            },
+          ]),
+          degradation: negotiation.degraded ? negotiation.reasons : undefined,
+        });
+      }, this.timeoutMs);
+
+      const finalize = (result: ExecutionResult): void => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      child.once('error', (error) => {
+        const completedAt = this.now();
+        finalize({
+          backendId: this.backendId,
+          status: 'failed',
+          error: {
+            code: 'backend_execution_error',
+            message: error instanceof Error ? error.message : `Unknown ${this.commandLabel} execution error.`,
+            retryable: true,
+          },
+          trace: buildTrace(startedAt, completedAt, 0, degraded, [
+            {
+              type: 'failure',
+              at: toIso(completedAt),
+              data: { stderr },
+            },
+          ]),
+          degradation: negotiation.degraded ? negotiation.reasons : undefined,
+        });
+      });
+
+      child.once('close', (code: number | null, signal: NodeJS.Signals | null) => {
+        const completedAt = this.now();
+
+        if (code !== 0) {
+          finalize({
+            backendId: this.backendId,
+            status: 'failed',
+            error: {
+              code: 'backend_execution_error',
+              message: `${this.commandLabel} exited with code ${code ?? 'unknown'}${
+                signal ? ` (signal ${signal})` : ''
+              }.`,
+              retryable: this.isNonZeroExitRetryable({ code, signal }),
+              metadata: stderr ? { stderr } : undefined,
+            },
+            trace: buildTrace(startedAt, completedAt, 0, degraded, [
+              {
+                type: 'failure',
+                at: toIso(completedAt),
+                data: { code, signal, stderr },
+              },
+            ]),
+            degradation: negotiation.degraded ? negotiation.reasons : undefined,
+          });
+          return;
+        }
+
+        let parsed: ParsedLocalCommandOutput | null = null;
+        try {
+          parsed = this.parseOutput(stdout);
+        } catch {
+          parsed = null;
+        }
+
+        if (!parsed) {
+          finalize({
+            backendId: this.backendId,
+            status: 'failed',
+            error: {
+              code: 'invalid_backend_output',
+              message: `${this.commandLabel} returned malformed output.`,
+              metadata: { stdout, stderr },
+            },
+            trace: buildTrace(startedAt, completedAt, 0, degraded, [
+              {
+                type: 'failure',
+                at: toIso(completedAt),
+                data: { stdoutPreview: stdout.slice(0, 200), stderr },
+              },
+            ]),
+            degradation: negotiation.degraded ? negotiation.reasons : undefined,
+          });
+          return;
+        }
+
+        const toolCallCount = parsed.toolCalls?.length ?? 0;
+        finalize({
+          backendId: this.backendId,
+          status: 'completed',
+          output: buildOutput(parsed),
+          trace: buildTrace(startedAt, completedAt, toolCallCount, degraded, [
+            { type: 'model_started', at: toIso(startedAt) },
+            {
+              type: 'model_completed',
+              at: toIso(completedAt),
+              data: { toolCallCount },
+            },
+          ]),
+          degradation: negotiation.degraded ? negotiation.reasons : undefined,
+          metadata:
+            stderr || parsed.metadata
+              ? {
+                  ...(stderr ? { stderr } : {}),
+                  ...(parsed.metadata ?? {}),
+                }
+              : undefined,
+        });
+      });
+    });
+  }
+}
+
+export function createLocalCommandAdapter(
+  config: LocalCommandAdapterConfig,
+): ExecutionAdapter {
+  return new LocalCommandExecutionAdapter(config);
+}

--- a/packages/harness/src/adapter/proof/fixtures/fake-harness.mjs
+++ b/packages/harness/src/adapter/proof/fixtures/fake-harness.mjs
@@ -1,0 +1,15 @@
+const prompt = process.argv[2] ?? '';
+const requestEnvelope = JSON.parse(process.argv[3] ?? '{}');
+
+process.stdout.write(
+  JSON.stringify({
+    text: `fake-harness handled: ${prompt}`,
+    structured: {
+      assistantId: requestEnvelope.assistantId,
+      systemPromptLength: requestEnvelope.systemPromptLength,
+      contextBlockCount: requestEnvelope.contextBlockCount,
+      toolNames: requestEnvelope.toolNames,
+    },
+    toolCalls: requestEnvelope.toolNames.map((name) => ({ name, result: 'ok' })),
+  }),
+);

--- a/packages/harness/src/adapter/proof/local-command-proof.test.ts
+++ b/packages/harness/src/adapter/proof/local-command-proof.test.ts
@@ -1,0 +1,92 @@
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { LocalCommandExecutionAdapter } from '../local-command-adapter.js';
+import type { ExecutionRequest } from '../types.js';
+
+const fakeHarnessPath = fileURLToPath(new URL('./fixtures/fake-harness.mjs', import.meta.url));
+
+function baseRequest(): ExecutionRequest {
+  return {
+    assistantId: 'assistant-1',
+    turnId: 'turn-1',
+    sessionId: 'session-1',
+    userId: 'user-1',
+    threadId: 'thread-1',
+    message: {
+      id: 'msg-1',
+      text: 'Prove the generic local harness path.',
+      receivedAt: '2026-04-20T12:00:00.000Z',
+    },
+    instructions: {
+      systemPrompt: 'You are Sage.',
+      developerPrompt: 'Keep the proof deterministic.',
+    },
+    context: {
+      blocks: [
+        {
+          id: 'ctx-1',
+          label: 'Scope',
+          text: 'Use a spawned fake harness process.',
+          category: 'workspace',
+        },
+        {
+          id: 'ctx-2',
+          label: 'Memory',
+          text: 'The local command adapter owns process translation only.',
+          category: 'memory',
+        },
+      ],
+    },
+    tools: [{ name: 'relay_lookup', description: 'Lookup relay proof evidence' }],
+  };
+}
+
+describe('LocalCommandExecutionAdapter proof', () => {
+  it('executes through a real spawned fake harness command', async () => {
+    const adapter = new LocalCommandExecutionAdapter({
+      backendId: 'fake-local-harness',
+      command: process.execPath,
+      capabilities: {
+        toolUse: 'adapter-mediated',
+        structuredToolCalls: true,
+        continuationSupport: 'none',
+        approvalInterrupts: 'none',
+        traceDepth: 'minimal',
+        attachments: false,
+        maxContextStrategy: 'medium',
+      },
+      buildArgs: (request) => [
+        fakeHarnessPath,
+        request.message.text,
+        JSON.stringify({
+          assistantId: request.assistantId,
+          systemPromptLength: request.instructions.systemPrompt.length,
+          contextBlockCount: request.context?.blocks.length ?? 0,
+          toolNames: (request.tools ?? []).map((tool) => tool.name),
+        }),
+      ],
+      parseOutput: (stdout) => JSON.parse(stdout) as {
+        text: string;
+        structured: Record<string, unknown>;
+        toolCalls: unknown[];
+      },
+      timeoutMs: 5_000,
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result.status).toBe('completed');
+    expect(result.backendId).toBe('fake-local-harness');
+    expect(result.output?.text).toBe('fake-harness handled: Prove the generic local harness path.');
+    expect(result.output?.structured).toMatchObject({
+      assistantId: 'assistant-1',
+      systemPromptLength: 'You are Sage.'.length,
+      contextBlockCount: 2,
+      toolNames: ['relay_lookup'],
+      toolCalls: [{ name: 'relay_lookup', result: 'ok' }],
+    });
+    expect(result.trace?.summary.toolCallCount).toBe(1);
+  });
+});

--- a/packages/turn-context/README.md
+++ b/packages/turn-context/README.md
@@ -109,6 +109,36 @@ const result = await harness.runTurn({
 
 The `harnessProjection` output is always a valid `HarnessInstructions` + `HarnessPreparedContext`. No adapter or transformation is needed between `assemble()` and `harness.runTurn()`.
 
+## Direct execution adapter projection
+
+Products that execute through an `ExecutionAdapter` can project the same assembly into the
+canonical `ExecutionRequest` shape with `toExecutionRequest`.
+
+```ts
+import {
+  createTurnContextAssembler,
+  toExecutionRequest,
+} from '@agent-assistant/turn-context';
+
+const assembler = createTurnContextAssembler();
+const assembly = await assembler.assemble(input);
+
+const request = toExecutionRequest(assembly, incomingMessage, {
+  tools: readOnlyToolDescriptors,
+  requirements: { toolUse: 'allowed', traceDepth: 'standard' },
+  metadata: { route: 'founder-chat' },
+});
+
+const negotiation = adapter.negotiate(request);
+const result = negotiation.supported
+  ? await adapter.execute(request)
+  : { status: 'unsupported', degradation: negotiation.reasons };
+```
+
+The projection preserves assistant/session/user/thread ids, rendered instructions, context
+blocks, response style, message metadata, and optional tools/requirements/continuation metadata.
+Execution adapters stay downstream of turn-context; products still own identity and policy.
+
 ---
 
 ## Multi-source assembly with memory, enrichment, and guardrails
@@ -281,3 +311,8 @@ try {
   }
 }
 ```
+
+### `toExecutionRequest(assembly, userMessage, overrides?)`
+
+Projects a `TurnContextAssembly` and incoming message into the canonical
+`@agent-assistant/harness` `ExecutionRequest` used by execution adapters.

--- a/packages/turn-context/dist/index.d.ts
+++ b/packages/turn-context/dist/index.d.ts
@@ -2,5 +2,7 @@ export { createTurnContextAssembler } from './assembler.js';
 export type { CreateTurnContextAssemblerOptions } from './assembler.js';
 export { createMemoryTurnRetriever } from './memory-retriever.js';
 export type { CreateMemoryTurnRetrieverOptions } from './memory-retriever.js';
+export { projectToHarness, toExecutionRequest } from './projection.js';
+export type { ExecutionRequestMessageInput, ProjectedExecutionRequest, ProjectedExecutionRequirements, ProjectedExecutionToolDescriptor, ToExecutionRequestOverrides, } from './projection.js';
 export type { TurnContextAssembler, TurnContextInput, TurnIdentityInput, TurnShapingInput, TurnInstructionOverlay, TurnSessionInput, TurnMemoryInput, TurnMemoryRetrievalInput, TurnMemoryCandidate, TurnEnrichmentInput, TurnEnrichmentCandidate, TurnGuardrailInput, TurnGuardrailOverlay, TurnExpressionProfile, TurnContextAssembly, TurnIdentityProjection, TurnInstructionBundle, TurnInstructionSegment, TurnPreparedContext, TurnPreparedContextBlock, TurnContextProvenance, TurnMemoryProjector, TurnMemoryRetriever, TurnEnrichmentProjector, TurnInstructionComposer, } from './types.js';
 export { TurnContextValidationError } from './validation.js';

--- a/packages/turn-context/dist/index.js
+++ b/packages/turn-context/dist/index.js
@@ -1,3 +1,4 @@
 export { createTurnContextAssembler } from './assembler.js';
 export { createMemoryTurnRetriever } from './memory-retriever.js';
+export { projectToHarness, toExecutionRequest } from './projection.js';
 export { TurnContextValidationError } from './validation.js';

--- a/packages/turn-context/dist/projection.d.ts
+++ b/packages/turn-context/dist/projection.d.ts
@@ -1,5 +1,66 @@
 import type { HarnessInstructions, HarnessPreparedContext } from '@agent-assistant/harness';
-import type { TurnInstructionBundle, TurnPreparedContext, TurnShapingInput } from './types.js';
+import type { TurnContextAssembly, TurnInstructionBundle, TurnPreparedContext, TurnShapingInput } from './types.js';
+export interface ProjectedExecutionToolDescriptor {
+    name: string;
+    description?: string;
+    inputSchema?: Record<string, unknown>;
+    requiresApproval?: boolean;
+    metadata?: Record<string, unknown>;
+}
+export interface ProjectedExecutionRequirements {
+    toolUse?: 'forbidden' | 'allowed' | 'required';
+    structuredToolCalls?: 'forbidden' | 'preferred' | 'required';
+    continuationSupport?: 'none' | 'preferred' | 'required';
+    approvalInterrupts?: 'none' | 'preferred' | 'required';
+    traceDepth?: 'minimal' | 'standard' | 'detailed';
+    attachments?: 'forbidden' | 'allowed' | 'required';
+}
+export interface ProjectedExecutionRequest {
+    assistantId: string;
+    turnId: string;
+    sessionId?: string;
+    userId?: string;
+    threadId?: string;
+    message: {
+        id: string;
+        text: string;
+        receivedAt: string;
+        attachments?: Array<{
+            id: string;
+            type: string;
+            name?: string;
+            url?: string;
+            metadata?: Record<string, unknown>;
+        }>;
+    };
+    instructions: {
+        systemPrompt: string;
+        developerPrompt?: string;
+        responseStyle?: {
+            preferMarkdown?: boolean;
+            maxAnswerChars?: number;
+        };
+    };
+    context?: {
+        blocks: Array<{
+            id: string;
+            label: string;
+            text: string;
+            category?: 'memory' | 'workspace' | 'enrichment' | 'guardrail' | 'other';
+            metadata?: Record<string, unknown>;
+        }>;
+        structured?: Record<string, unknown>;
+    };
+    continuation?: {
+        continuationId?: string;
+        kind?: 'clarification' | 'approval' | 'deferred' | string;
+        state?: Record<string, unknown>;
+        metadata?: Record<string, unknown>;
+    };
+    tools?: ProjectedExecutionToolDescriptor[];
+    requirements?: ProjectedExecutionRequirements;
+    metadata?: Record<string, unknown>;
+}
 /**
  * Projects the internal turn assembly into HarnessInstructions + HarnessPreparedContext.
  *
@@ -13,3 +74,11 @@ export declare function projectToHarness(instructions: TurnInstructionBundle, co
     instructions: HarnessInstructions;
     context: HarnessPreparedContext;
 };
+export type ExecutionRequestMessageInput = ProjectedExecutionRequest['message'];
+export interface ToExecutionRequestOverrides {
+    tools?: ProjectedExecutionToolDescriptor[];
+    requirements?: ProjectedExecutionRequirements;
+    continuation?: ProjectedExecutionRequest['continuation'];
+    metadata?: Record<string, unknown>;
+}
+export declare function toExecutionRequest(assembly: TurnContextAssembly, userMessage: ExecutionRequestMessageInput, overrides?: ToExecutionRequestOverrides): ProjectedExecutionRequest;

--- a/packages/turn-context/dist/projection.js
+++ b/packages/turn-context/dist/projection.js
@@ -52,3 +52,57 @@ export function projectToHarness(instructions, context, responseStyle) {
         context: harnessContext,
     };
 }
+function mapContextCategory(category) {
+    if (category === 'session') {
+        return 'other';
+    }
+    return category;
+}
+function mapContextBlock(block) {
+    const mappedCategory = mapContextCategory(block.category);
+    return {
+        id: block.id,
+        label: block.label,
+        text: block.content,
+        ...(mappedCategory !== undefined ? { category: mappedCategory } : {}),
+        ...(block.source !== undefined || block.importance !== undefined || block.category === 'session'
+            ? {
+                metadata: {
+                    ...(block.source !== undefined ? { source: block.source } : {}),
+                    ...(block.importance !== undefined ? { importance: block.importance } : {}),
+                    ...(block.category === 'session' ? { turnContextCategory: 'session' } : {}),
+                },
+            }
+            : {}),
+    };
+}
+function mergeMetadata(assemblyMetadata, overrideMetadata) {
+    if (assemblyMetadata === undefined && overrideMetadata === undefined) {
+        return undefined;
+    }
+    return {
+        ...(assemblyMetadata ?? {}),
+        ...(overrideMetadata ?? {}),
+    };
+}
+export function toExecutionRequest(assembly, userMessage, overrides = {}) {
+    const context = {
+        blocks: assembly.context.blocks.map(mapContextBlock),
+        ...(assembly.context.structured !== undefined ? { structured: assembly.context.structured } : {}),
+    };
+    const metadata = mergeMetadata(assembly.metadata, overrides.metadata);
+    return {
+        assistantId: assembly.assistantId,
+        turnId: assembly.turnId,
+        ...(assembly.sessionId !== undefined ? { sessionId: assembly.sessionId } : {}),
+        ...(assembly.userId !== undefined ? { userId: assembly.userId } : {}),
+        ...(assembly.threadId !== undefined ? { threadId: assembly.threadId } : {}),
+        message: userMessage,
+        instructions: assembly.harnessProjection.instructions,
+        context,
+        ...(overrides.continuation !== undefined ? { continuation: overrides.continuation } : {}),
+        ...(overrides.tools !== undefined ? { tools: overrides.tools } : {}),
+        ...(overrides.requirements !== undefined ? { requirements: overrides.requirements } : {}),
+        ...(metadata !== undefined ? { metadata } : {}),
+    };
+}

--- a/packages/turn-context/package.json
+++ b/packages/turn-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/turn-context",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Turn-scoped context assembly for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/turn-context/src/index.ts
+++ b/packages/turn-context/src/index.ts
@@ -2,6 +2,14 @@ export { createTurnContextAssembler } from './assembler.js';
 export type { CreateTurnContextAssemblerOptions } from './assembler.js';
 export { createMemoryTurnRetriever } from './memory-retriever.js';
 export type { CreateMemoryTurnRetrieverOptions } from './memory-retriever.js';
+export { projectToHarness, toExecutionRequest } from './projection.js';
+export type {
+  ExecutionRequestMessageInput,
+  ProjectedExecutionRequest,
+  ProjectedExecutionRequirements,
+  ProjectedExecutionToolDescriptor,
+  ToExecutionRequestOverrides,
+} from './projection.js';
 
 export type {
   // Assembler interface

--- a/packages/turn-context/src/projection.test.ts
+++ b/packages/turn-context/src/projection.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTurnContextAssembler } from './assembler.js';
+import { toExecutionRequest } from './projection.js';
+
+describe('toExecutionRequest', () => {
+  it('projects turn-context assembly into the canonical ExecutionRequest shape', async () => {
+    const assembler = createTurnContextAssembler();
+    const assembly = await assembler.assemble({
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      userId: 'user-1',
+      threadId: 'thread-1',
+      identity: {
+        assistantName: 'Sage',
+        baseInstructions: {
+          systemPrompt: 'You are Sage.',
+          developerPrompt: 'Preserve product identity.',
+        },
+      },
+      shaping: {
+        mode: 'founder-advisory',
+        instructionOverlays: [
+          {
+            id: 'overlay-1',
+            source: 'triage',
+            text: 'Focus on delivery risk.',
+            priority: 'high',
+          },
+        ],
+        responseStyle: {
+          preferMarkdown: true,
+          maxAnswerChars: 1200,
+        },
+      },
+      memory: {
+        candidates: [
+          {
+            id: 'mem-1',
+            text: 'Founder prefers concise risk calls.',
+            scope: 'user',
+            source: 'memory',
+            relevance: 0.9,
+          },
+        ],
+      },
+      enrichment: {
+        candidates: [
+          {
+            id: 'enrich-1',
+            kind: 'workspace_state',
+            source: 'reviewer',
+            title: 'Review Signal',
+            content: 'The implementation plan is ready.',
+            importance: 'high',
+          },
+        ],
+      },
+      guardrails: {
+        overlays: [
+          {
+            id: 'guardrail-1',
+            source: 'policy',
+            rule: 'Do not claim unverified test results.',
+            priority: 'high',
+          },
+        ],
+      },
+      metadata: {
+        assemblySource: 'test',
+        owner: 'assembly',
+      },
+    });
+
+    const request = toExecutionRequest(
+      assembly,
+      {
+        id: 'msg-1',
+        text: 'What is left for local BYOH?',
+        receivedAt: '2026-04-20T12:00:00.000Z',
+        attachments: [
+          {
+            id: 'att-1',
+            type: 'text/markdown',
+            name: 'plan.md',
+          },
+        ],
+      },
+      {
+        tools: [{ name: 'relay_lookup', description: 'Lookup relay evidence' }],
+        requirements: { toolUse: 'allowed', traceDepth: 'standard' },
+        continuation: {
+          continuationId: 'cont-1',
+          kind: 'deferred',
+          state: { cursor: 'abc' },
+        },
+        metadata: {
+          owner: 'override',
+          triage: { route: 'local-byoh' },
+        },
+      },
+    );
+
+    expect(request).toMatchObject({
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      userId: 'user-1',
+      threadId: 'thread-1',
+      message: {
+        id: 'msg-1',
+        text: 'What is left for local BYOH?',
+        receivedAt: '2026-04-20T12:00:00.000Z',
+        attachments: [{ id: 'att-1', type: 'text/markdown', name: 'plan.md' }],
+      },
+      tools: [{ name: 'relay_lookup', description: 'Lookup relay evidence' }],
+      requirements: { toolUse: 'allowed', traceDepth: 'standard' },
+      continuation: {
+        continuationId: 'cont-1',
+        kind: 'deferred',
+        state: { cursor: 'abc' },
+      },
+      metadata: {
+        assemblySource: 'test',
+        owner: 'override',
+        triage: { route: 'local-byoh' },
+      },
+    });
+
+    for (const segment of assembly.instructions.systemSegments) {
+      expect(request.instructions.systemPrompt).toContain(segment.text);
+    }
+    for (const segment of [
+      ...assembly.instructions.developerSegments,
+      ...assembly.instructions.guardrailSegments,
+    ]) {
+      expect(request.instructions.developerPrompt).toContain(segment.text);
+    }
+    expect(request.instructions.responseStyle).toEqual({
+      preferMarkdown: true,
+      maxAnswerChars: 1200,
+    });
+
+    expect(request.context?.blocks).toHaveLength(2);
+    expect(request.context?.blocks[0]).toMatchObject({
+      id: assembly.context.blocks[0]?.id,
+      label: assembly.context.blocks[0]?.label,
+      text: assembly.context.blocks[0]?.content,
+      category: assembly.context.blocks[0]?.category,
+    });
+    expect(request.context?.blocks[1]).toMatchObject({
+      id: assembly.context.blocks[1]?.id,
+      label: assembly.context.blocks[1]?.label,
+      text: assembly.context.blocks[1]?.content,
+      category: assembly.context.blocks[1]?.category,
+    });
+  });
+
+  it('maps session context blocks to ExecutionRequest other blocks with source metadata', async () => {
+    const assembler = createTurnContextAssembler();
+    const assembly = await assembler.assemble({
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      sessionId: 'session-1',
+      identity: {
+        baseInstructions: {
+          systemPrompt: 'You are Sage.',
+        },
+      },
+      session: {
+        state: 'active',
+        summary: 'Discussing local BYOH.',
+      },
+    });
+
+    const request = toExecutionRequest(assembly, {
+      id: 'msg-1',
+      text: 'Continue.',
+      receivedAt: '2026-04-20T12:00:00.000Z',
+    });
+
+    expect(request.context?.blocks[0]).toMatchObject({
+      label: 'Session Context',
+      text: 'State: active\nSummary: Discussing local BYOH.',
+      category: 'other',
+      metadata: {
+        source: 'session',
+        turnContextCategory: 'session',
+      },
+    });
+  });
+});

--- a/packages/turn-context/src/projection.ts
+++ b/packages/turn-context/src/projection.ts
@@ -1,12 +1,81 @@
-import type { HarnessInstructions, HarnessPreparedContext } from '@agent-assistant/harness';
 import type {
+  HarnessInstructions,
+  HarnessPreparedContext,
+} from '@agent-assistant/harness';
+import type {
+  TurnContextAssembly,
   TurnInstructionBundle,
   TurnInstructionSegment,
+  TurnPreparedContextBlock,
   TurnPreparedContext,
   TurnShapingInput,
 } from './types.js';
 
 type Priority = 'low' | 'medium' | 'high';
+
+export interface ProjectedExecutionToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  requiresApproval?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProjectedExecutionRequirements {
+  toolUse?: 'forbidden' | 'allowed' | 'required';
+  structuredToolCalls?: 'forbidden' | 'preferred' | 'required';
+  continuationSupport?: 'none' | 'preferred' | 'required';
+  approvalInterrupts?: 'none' | 'preferred' | 'required';
+  traceDepth?: 'minimal' | 'standard' | 'detailed';
+  attachments?: 'forbidden' | 'allowed' | 'required';
+}
+
+export interface ProjectedExecutionRequest {
+  assistantId: string;
+  turnId: string;
+  sessionId?: string;
+  userId?: string;
+  threadId?: string;
+  message: {
+    id: string;
+    text: string;
+    receivedAt: string;
+    attachments?: Array<{
+      id: string;
+      type: string;
+      name?: string;
+      url?: string;
+      metadata?: Record<string, unknown>;
+    }>;
+  };
+  instructions: {
+    systemPrompt: string;
+    developerPrompt?: string;
+    responseStyle?: {
+      preferMarkdown?: boolean;
+      maxAnswerChars?: number;
+    };
+  };
+  context?: {
+    blocks: Array<{
+      id: string;
+      label: string;
+      text: string;
+      category?: 'memory' | 'workspace' | 'enrichment' | 'guardrail' | 'other';
+      metadata?: Record<string, unknown>;
+    }>;
+    structured?: Record<string, unknown>;
+  };
+  continuation?: {
+    continuationId?: string;
+    kind?: 'clarification' | 'approval' | 'deferred' | string;
+    state?: Record<string, unknown>;
+    metadata?: Record<string, unknown>;
+  };
+  tools?: ProjectedExecutionToolDescriptor[];
+  requirements?: ProjectedExecutionRequirements;
+  metadata?: Record<string, unknown>;
+}
 
 const PRIORITY_ORDER: Record<Priority, number> = { low: 0, medium: 1, high: 2 };
 
@@ -75,5 +144,87 @@ export function projectToHarness(
   return {
     instructions: harnessInstructions,
     context: harnessContext,
+  };
+}
+
+export type ExecutionRequestMessageInput = ProjectedExecutionRequest['message'];
+
+export interface ToExecutionRequestOverrides {
+  tools?: ProjectedExecutionToolDescriptor[];
+  requirements?: ProjectedExecutionRequirements;
+  continuation?: ProjectedExecutionRequest['continuation'];
+  metadata?: Record<string, unknown>;
+}
+
+function mapContextCategory(
+  category: TurnPreparedContextBlock['category'],
+): NonNullable<NonNullable<ProjectedExecutionRequest['context']>['blocks'][number]['category']> | undefined {
+  if (category === 'session') {
+    return 'other';
+  }
+
+  return category;
+}
+
+function mapContextBlock(
+  block: TurnPreparedContextBlock,
+): NonNullable<ProjectedExecutionRequest['context']>['blocks'][number] {
+  const mappedCategory = mapContextCategory(block.category);
+
+  return {
+    id: block.id,
+    label: block.label,
+    text: block.content,
+    ...(mappedCategory !== undefined ? { category: mappedCategory } : {}),
+    ...(block.source !== undefined || block.importance !== undefined || block.category === 'session'
+      ? {
+          metadata: {
+            ...(block.source !== undefined ? { source: block.source } : {}),
+            ...(block.importance !== undefined ? { importance: block.importance } : {}),
+            ...(block.category === 'session' ? { turnContextCategory: 'session' } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function mergeMetadata(
+  assemblyMetadata: Record<string, unknown> | undefined,
+  overrideMetadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (assemblyMetadata === undefined && overrideMetadata === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(assemblyMetadata ?? {}),
+    ...(overrideMetadata ?? {}),
+  };
+}
+
+export function toExecutionRequest(
+  assembly: TurnContextAssembly,
+  userMessage: ExecutionRequestMessageInput,
+  overrides: ToExecutionRequestOverrides = {},
+): ProjectedExecutionRequest {
+  const context: ProjectedExecutionRequest['context'] = {
+    blocks: assembly.context.blocks.map(mapContextBlock),
+    ...(assembly.context.structured !== undefined ? { structured: assembly.context.structured } : {}),
+  };
+  const metadata = mergeMetadata(assembly.metadata, overrides.metadata);
+
+  return {
+    assistantId: assembly.assistantId,
+    turnId: assembly.turnId,
+    ...(assembly.sessionId !== undefined ? { sessionId: assembly.sessionId } : {}),
+    ...(assembly.userId !== undefined ? { userId: assembly.userId } : {}),
+    ...(assembly.threadId !== undefined ? { threadId: assembly.threadId } : {}),
+    message: userMessage,
+    instructions: assembly.harnessProjection.instructions,
+    context,
+    ...(overrides.continuation !== undefined ? { continuation: overrides.continuation } : {}),
+    ...(overrides.tools !== undefined ? { tools: overrides.tools } : {}),
+    ...(overrides.requirements !== undefined ? { requirements: overrides.requirements } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
   };
 }


### PR DESCRIPTION
## Summary

- Adds reusable Agent Assistant BYOH/local harness primitives for product consumers.
- Exposes/proves the turn-context to execution-request path needed by NightCTO.
- Keeps local harness execution generic so Claude Code is a default/example, not the architecture boundary.

## Validation

- npm run test --workspace @agent-assistant/harness
- npm run test --workspace @agent-assistant/turn-context
- npm run build --workspace @agent-assistant/harness
- npm run build --workspace @agent-assistant/turn-context

## Dependent PRs

- NightCTO consumer PR, draft until this lands: https://github.com/AgentWorkforce/nightcto/pull/52
