### PR TITLE
feat(surfaces): SlackEventDedupGate for Slack retry dedup

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,6 +1,6 @@
 # Current State
 
-Date: 2026-04-16
+Date: 2026-04-22
 
 Authoritative snapshot of package implementation status, local test results, and the most important remaining gaps. This document is a status record, not a design doc — see [docs/index.md](index.md) for navigation and [docs/specs/](specs/) for canonical contracts.
 
@@ -8,7 +8,7 @@ Current architecture framing reminder: `@agent-assistant/harness` is the bounded
 
 ---
 
-## Test Results (2026-04-16)
+## Test Results (2026-04-22)
 
 Run: `npx vitest run`
 
@@ -16,7 +16,7 @@ Run: `npx vitest run`
 | --- | --- | --- | --- |
 | `@agent-assistant/core` | `core.test.ts`, `core-traits.test.ts`, `core-sessions.test.ts`, `core-sessions-surfaces.test.ts` | 16 + 9 + 9 + 6 | **PASS** |
 | `@agent-assistant/sessions` | `sessions.test.ts` | 25 | **PASS** |
-| `@agent-assistant/surfaces` | `surfaces.test.ts`, `slack-thread-gate.test.ts` | 28 + 11 | **PASS** |
+| `@agent-assistant/surfaces` | `surfaces.test.ts`, `slack-thread-gate.test.ts`, `slack-event-dedup.test.ts`, `slack-ingress.test.ts` | 28 + 11 + 9 + 4 | **PASS** |
 | `@agent-assistant/routing` | `routing.test.ts` | 52 | **PASS** |
 | `@agent-assistant/traits` | `traits.test.ts` | 32 | **PASS** |
 | `@agent-assistant/proactive` | `proactive.test.ts` | 53 | **PASS** |
@@ -30,7 +30,7 @@ Run: `npx vitest run`
 | `@agent-assistant/inbox` | `inbox.test.ts`, `memory-projector.test.ts`, `enrichment-projector.test.ts` | 15 + 13 + 11 | **PASS** |
 | `@agent-assistant/integration-tests` | `integration.test.ts` | 14 | **PASS** |
 
-**Total verified passing: 566 tests across 23 test files**
+**Total verified passing: 579 tests across 24 test files**
 
 ---
 
@@ -40,7 +40,7 @@ Run: `npx vitest run`
 | --- | --- | --- |
 | `@agent-assistant/core` | **IMPLEMENTED** | Stable runtime shell |
 | `@agent-assistant/sessions` | **IMPLEMENTED** | Stable continuity primitive |
-| `@agent-assistant/surfaces` | **IMPLEMENTED** | Includes Slack thread gate coverage |
+| `@agent-assistant/surfaces` | **IMPLEMENTED** | Includes Slack thread gate and event dedup coverage |
 | `@agent-assistant/routing` | **IMPLEMENTED** | Routing hardening landed |
 | `@agent-assistant/connectivity` | **IMPLEMENTED** | Package-local publishability cleanup landed |
 | `@agent-assistant/coordination` | **IMPLEMENTED** | Coordination package currently green locally |
@@ -67,7 +67,7 @@ Older status docs in this repo may still imply some combination of the following
 - coordination is blocked in practice
 - test counts are much lower than current reality
 
-Those statements are no longer accurate for the current local repo state verified on 2026-04-16.
+Those statements are no longer accurate for the current local repo state verified on 2026-04-22.
 
 ---
 

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -39,3 +39,15 @@ export type {
   SlackIngressClassification,
   SlackIngressKind,
 } from "./slack-ingress.js";
+
+export {
+  SlackEventDedupGate,
+  getSlackDeduplicationKey,
+} from "./slack-event-dedup.js";
+export type {
+  SlackEventDedupDecision,
+  SlackEventDedupDropReason,
+  SlackEventDedupGateOptions,
+  SlackEventDedupInput,
+  SlackEventDedupStore,
+} from "./slack-event-dedup.js";

