### PR TITLE
fix(harness)!: move AgentRelayExecutionAdapter to dedicated subpath so worker bundles link

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.3.6",
+  "version": "0.3.5",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,14 +1,19 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./agent-relay": {
+      "import": "./dist/adapter/agent-relay-adapter.js",
+      "types": "./dist/adapter/agent-relay-adapter.d.ts"
     },
     "./proof": {
       "import": "./dist/proof.js",

--- a/packages/harness/src/adapter/index.ts
+++ b/packages/harness/src/adapter/index.ts
@@ -1,13 +1,19 @@
 export { ClaudeCodeExecutionAdapter, createClaudeCodeAdapter } from './claude-code-adapter.js';
-export {
-  AGENT_RELAY_EXECUTION_REQUEST_TYPE,
-  AGENT_RELAY_EXECUTION_RESULT_TYPE,
-  AgentRelayExecutionAdapter,
-  createAgentRelayExecutionAdapter,
-} from './agent-relay-adapter.js';
+// NOTE: AgentRelayExecutionAdapter is intentionally NOT re-exported from
+// the default barrel. It imports RelayAdapter from @agent-relay/sdk, which
+// has a Node-only implementation — the SDK's workerd/worker conditional
+// export omits RelayAdapter, so bundlers targeting Cloudflare Workers fail
+// to link this file when it's pulled in transitively.
+//
+// Consumers that need the adapter should import from the dedicated subpath:
+//     import { createAgentRelayExecutionAdapter } from '@agent-assistant/harness/agent-relay';
+// Workers bundlers won't resolve that subpath unless the consumer asks
+// for it explicitly, so worker bundles stay clean.
 export { LocalCommandExecutionAdapter, createLocalCommandAdapter } from './local-command-adapter.js';
 export { OpenRouterExecutionAdapter, createOpenRouterAdapter } from './openrouter-adapter.js';
 
+// Type-only re-exports are stripped by the TS compiler to nothing in JS,
+// so bundlers never follow the link. Safe to keep here for convenience.
 export type {
   AgentRelayExecutionAdapterConfig,
   AgentRelayExecutionRequestMessage,


### PR DESCRIPTION
## Problem

The AgentRelayExecutionAdapter in \`packages/harness/src/adapter/agent-relay-adapter.ts\` imports \`RelayAdapter\` from \`@agent-relay/sdk\`. The SDK has a \`workerd\`/\`worker\` conditional export (\`dist/workers.js\`) that intentionally omits \`RelayAdapter\` — the underlying implementation is Node-only.

When harness is consumed in a Cloudflare Workers bundle (e.g. \`cloud/sage-worker\`, \`cloud/specialist-worker\` in AgentWorkforce/cloud), esbuild follows the default adapter barrel, tries to link the import, and fails at build time:

\`\`\`
[ERROR] No matching export in "node_modules/@agent-relay/sdk/dist/workers.js" for import "RelayAdapter"
  packages/sage-worker/node_modules/@agent-assistant/harness/dist/adapter/agent-relay-adapter.js:1:9
\`\`\`

\`"sideEffects": false\` alone doesn't fix it: esbuild resolves imports **before** tree-shaking, so the link error fires regardless of whether the adapter's exports are consumed.

## Fix

Move the Agent Relay adapter behind a dedicated subpath export so worker bundlers don't pull it in unless a consumer asks for it explicitly.

- **Remove runtime re-exports** of \`AgentRelayExecutionAdapter\`, \`createAgentRelayExecutionAdapter\`, and the event-type constants from \`src/adapter/index.ts\`.
- **Keep type-only re-exports** (\`export type { ... }\`) — TS strips these from the compiled JS, so bundlers never see the link.
- **Add \`./agent-relay\`** to \`package.json\` exports, pointing at \`./dist/adapter/agent-relay-adapter.js\`.
- **Add \`"sideEffects": false\`** — defensive tree-shaking help, bonus win once the link barrier is removed.

## Breaking change

Consumers that previously imported from the default barrel:

\`\`\`ts
// before
import { AgentRelayExecutionAdapter, createAgentRelayExecutionAdapter } from '@agent-assistant/harness';
\`\`\`

now need:

\`\`\`ts
// after
import { AgentRelayExecutionAdapter, createAgentRelayExecutionAdapter } from '@agent-assistant/harness/agent-relay';
\`\`\`

Type-only imports (\`import type { AgentRelayExecutionAdapterConfig }\`) still work from the default barrel.

I grepped AgentWorkforce/cloud and the only harness consumer there is \`@agentworkforce/sage\`, which uses \`createHarness\` / \`createOpenRouterModelAdapter\` / \`createOpenRouterSingleShotAdapter\` — none of the relay-adapter surface. No cloud consumer needs to update.

Minor version bump (0.3.5 → 0.3.6). Happy to retag as a major if the inventory review prefers.

## Verification

\`\`\`
$ cd agent-assistant/packages/harness && npm run build && npm pack
# then swapped the packed tgz into cloud@main via overrides:
$ cd cloud && node scripts/check-sage-worker-bundle.mjs
...
OK: sage worker bundle initialized cleanly and /health returned 200
\`\`\`

## Related

- **AgentWorkforce/cloud#254** — cloud-side hotfix pinning harness to 0.3.1 (the last \`^0.3.1\` version that didn't ship \`agent-relay-adapter.js\`). Once this PR publishes, that pin can be lifted.
- Introduced the link failure: \`agent-relay-adapter.js\` was added to the default barrel in harness 0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
