### PR TITLE
fix(webhook-runtime): semver dep + wire into publish matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,11 @@ jobs:
               # telemetry depends on harness (HarnessUsage / HarnessResult types) —
               # must build + publish after it. Order preserved by max-parallel: 1
               # in the publish matrix, so telemetry publish waits for harness.
-              PACKAGES='["traits","connectivity","coordination","core","sessions","surfaces","policy","proactive","harness","telemetry","memory","turn-context","inbox","continuation","sdk","vfs","specialists"]'
+              # webhook-runtime depends on specialists (SpecialistRegistry /
+              # DelegationRequest types) — must build + publish after it. Same
+              # max-parallel: 1 contract keeps webhook-runtime's publish after
+              # specialists'.
+              PACKAGES='["traits","connectivity","coordination","core","sessions","surfaces","policy","proactive","harness","telemetry","memory","turn-context","inbox","continuation","sdk","vfs","specialists","webhook-runtime"]'
               FIRST='traits'
               ;;
             *)
@@ -161,7 +165,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ORDER=(traits connectivity coordination core sessions surfaces policy proactive harness telemetry memory turn-context inbox continuation sdk vfs specialists)
+          ORDER=(traits connectivity coordination core sessions surfaces policy proactive harness telemetry memory turn-context inbox continuation sdk vfs specialists webhook-runtime)
           for pkg in "${ORDER[@]}"; do
             if echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -e --arg pkg "$pkg" '.[] | select(. == $pkg)' >/dev/null; then
               echo "==> Building $pkg"

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,6 +322,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5334,7 +5335,7 @@
       "name": "@agent-assistant/webhook-runtime",
       "version": "0.1.0",
       "dependencies": {
-        "@agent-assistant/specialists": "file:../specialists",
+        "@agent-assistant/specialists": "^0.3.5",
         "@hono/node-server": "^2.0.0",
         "hono": "^4"
       },

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "test": "vitest run",
     "example:sim": "tsx examples/slack-to-github-sim.ts"
   },
   "dependencies": {
@@ -39,5 +40,12 @@
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/agent-assistant"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -30,7 +30,7 @@
     "example:sim": "tsx examples/slack-to-github-sim.ts"
   },
   "dependencies": {
-    "@agent-assistant/specialists": "file:../specialists",
+    "@agent-assistant/specialists": "^0.3.5",
     "@hono/node-server": "^2.0.0",
     "hono": "^4"
   },


### PR DESCRIPTION
## Summary

Follow-up to #34. Two related fixes so `@agent-assistant/webhook-runtime` can actually be consumed by sage / nightcto / My-Senior-Dev:

1. **Specialists dep corrected to semver.** PR #34's feedback commit (`6dee63f`) set `@agent-assistant/specialists` to `file:../specialists` to unblock `npm install`. That would have hard-coded a repo-local path into the published tarball and broken every consumer outside this repo. Switched to the published semver range `^0.3.5`, matching every other package in this repo. npm workspaces transparently symlinks the local copy during development (`node_modules/@agent-assistant/specialists` → `packages/specialists`).

2. **Wired into the `runtime-core` publish matrix.** Without this, there is no path from this repo to the npm registry for `webhook-runtime`, so the primitive cannot actually replace the hand-rolled webhook plumbing in sage / nightcto / My-Senior-Dev. Added `webhook-runtime` to both `PACKAGES` and the build `ORDER` in `.github/workflows/publish.yml`, positioned after `specialists` (which it depends on). Added `"test": "vitest run"`, `repository`, and `publishConfig.access: "public"` to the package manifest so the workflow's run-tests gate and publish step behave the same as every other package in the matrix.

## Test plan

- [x] `npm install` at repo root — no `EUNSUPPORTEDPROTOCOL`; `node_modules/@agent-assistant/specialists` symlinks to `packages/specialists`.
- [x] `npm test -w @agent-assistant/webhook-runtime` — 19/19 pass.
- [x] `npm run build -w @agent-assistant/webhook-runtime` — clean; `find dist -name '*.test.*'` returns nothing, so the workflow's Verify no test artifacts step stays green.
- [ ] First `Publish Packages` (`runtime-core`, dry-run) workflow run after merge — confirm `webhook-runtime@0.1.0` shows up in the matrix and the dep rewrite step leaves `@agent-assistant/specialists: ^<new-version>` intact.
- [ ] After the real publish, verify a fresh consumer outside this repo can `npm install @agent-assistant/webhook-runtime` and get `@agent-assistant/specialists` resolved from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)