--- a/packages/surfaces/src/slack-event-dedup.test.ts
+++ b/packages/surfaces/src/slack-event-dedup.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  SlackEventDedupGate,
+  getSlackDeduplicationKey,
+  type SlackEventDedupStore,
+} from './slack-event-dedup.js';
+
+function createFakeStore() {
+  const entries = new Map<string, { ttl: number; markedAt: number }>();
+  const store: SlackEventDedupStore = {
+    async hasBeenProcessed(key) {
+      return entries.has(key);
+    },
+    async markProcessed(key, ttlSeconds) {
+      entries.set(key, { ttl: ttlSeconds, markedAt: Date.now() });
+    },
+  };
+  return { store, entries };
+}
+
+describe('getSlackDeduplicationKey', () => {
+  it('prefers event_id over ts', () => {
+    expect(getSlackDeduplicationKey({ eventId: 'Ev123', ts: '1700000000.000100' })).toBe('Ev123');
+  });
+
+  it('falls back to ts when event_id is missing', () => {
+    expect(getSlackDeduplicationKey({ ts: '1700000000.000100' })).toBe('1700000000.000100');
+  });
+
+  it('returns undefined when both are missing', () => {
+    expect(getSlackDeduplicationKey({})).toBeUndefined();
+  });
+
+  it('treats empty strings as missing', () => {
+    expect(getSlackDeduplicationKey({ eventId: '', ts: '' })).toBeUndefined();
+    expect(getSlackDeduplicationKey({ eventId: '', ts: '123' })).toBe('123');
+  });
+});
+
+describe('SlackEventDedupGate.claim', () => {
+  it('lets a first-time event proceed and marks it in the store', async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackEventDedupGate({ store });
+
+    const decision = await gate.claim({ eventId: 'Ev123' });
+
+    expect(decision.proceed).toBe(true);
+    expect(decision.key).toBe('Ev123');
+    expect(entries.has('Ev123')).toBe(true);
+    expect(entries.get('Ev123')?.ttl).toBe(SlackEventDedupGate.DEFAULT_TTL_SECONDS);
+  });
+
+  it('blocks a repeated delivery of the same event_id', async () => {
+    const { store } = createFakeStore();
+    const gate = new SlackEventDedupGate({ store });
+
+    await gate.claim({ eventId: 'Ev123' });
+    const second = await gate.claim({ eventId: 'Ev123' });
+
+    expect(second.proceed).toBe(false);
+    expect(second.reason).toBe('duplicate-event');
+    expect(second.key).toBe('Ev123');
+  });
+
+  it('does not block when only ts is available and two different events share no ts', async () => {
+    const { store } = createFakeStore();
+    const gate = new SlackEventDedupGate({ store });
+
+    const a = await gate.claim({ ts: '1700000000.000100' });
+    const b = await gate.claim({ ts: '1700000000.000200' });
+
+    expect(a.proceed).toBe(true);
+    expect(b.proceed).toBe(true);
+  });
+
+  it('proceeds without a key when neither event_id nor ts is present', async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackEventDedupGate({ store });
+
+    const decision = await gate.claim({});
+
+    expect(decision.proceed).toBe(true);
+    expect(decision.reason).toBe('no-dedup-key');
+    expect(decision.key).toBeUndefined();
+    expect(entries.size).toBe(0);
+  });
+
+  it('honors a caller-supplied ttl', async () => {
+    const { store, entries } = createFakeStore();
+    const gate = new SlackEventDedupGate({ store, ttlSeconds: 120 });
+
+    await gate.claim({ eventId: 'Ev999' });
+
+    expect(entries.get('Ev999')?.ttl).toBe(120);
+  });
+});

