### PR TITLE
Add local BYOH Relay harness support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3514,7 +3514,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.3.2",
+      "version": "0.3.4",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -247,9 +247,12 @@ const adapter = new AgentRelayExecutionAdapter({
 
 The request message body is JSON with type `agent-assistant.execution-request.v1`.
 Workers reply with JSON type `agent-assistant.execution-result.v1` and an `executionResult`
-that follows the normal `ExecutionResult` contract. This keeps Claude Code, Codex, OpenCode,
-or a custom local worker behind Relay instead of baking provider-specific CLI argv into the
-product.
+that follows the normal `ExecutionResult` contract. Successful turns should use
+`executionResult.status: "completed"` and put the assistant answer in
+`executionResult.output.text`. The adapter also tolerates common local-worker shorthands
+such as `status: "ok"` plus `answer` and normalizes them into the same `ExecutionResult`
+shape. This keeps Claude Code, Codex, OpenCode, or a custom local worker behind Relay
+instead of baking provider-specific CLI argv into the product.
 
 ## Public API
 

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/adapter/agent-relay-adapter.test.ts
+++ b/packages/harness/src/adapter/agent-relay-adapter.test.ts
@@ -44,6 +44,7 @@ class FakeRelayTransport implements AgentRelayExecutionTransport {
     respond?: boolean;
     failSend?: boolean;
     failSpawn?: boolean;
+    responseBody?: (input: SendMessageInput) => Record<string, unknown>;
   } = {}) {}
 
   async start(): Promise<void> {
@@ -59,24 +60,26 @@ class FakeRelayTransport implements AgentRelayExecutionTransport {
     if (this.options.respond ?? true) {
       const requestMessage = JSON.parse(input.text) as { turnId: string; threadId: string };
       queueMicrotask(() => {
+        const body = this.options.responseBody?.(input) ?? {
+          type: AGENT_RELAY_EXECUTION_RESULT_TYPE,
+          turnId: requestMessage.turnId,
+          threadId: requestMessage.threadId,
+          executionResult: {
+            backendId: 'worker-backend',
+            status: 'completed',
+            output: {
+              text: 'Relay worker completed the turn.',
+            },
+          } satisfies ExecutionResult,
+        };
+
         this.emit({
           kind: 'relay_inbound',
           event_id: 'evt-result-1',
           from: 'local-worker',
           target: input.from ?? 'agent-assistant',
           thread_id: input.threadId,
-          body: JSON.stringify({
-            type: AGENT_RELAY_EXECUTION_RESULT_TYPE,
-            turnId: requestMessage.turnId,
-            threadId: requestMessage.threadId,
-            executionResult: {
-              backendId: 'worker-backend',
-              status: 'completed',
-              output: {
-                text: 'Relay worker completed the turn.',
-              },
-            } satisfies ExecutionResult,
-          }),
+          body: JSON.stringify(body),
         });
       });
     }
@@ -165,6 +168,61 @@ describe('AgentRelayExecutionAdapter', () => {
           channelId: 'nightcto-local',
           target: 'local-worker',
         },
+      },
+    });
+  });
+
+  it('normalizes a practical worker result that uses status ok and answer', async () => {
+    const relay = new FakeRelayTransport({
+      responseBody(input) {
+        const requestMessage = JSON.parse(input.text) as { turnId: string; threadId: string };
+
+        return {
+          type: AGENT_RELAY_EXECUTION_RESULT_TYPE,
+          turnId: requestMessage.turnId,
+          threadId: requestMessage.threadId,
+          assistantId: 'nightcto-local-chat',
+          executionResult: {
+            status: 'ok',
+            answer: 'E2E_OK: local git status was inspected.',
+            toolCalls: [
+              {
+                name: 'Bash(git status:*)',
+                input: { command: 'git status' },
+                output: 'On branch codex/example; no staged changes.',
+              },
+            ],
+          },
+        };
+      },
+    });
+    const adapter = new AgentRelayExecutionAdapter({
+      relay,
+      workerName: 'local-worker',
+      orchestratorName: 'nightcto',
+      channelId: 'nightcto-local',
+    });
+
+    const result = await adapter.execute(baseRequest());
+
+    expect(result).toMatchObject({
+      backendId: 'agent-relay',
+      status: 'completed',
+      output: {
+        text: 'E2E_OK: local git status was inspected.',
+        structured: {
+          toolCalls: [
+            {
+              name: 'Bash(git status:*)',
+            },
+          ],
+        },
+      },
+      metadata: {
+        relay: {
+          workerBackendId: 'agent-relay-worker',
+        },
+        normalizedFromRelayWorker: true,
       },
     });
   });

--- a/packages/harness/src/adapter/agent-relay-adapter.ts
+++ b/packages/harness/src/adapter/agent-relay-adapter.ts
@@ -270,6 +270,97 @@ function isExecutionResult(value: unknown): value is ExecutionResult {
   return typeof candidate.backendId === 'string' && typeof candidate.status === 'string';
 }
 
+function readString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function readOutputText(record: Record<string, unknown>): string | undefined {
+  const directText = readString(record, ['text', 'answer', 'output_text', 'outputText', 'result']);
+
+  if (directText) {
+    return directText;
+  }
+
+  const output = record.output;
+
+  if (output && typeof output === 'object' && !Array.isArray(output)) {
+    return readString(output as Record<string, unknown>, ['text', 'answer', 'output_text', 'outputText']);
+  }
+
+  return undefined;
+}
+
+function normalizeWorkerStatus(status: unknown): ExecutionResult['status'] | undefined {
+  if (
+    status === 'completed' ||
+    status === 'needs_clarification' ||
+    status === 'awaiting_approval' ||
+    status === 'deferred' ||
+    status === 'failed' ||
+    status === 'unsupported'
+  ) {
+    return status;
+  }
+
+  if (status === 'ok' || status === 'success' || status === 'done') {
+    return 'completed';
+  }
+
+  if (status === undefined || status === null) {
+    return undefined;
+  }
+
+  return 'failed';
+}
+
+function coerceExecutionResult(value: unknown): ExecutionResult | null {
+  if (isExecutionResult(value)) {
+    return value;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const status = normalizeWorkerStatus(record.status);
+  const text = readOutputText(record);
+
+  if (!status || !text) {
+    return null;
+  }
+
+  const structured: Record<string, unknown> = {};
+
+  for (const key of ['structured', 'toolCalls', 'tool_calls']) {
+    const valueForKey = record[key];
+
+    if (valueForKey !== undefined) {
+      structured[key] = valueForKey;
+    }
+  }
+
+  return {
+    backendId: readString(record, ['backendId', 'backend_id', 'backend']) ?? 'agent-relay-worker',
+    status,
+    output: {
+      text,
+      ...(Object.keys(structured).length > 0 ? { structured } : {}),
+    },
+    metadata: {
+      normalizedFromRelayWorker: true,
+    },
+  };
+}
+
 function parseResultMessage(raw: string): AgentRelayExecutionResultMessage | null {
   const record = parseJsonObject(raw);
 
@@ -282,8 +373,9 @@ function parseResultMessage(raw: string): AgentRelayExecutionResultMessage | nul
   }
 
   const result = record.executionResult ?? record.result;
+  const executionResult = coerceExecutionResult(result);
 
-  if (!isExecutionResult(result)) {
+  if (!executionResult) {
     return null;
   }
 
@@ -298,7 +390,7 @@ function parseResultMessage(raw: string): AgentRelayExecutionResultMessage | nul
     type: record.type,
     turnId,
     threadId,
-    executionResult: result,
+    executionResult,
   } as AgentRelayExecutionResultMessage;
 }
 
@@ -312,7 +404,10 @@ function buildDefaultWorkerTask(input: {
     'For each request, preserve the assistant identity and instructions inside request.instructions.',
     'Use only the tools described by request.tools and respect read-only metadata.',
     'Send the result back to the sender on the same thread using Relay messaging.',
-    `The response body must be JSON with type "${AGENT_RELAY_EXECUTION_RESULT_TYPE}", the same turnId/threadId, and executionResult shaped like Agent Assistant ExecutionResult.`,
+    `The response body must be JSON with type "${AGENT_RELAY_EXECUTION_RESULT_TYPE}", the same turnId/threadId, and an executionResult shaped exactly like Agent Assistant ExecutionResult.`,
+    'Use executionResult.status "completed" for successful turns, not "ok" or "success".',
+    'Put the final assistant response in executionResult.output.text, not top-level answer/text.',
+    'Minimum successful response shape: {"type":"agent-assistant.execution-result.v1","turnId":"<same>","threadId":"<same>","executionResult":{"backendId":"agent-relay-worker","status":"completed","output":{"text":"<final response>"}}}.',
     `Default channel: ${input.channelId}.`,
   ].join('\n');
 }


### PR DESCRIPTION
## Summary
- add reusable local command and Agent Relay execution adapters for Agent Assistant BYOH flows
- add turn-context projection helpers so NightCTO can send structured ExecutionRequest payloads through a local harness
- tighten Relay worker result handling by normalizing practical worker replies like `status: "ok"` + `answer` into Agent Assistant `ExecutionResult` objects
- document the Relay request/result contract and local harness usage

## Validation
- `npm test --workspace @agent-assistant/harness`
- `npm run build --workspace @agent-assistant/harness`
- `npm pack --workspace @agent-assistant/harness --pack-destination /tmp`
- NightCTO live E2E against the packed `@agent-assistant/harness@0.3.4`: root `npm run local-chat:relay -- --once ...` auto-spawned a Relay/Claude local worker, inspected `git status`, printed `E2E_OK`, and exited code 0

## Notes
- `@agent-assistant/harness@0.3.4` is ready to publish, but publishing from my shell was blocked by npm auth (`npm whoami` returned E401). NightCTO can bump to the registry package after that publish is done from an authenticated session.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