--- a/packages/surfaces/src/slack-event-dedup.ts
+++ b/packages/surfaces/src/slack-event-dedup.ts
@@ -1,0 +1,96 @@
+/**
+ * Slack Events API delivers retries when the receiver doesn't ack within 3s, when
+ * the `x-slack-retry-num` header fires, or during at-least-once delivery windows.
+ * Without dedup, a single user message produces multiple assistant replies.
+ *
+ * `SlackEventDedupGate` centralizes the check: given a Slack event envelope, it
+ * derives a stable key (preferring `event_id`, falling back to `ts`) and consults
+ * a caller-supplied store. The store interface is runtime-agnostic (Cloudflare
+ * KV, Redis, Postgres, in-memory) — the same shape we use for
+ * {@link ActiveThreadStore}.
+ *
+ * Ported from sage's `src/app/slack-state.ts` so every consumer of
+ * `@agent-assistant/surfaces` gets the same guarantee.
+ *
+ * @see https://api.slack.com/apis/events-api#retries
+ */
+
+export interface SlackEventDedupStore {
+  /**
+   * Return true when the key has already been recorded (within its TTL window).
+   * Returning `false` when the key has expired is expected and correct.
+   */
+  hasBeenProcessed(key: string): Promise<boolean>;
+
+  /**
+   * Record the key. Implementations should honor `ttlSeconds` so stale keys can
+   * be garbage-collected — the gate only needs dedup inside Slack's retry window
+   * (a few minutes), so callers typically pick 600s.
+   */
+  markProcessed(key: string, ttlSeconds: number): Promise<void>;
+}
+
+export interface SlackEventDedupInput {
+  eventId?: string;
+  ts?: string;
+}
+
+export interface SlackEventDedupGateOptions {
+  store: SlackEventDedupStore;
+  /** Dedup window. Defaults to 600s — wider than any observed Slack retry window. */
+  ttlSeconds?: number;
+}
+
+export type SlackEventDedupDropReason = 'duplicate-event' | 'no-dedup-key';
+
+export interface SlackEventDedupDecision {
+  proceed: boolean;
+  reason?: SlackEventDedupDropReason;
+  key?: string;
+}
+
+/**
+ * Derive the dedup key for a Slack event envelope. Prefers the immutable
+ * `event_id` Slack assigns on delivery; falls back to the message `ts` for older
+ * envelopes that lack it. Returns `undefined` when neither field is present, in
+ * which case callers should let the event proceed (there's nothing safe to key
+ * on — duplicates are still possible but can't be detected here).
+ */
+export function getSlackDeduplicationKey(event: SlackEventDedupInput): string | undefined {
+  const eventId = typeof event.eventId === 'string' && event.eventId.length > 0
+    ? event.eventId
+    : undefined;
+  if (eventId) return eventId;
+  const ts = typeof event.ts === 'string' && event.ts.length > 0 ? event.ts : undefined;
+  return ts;
+}
+
+export class SlackEventDedupGate {
+  static readonly DEFAULT_TTL_SECONDS = 600;
+
+  private readonly store: SlackEventDedupStore;
+
+  private readonly ttlSeconds: number;
+
+  constructor(options: SlackEventDedupGateOptions) {
+    this.store = options.store;
+    this.ttlSeconds = options.ttlSeconds ?? SlackEventDedupGate.DEFAULT_TTL_SECONDS;
+  }
+
+  /**
+   * Single-call API: atomically check + claim the dedup slot. Returns a decision
+   * describing whether the caller should proceed to handle the event.
+   *
+   * Non-atomic by design — stores are caller-supplied and may be eventually
+   * consistent (KV). Duplicate deliveries within the same millisecond can slip
+   * through; for strict once-only semantics layer a mutex above this gate.
+   */
+  async claim(event: SlackEventDedupInput): Promise<SlackEventDedupDecision> {
+    const key = getSlackDeduplicationKey(event);
+    if (!key) return { proceed: true, reason: 'no-dedup-key' };
+    const seen = await this.store.hasBeenProcessed(key);
+    if (seen) return { proceed: false, reason: 'duplicate-event', key };
+    await this.store.markProcessed(key, this.ttlSeconds);
+    return { proceed: true, key };
+  }
+}


### PR DESCRIPTION
## Summary
- Slack Events API retries deliveries when the receiver doesn't ack within 3s (or during at-least-once windows). Without dedup, one user message produces multiple assistant replies. MSD surfaced this today: a single Slack DM produced two greetings because both retry deliveries ran through the dispatcher.
- Sage has a local fix in \`src/app/slack-state.ts\` + \`slack-webhooks.ts\`, but the guarantee belongs one layer deeper so every consumer of \`@agent-assistant/surfaces\` gets it by default.
- Adds \`SlackEventDedupGate\` alongside the existing \`SlackThreadGate\` — same caller-supplied-store pattern, runtime-agnostic (KV, Redis, Postgres, in-memory).

## What's added
- \`packages/surfaces/src/slack-event-dedup.ts\`
  - \`getSlackDeduplicationKey(event)\` — prefers \`event_id\`, falls back to \`ts\`.
  - \`SlackEventDedupStore\` interface — \`hasBeenProcessed(key)\` / \`markProcessed(key, ttl)\`.
  - \`SlackEventDedupGate\` — \`claim(event)\` returns a \`{ proceed, reason, key }\` decision.
- Exported from \`packages/surfaces/src/index.ts\`.
- 9 new unit tests; 52/52 surfaces tests pass.

## Migration for consumers
Replace local dedup (e.g. sage's \`isDuplicateEvent\`/\`markEventSeen\` + \`getSlackDeduplicationKey\`) with:

\`\`\`ts
import { SlackEventDedupGate } from '@agent-assistant/surfaces';

const dedup = new SlackEventDedupGate({ store: yourStore });
const decision = await dedup.claim({ eventId: event.event_id, ts: event.ts });
if (!decision.proceed) return c.json({ ok: true });
\`\`\`

## Design notes
- Non-atomic by design — stores may be eventually consistent (Cloudflare KV, etc.). Duplicate deliveries within the same millisecond can slip through; callers needing strict once-only semantics should layer a mutex above.
- Default TTL is 600s, wider than any observed Slack retry window.
- \`claim()\` is a single-call check+mark to minimize round trips.

## Test plan
- [x] \`npx vitest run\` in \`packages/surfaces\` (52/52 pass)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Downstream: bump \`@agent-assistant/surfaces\` in sage, drop \`src/app/slack-state.ts\` dedup helpers, re-point to the exported gate
- [ ] Downstream: wire into MSD's \`msdSlackInboundAdapter.handleEvent\` with a Postgres-backed store (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
