### PR TITLE
feat(proactive,surfaces): notify-channel resolver + Slack bot-channel discovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -322,6 +322,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5190,6 +5191,7 @@
       "version": "0.2.18",
       "license": "MIT",
       "dependencies": {
+        "@agent-assistant/surfaces": ">=0.1.0",
         "nanoid": "^5.0.7"
       },
       "devDependencies": {
@@ -5339,6 +5341,7 @@
         "hono": "^4"
       },
       "devDependencies": {
+        "@agent-assistant/harness": "^0.3.8",
         "@types/node": "^24.6.0",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",

--- a/packages/proactive/package.json
+++ b/packages/proactive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/proactive",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Proactive decision engine for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@agent-assistant/surfaces": ">=0.1.0",
+    "@agent-assistant/surfaces": ">=0.2.19",
     "nanoid": "^5.0.7"
   },
   "devDependencies": {

--- a/packages/proactive/package.json
+++ b/packages/proactive/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@agent-assistant/surfaces": ">=0.1.0",
     "nanoid": "^5.0.7"
   },
   "devDependencies": {

--- a/packages/proactive/src/channel-picker.test.ts
+++ b/packages/proactive/src/channel-picker.test.ts
@@ -1,0 +1,95 @@
+import type { BotChannel } from '@agent-assistant/surfaces';
+import { describe, expect, it, vi } from 'vitest';
+
+import { pickChannel, type ChatFn, type ProactivePayload } from './channel-picker.js';
+
+const payload: ProactivePayload = {
+  kind: 'follow-up',
+  topic: 'incident retro',
+  preview: 'Summary of incident X',
+};
+
+const channels: BotChannel[] = [
+  { id: 'C_ENG', name: 'engineering' },
+  { id: 'C_INC', name: 'incidents', topic: 'incident response' },
+];
+
+function mockChat(content: string): ChatFn {
+  return vi.fn(async () => ({ content }));
+}
+
+describe('pickChannel', () => {
+  it('returns null for empty channels', async () => {
+    const chat = mockChat('');
+    expect(await pickChannel(chat, [], payload)).toBeNull();
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it('returns the only channel with confidence 1.0 without calling chat', async () => {
+    const chat = mockChat('');
+    const picked = await pickChannel(chat, [channels[0]], payload);
+    expect(picked).toEqual({
+      channelId: 'C_ENG',
+      channelName: 'engineering',
+      confidence: 1,
+      reason: 'only channel',
+    });
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it('parses a valid JSON response and returns the matched channel', async () => {
+    const chat = mockChat(
+      JSON.stringify({ channelId: 'C_INC', confidence: 0.9, reason: 'topic matches' }),
+    );
+    const picked = await pickChannel(chat, channels, payload);
+    expect(picked).toEqual({
+      channelId: 'C_INC',
+      channelName: 'incidents',
+      confidence: 0.9,
+      reason: 'topic matches',
+    });
+  });
+
+  it('falls back to the first channel when the response is invalid JSON', async () => {
+    const chat = mockChat('not json at all');
+    const picked = await pickChannel(chat, channels, payload);
+    expect(picked).toMatchObject({
+      channelId: 'C_ENG',
+      confidence: 0.3,
+      reason: 'llm-parse-fallback',
+    });
+  });
+
+  it('falls back when the LLM picks an unknown channelId', async () => {
+    const chat = mockChat(
+      JSON.stringify({ channelId: 'C_MISSING', confidence: 0.8, reason: 'whatever' }),
+    );
+    const picked = await pickChannel(chat, channels, payload);
+    expect(picked).toMatchObject({ channelId: 'C_ENG', reason: 'llm-parse-fallback' });
+  });
+
+  it('falls back when chat throws', async () => {
+    const chat: ChatFn = vi.fn(async () => {
+      throw new Error('boom');
+    });
+    const picked = await pickChannel(chat, channels, payload);
+    expect(picked).toMatchObject({ channelId: 'C_ENG', reason: 'llm-parse-fallback' });
+  });
+
+  it('rejects out-of-range confidence', async () => {
+    const chat = mockChat(
+      JSON.stringify({ channelId: 'C_INC', confidence: 1.5, reason: 'topic matches' }),
+    );
+    const picked = await pickChannel(chat, channels, payload);
+    expect(picked).toMatchObject({ channelId: 'C_ENG', reason: 'llm-parse-fallback' });
+  });
+
+  it('truncates the reason to 15 words', async () => {
+    const longReason = 'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen';
+    const chat = mockChat(
+      JSON.stringify({ channelId: 'C_INC', confidence: 0.5, reason: longReason }),
+    );
+    const picked = await pickChannel(chat, channels, payload);
+    expect(picked?.reason.split(/\s+/).length).toBe(15);
+  });
+});

--- a/packages/proactive/src/channel-picker.ts
+++ b/packages/proactive/src/channel-picker.ts
@@ -1,0 +1,157 @@
+/**
+ * LLM-driven picker that selects the best Slack channel for a proactive message
+ * when the bot is a member of multiple channels.
+ *
+ * Consumers inject a {@link ChatFn} so the picker is agnostic to which LLM
+ * provider is used. Typical wiring points it at a cheap classifier model
+ * (Haiku, GPT-5-mini, etc.) with temperature 0.
+ */
+
+import type { BotChannel } from '@agent-assistant/surfaces';
+
+export interface ProactivePayload {
+  kind: 'follow-up' | 'stale-thread' | 'context-change' | 'pr-match';
+  topic: string;
+  preview: string;
+}
+
+export interface PickedChannel {
+  channelId: string;
+  channelName: string;
+  confidence: number;
+  reason: string;
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatOptions {
+  temperature?: number;
+}
+
+export type ChatFn = (
+  messages: ChatMessage[],
+  options?: ChatOptions,
+) => Promise<{ content: string }>;
+
+const CHANNEL_PICKER_SYSTEM_PROMPT =
+  'Pick the Slack channel that is the best fit for this proactive message. Prefer topic-matched channels. Return strict JSON {channelId, confidence (0..1), reason (<=15 words)}.';
+const FALLBACK_CONFIDENCE = 0.3;
+const FALLBACK_REASON = 'llm-parse-fallback';
+const MAX_REASON_WORDS = 15;
+
+interface ChannelPickJson {
+  channelId?: unknown;
+  confidence?: unknown;
+  reason?: unknown;
+}
+
+function extractJsonObject(value: string): string | null {
+  const start = value.indexOf('{');
+  const end = value.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) {
+    return null;
+  }
+  return value.slice(start, end + 1);
+}
+
+function channelToPick(channel: BotChannel, confidence: number, reason: string): PickedChannel {
+  return {
+    channelId: channel.id,
+    channelName: channel.name,
+    confidence,
+    reason,
+  };
+}
+
+function fallbackChannel(channel: BotChannel): PickedChannel {
+  return channelToPick(channel, FALLBACK_CONFIDENCE, FALLBACK_REASON);
+}
+
+function limitReason(value: string): string {
+  return value.trim().split(/\s+/).slice(0, MAX_REASON_WORDS).join(' ');
+}
+
+function parsePickedChannel(content: string, channels: BotChannel[]): PickedChannel | null {
+  const json = extractJsonObject(content);
+  if (!json) {
+    return null;
+  }
+
+  let parsed: ChannelPickJson;
+  try {
+    parsed = JSON.parse(json) as ChannelPickJson;
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed.channelId !== 'string' || parsed.channelId.trim().length === 0) {
+    return null;
+  }
+  const channelId = parsed.channelId.trim();
+
+  if (typeof parsed.confidence !== 'number' || !Number.isFinite(parsed.confidence)) {
+    return null;
+  }
+  if (parsed.confidence < 0 || parsed.confidence > 1) {
+    return null;
+  }
+
+  if (typeof parsed.reason !== 'string' || parsed.reason.trim().length === 0) {
+    return null;
+  }
+
+  const channel = channels.find((candidate) => candidate.id === channelId);
+  if (!channel) {
+    return null;
+  }
+
+  return channelToPick(channel, parsed.confidence, limitReason(parsed.reason));
+}
+
+function buildUserPrompt(channels: BotChannel[], payload: ProactivePayload): string {
+  return JSON.stringify(
+    {
+      payload,
+      channels: channels.map((channel) => ({
+        id: channel.id,
+        name: channel.name,
+        topic: channel.topic ?? '',
+        purpose: channel.purpose ?? '',
+        numMembers: channel.numMembers ?? null,
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+export async function pickChannel(
+  chat: ChatFn,
+  channels: BotChannel[],
+  payload: ProactivePayload,
+): Promise<PickedChannel | null> {
+  const [first, ...rest] = channels;
+  if (!first) {
+    return null;
+  }
+
+  if (rest.length === 0) {
+    return channelToPick(first, 1.0, 'only channel');
+  }
+
+  try {
+    const response = await chat(
+      [
+        { role: 'system', content: CHANNEL_PICKER_SYSTEM_PROMPT },
+        { role: 'user', content: buildUserPrompt(channels, payload) },
+      ],
+      { temperature: 0 },
+    );
+    return parsePickedChannel(response.content, channels) ?? fallbackChannel(first);
+  } catch {
+    return fallbackChannel(first);
+  }
+}

--- a/packages/proactive/src/index.ts
+++ b/packages/proactive/src/index.ts
@@ -27,3 +27,42 @@ export {
 } from './types.js';
 
 export { createProactiveEngine, InMemorySchedulerBinding } from './proactive.js';
+
+// ── Notify-channel resolution ───────────────────────────────────────────────
+// Dynamic channel picking for proactive Slack posts: discover bot-member
+// channels, pick one with an injected LLM, persist the user's confirmation
+// in a pluggable pref store.
+export {
+  getNotifyChannelPref,
+  hasPrefStore,
+  incrementUnconfirmedPosts,
+  setNotifyChannelPref,
+} from './notify-channel-prefs.js';
+export type { NotifyChannelPref, PrefStore } from './notify-channel-prefs.js';
+
+export { pickChannel } from './channel-picker.js';
+export type {
+  ChatFn,
+  ChatMessage,
+  ChatOptions,
+  PickedChannel,
+  ProactivePayload,
+} from './channel-picker.js';
+
+export {
+  CONFIRM_PROMPT_SUFFIX,
+  normalizeChannelName,
+  parseConfirmReply,
+  parseRedirectChannelName,
+} from './notify-channel-reply.js';
+export type { ConfirmReplyParse } from './notify-channel-reply.js';
+
+export {
+  AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS,
+  resolveNotifyChannel,
+} from './notify-channel-resolver.js';
+export type {
+  ListBotChannelsFn,
+  ResolvedNotifyChannel,
+  ResolveNotifyChannelInput,
+} from './notify-channel-resolver.js';

--- a/packages/proactive/src/notify-channel-prefs.test.ts
+++ b/packages/proactive/src/notify-channel-prefs.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getNotifyChannelPref,
+  hasPrefStore,
+  incrementUnconfirmedPosts,
+  setNotifyChannelPref,
+  type PrefStore,
+} from './notify-channel-prefs.js';
+
+function createInMemoryStore(): PrefStore {
+  const data = new Map<string, string>();
+  return {
+    async get(key) {
+      return data.get(key) ?? null;
+    },
+    async put(key, value) {
+      data.set(key, value);
+    },
+  };
+}
+
+describe('notify-channel-prefs', () => {
+  it('returns null when unset', async () => {
+    const store = createInMemoryStore();
+    expect(await getNotifyChannelPref(store, 'W1')).toBeNull();
+  });
+
+  it('round-trips a pref via set + get', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C1', false);
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref).toMatchObject({
+      channel: 'C1',
+      confirmed: false,
+      unconfirmedPosts: 0,
+    });
+    expect(typeof pref?.updatedAt).toBe('number');
+  });
+
+  it('incrementUnconfirmedPosts bumps count by 1', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C1', false);
+    expect(await incrementUnconfirmedPosts(store, 'W1')).toBe(1);
+    expect(await incrementUnconfirmedPosts(store, 'W1')).toBe(2);
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref?.unconfirmedPosts).toBe(2);
+  });
+
+  it('incrementUnconfirmedPosts preserves channel + confirmed on update', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C1', false);
+    await incrementUnconfirmedPosts(store, 'W1');
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref).toMatchObject({ channel: 'C1', confirmed: false });
+  });
+
+  it('incrementUnconfirmedPosts starts from 0 when pref unset', async () => {
+    const store = createInMemoryStore();
+    expect(await incrementUnconfirmedPosts(store, 'W1')).toBe(1);
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref?.unconfirmedPosts).toBe(1);
+    expect(pref?.channel).toBe('');
+  });
+
+  it('returns null for malformed JSON', async () => {
+    const store = createInMemoryStore();
+    await store.put('notify-channel:W1', 'not json');
+    expect(await getNotifyChannelPref(store, 'W1')).toBeNull();
+  });
+
+  it('returns null for valid JSON that fails schema validation', async () => {
+    const store = createInMemoryStore();
+    await store.put('notify-channel:W1', JSON.stringify({ channel: 'C1' }));
+    expect(await getNotifyChannelPref(store, 'W1')).toBeNull();
+  });
+
+  describe('hasPrefStore', () => {
+    it('recognises a store with get + put functions', () => {
+      expect(hasPrefStore(createInMemoryStore())).toBe(true);
+    });
+    it('rejects undefined', () => {
+      expect(hasPrefStore(undefined)).toBe(false);
+    });
+    it('rejects an object missing put', () => {
+      expect(hasPrefStore({ get: async () => null })).toBe(false);
+    });
+  });
+});

--- a/packages/proactive/src/notify-channel-prefs.ts
+++ b/packages/proactive/src/notify-channel-prefs.ts
@@ -1,0 +1,111 @@
+/**
+ * Per-workspace notify-channel preferences backed by a pluggable key-value store.
+ *
+ * Consumers supply a {@link PrefStore} (e.g. a Cloudflare KV adapter on the
+ * edge, or an in-memory Map for tests) and this module handles schema
+ * validation, serialization, and the unconfirmed-posts counter used for
+ * silent-fallback auto-confirmation.
+ */
+
+export interface PrefStore {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+}
+
+export interface NotifyChannelPref {
+  channel: string;
+  confirmed: boolean;
+  unconfirmedPosts: number;
+  updatedAt: number;
+}
+
+const notifyChannelKey = (workspaceId: string): string => `notify-channel:${workspaceId}`;
+
+export function hasPrefStore(value: unknown): value is PrefStore {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      typeof (value as Partial<PrefStore>).get === 'function' &&
+      typeof (value as Partial<PrefStore>).put === 'function',
+  );
+}
+
+function isNotifyChannelPref(value: unknown): value is NotifyChannelPref {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<NotifyChannelPref>;
+  return (
+    typeof candidate.channel === 'string' &&
+    typeof candidate.confirmed === 'boolean' &&
+    typeof candidate.unconfirmedPosts === 'number' &&
+    Number.isFinite(candidate.unconfirmedPosts) &&
+    typeof candidate.updatedAt === 'number' &&
+    Number.isFinite(candidate.updatedAt)
+  );
+}
+
+export async function getNotifyChannelPref(
+  store: PrefStore,
+  workspaceId: string,
+): Promise<NotifyChannelPref | null> {
+  const raw = await store.get(notifyChannelKey(workspaceId));
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return isNotifyChannelPref(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setNotifyChannelPref(
+  store: PrefStore,
+  workspaceId: string,
+  channel: string,
+  confirmed: boolean,
+): Promise<void> {
+  await store.put(
+    notifyChannelKey(workspaceId),
+    JSON.stringify({
+      channel,
+      confirmed,
+      unconfirmedPosts: 0,
+      updatedAt: Date.now(),
+    } satisfies NotifyChannelPref),
+  );
+}
+
+/**
+ * Reads the current pref, increments `unconfirmedPosts`, writes back.
+ *
+ * NOTE: read-modify-write over the pref store is not atomic. Under
+ * concurrent writers, increments can be lost. For the notify-channel
+ * use case this at worst delays the silent-fallback auto-confirm by
+ * one post, which is acceptable. If callers need stronger guarantees,
+ * they should wrap this behind a serialization mechanism (e.g. a
+ * Cloudflare Durable Object).
+ */
+export async function incrementUnconfirmedPosts(
+  store: PrefStore,
+  workspaceId: string,
+): Promise<number> {
+  const current = await getNotifyChannelPref(store, workspaceId);
+  const unconfirmedPosts = (current?.unconfirmedPosts ?? 0) + 1;
+
+  await store.put(
+    notifyChannelKey(workspaceId),
+    JSON.stringify({
+      channel: current?.channel ?? '',
+      confirmed: current?.confirmed ?? false,
+      unconfirmedPosts,
+      updatedAt: Date.now(),
+    } satisfies NotifyChannelPref),
+  );
+
+  return unconfirmedPosts;
+}

--- a/packages/proactive/src/notify-channel-reply.test.ts
+++ b/packages/proactive/src/notify-channel-reply.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeChannelName,
+  parseConfirmReply,
+  parseRedirectChannelName,
+} from './notify-channel-reply.js';
+
+describe('normalizeChannelName', () => {
+  it('strips leading # and lowercases', () => {
+    expect(normalizeChannelName('#General')).toBe('general');
+    expect(normalizeChannelName('  #Foo ')).toBe('foo');
+  });
+});
+
+describe('parseRedirectChannelName', () => {
+  it('returns normalized name when input starts with #', () => {
+    expect(parseRedirectChannelName('#foo-bar')).toBe('foo-bar');
+    expect(parseRedirectChannelName('#FooBar')).toBe('foobar');
+  });
+  it('returns undefined when input does not start with #', () => {
+    expect(parseRedirectChannelName('foo')).toBeUndefined();
+  });
+  it('rejects invalid characters', () => {
+    expect(parseRedirectChannelName('#foo bar')).toBeUndefined();
+    expect(parseRedirectChannelName('#foo/bar')).toBeUndefined();
+  });
+});
+
+describe('parseConfirmReply', () => {
+  it('classifies yes/y/confirm as confirm', () => {
+    expect(parseConfirmReply('yes')).toEqual({ kind: 'confirm' });
+    expect(parseConfirmReply('Y')).toEqual({ kind: 'confirm' });
+    expect(parseConfirmReply(' Confirm ')).toEqual({ kind: 'confirm' });
+  });
+  it('classifies #channel as redirect', () => {
+    expect(parseConfirmReply('#incidents')).toEqual({ kind: 'redirect', channelName: 'incidents' });
+  });
+  it('classifies unrelated text as none', () => {
+    expect(parseConfirmReply('maybe later')).toEqual({ kind: 'none' });
+    expect(parseConfirmReply('')).toEqual({ kind: 'none' });
+    expect(parseConfirmReply('#')).toEqual({ kind: 'none' });
+  });
+});

--- a/packages/proactive/src/notify-channel-reply.test.ts
+++ b/packages/proactive/src/notify-channel-reply.test.ts
@@ -14,16 +14,42 @@ describe('normalizeChannelName', () => {
 });
 
 describe('parseRedirectChannelName', () => {
-  it('returns normalized name when input starts with #', () => {
-    expect(parseRedirectChannelName('#foo-bar')).toBe('foo-bar');
-    expect(parseRedirectChannelName('#FooBar')).toBe('foobar');
+  it('accepts literal #channel-name and returns channelName', () => {
+    expect(parseRedirectChannelName('#foo-bar')).toEqual({ channelName: 'foo-bar' });
+    expect(parseRedirectChannelName('#FooBar')).toEqual({ channelName: 'foobar' });
   });
-  it('returns undefined when input does not start with #', () => {
+
+  it('accepts Slack-rewritten mention with id and name', () => {
+    expect(parseRedirectChannelName('<#C123|general>')).toEqual({
+      channelId: 'C123',
+      channelName: 'general',
+    });
+  });
+
+  it('accepts Slack-rewritten mention with id only', () => {
+    expect(parseRedirectChannelName('<#C123>')).toEqual({ channelId: 'C123' });
+  });
+
+  it('normalizes the name portion of a Slack mention', () => {
+    expect(parseRedirectChannelName('<#C123|General>')).toEqual({
+      channelId: 'C123',
+      channelName: 'general',
+    });
+  });
+
+  it('returns undefined when input does not start with # or <#', () => {
     expect(parseRedirectChannelName('foo')).toBeUndefined();
+    expect(parseRedirectChannelName('')).toBeUndefined();
   });
-  it('rejects invalid characters', () => {
+
+  it('rejects invalid characters in the literal form', () => {
     expect(parseRedirectChannelName('#foo bar')).toBeUndefined();
     expect(parseRedirectChannelName('#foo/bar')).toBeUndefined();
+  });
+
+  it('rejects malformed Slack mentions', () => {
+    expect(parseRedirectChannelName('<#>')).toBeUndefined();
+    expect(parseRedirectChannelName('<#lowercase>')).toBeUndefined();
   });
 });
 
@@ -33,12 +59,26 @@ describe('parseConfirmReply', () => {
     expect(parseConfirmReply('Y')).toEqual({ kind: 'confirm' });
     expect(parseConfirmReply(' Confirm ')).toEqual({ kind: 'confirm' });
   });
-  it('classifies #channel as redirect', () => {
-    expect(parseConfirmReply('#incidents')).toEqual({ kind: 'redirect', channelName: 'incidents' });
+
+  it('classifies literal #channel as redirect with channelName', () => {
+    expect(parseConfirmReply('#incidents')).toEqual({
+      kind: 'redirect',
+      channelName: 'incidents',
+    });
   });
+
+  it('classifies Slack-rewritten mention as redirect with id and name', () => {
+    expect(parseConfirmReply('<#C123|incidents>')).toEqual({
+      kind: 'redirect',
+      channelId: 'C123',
+      channelName: 'incidents',
+    });
+  });
+
   it('classifies unrelated text as none', () => {
     expect(parseConfirmReply('maybe later')).toEqual({ kind: 'none' });
     expect(parseConfirmReply('')).toEqual({ kind: 'none' });
     expect(parseConfirmReply('#')).toEqual({ kind: 'none' });
+    expect(parseConfirmReply('<#>')).toEqual({ kind: 'none' });
   });
 });

--- a/packages/proactive/src/notify-channel-reply.ts
+++ b/packages/proactive/src/notify-channel-reply.ts
@@ -7,35 +7,73 @@
  *    `#channel-name` to redirect."
  *
  * A reply is classified as one of:
- *   - {@link ConfirmReplyKind.Confirm}: user typed yes / y / confirm
- *   - {@link ConfirmReplyKind.Redirect}: user typed `#channel-name`
- *   - {@link ConfirmReplyKind.None}: anything else (fall through)
+ *   - confirm: user typed yes / y / confirm
+ *   - redirect: user typed `#channel-name` OR Slack auto-rewrote the
+ *     mention into its event-text form `<#C123|channel-name>`
+ *   - none: anything else (fall through to existing handlers)
+ *
+ * The redirect payload exposes both `channelId` (when available from a
+ * Slack-formatted mention) and `channelName`. Callers should prefer
+ * `channelId` — ID lookup is more robust than name lookup — and fall
+ * back to resolving by `channelName` when only a literal `#name` was
+ * typed.
  */
 
 export const CONFIRM_PROMPT_SUFFIX =
   '\n\n_Was this the right channel? Reply `yes` to confirm, or `#channel-name` to redirect._';
 
+export interface RedirectTarget {
+  channelId?: string;
+  channelName?: string;
+}
+
 export type ConfirmReplyParse =
   | { kind: 'confirm' }
-  | { kind: 'redirect'; channelName: string }
+  | ({ kind: 'redirect' } & RedirectTarget)
   | { kind: 'none' };
+
+const SLACK_CHANNEL_MENTION = /^<#([A-Z0-9]+)(?:\|([^>]*))?>$/;
+const LITERAL_CHANNEL_NAME = /^[a-z0-9_-]+$/i;
 
 export function normalizeChannelName(channel: string): string {
   return channel.trim().replace(/^#/, '').toLowerCase();
 }
 
-export function parseRedirectChannelName(text: string): string | undefined {
+/**
+ * Parses the channel-redirect form of a confirmation reply.
+ *
+ * Accepts:
+ *   - `#channel-name`                — literal composer input
+ *   - `<#C123>` / `<#C123|name>`     — Slack's event-text rewrite
+ *
+ * Returns `undefined` if neither form matches.
+ */
+export function parseRedirectChannelName(text: string): RedirectTarget | undefined {
   const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const mentionMatch = SLACK_CHANNEL_MENTION.exec(trimmed);
+  if (mentionMatch) {
+    const [, channelId, rawName] = mentionMatch;
+    const channelName = rawName && rawName.length > 0 ? normalizeChannelName(rawName) : undefined;
+    return {
+      ...(channelId ? { channelId } : {}),
+      ...(channelName ? { channelName } : {}),
+    };
+  }
+
   if (!trimmed.startsWith('#')) {
     return undefined;
   }
 
-  const channelName = trimmed.slice(1).trim();
-  if (!/^[a-z0-9_-]+$/i.test(channelName)) {
+  const candidate = trimmed.slice(1).trim();
+  if (!LITERAL_CHANNEL_NAME.test(candidate)) {
     return undefined;
   }
 
-  return normalizeChannelName(channelName);
+  return { channelName: normalizeChannelName(candidate) };
 }
 
 export function parseConfirmReply(text: string): ConfirmReplyParse {
@@ -50,8 +88,8 @@ export function parseConfirmReply(text: string): ConfirmReplyParse {
   }
 
   const redirect = parseRedirectChannelName(trimmed);
-  if (redirect) {
-    return { kind: 'redirect', channelName: redirect };
+  if (redirect && (redirect.channelId || redirect.channelName)) {
+    return { kind: 'redirect', ...redirect };
   }
 
   return { kind: 'none' };

--- a/packages/proactive/src/notify-channel-reply.ts
+++ b/packages/proactive/src/notify-channel-reply.ts
@@ -1,0 +1,58 @@
+/**
+ * Helpers for interpreting freeform user replies to a pending
+ * notify-channel confirmation prompt.
+ *
+ * The pattern posted by the resolver is:
+ *   "Was this the right channel? Reply `yes` to confirm, or
+ *    `#channel-name` to redirect."
+ *
+ * A reply is classified as one of:
+ *   - {@link ConfirmReplyKind.Confirm}: user typed yes / y / confirm
+ *   - {@link ConfirmReplyKind.Redirect}: user typed `#channel-name`
+ *   - {@link ConfirmReplyKind.None}: anything else (fall through)
+ */
+
+export const CONFIRM_PROMPT_SUFFIX =
+  '\n\n_Was this the right channel? Reply `yes` to confirm, or `#channel-name` to redirect._';
+
+export type ConfirmReplyParse =
+  | { kind: 'confirm' }
+  | { kind: 'redirect'; channelName: string }
+  | { kind: 'none' };
+
+export function normalizeChannelName(channel: string): string {
+  return channel.trim().replace(/^#/, '').toLowerCase();
+}
+
+export function parseRedirectChannelName(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('#')) {
+    return undefined;
+  }
+
+  const channelName = trimmed.slice(1).trim();
+  if (!/^[a-z0-9_-]+$/i.test(channelName)) {
+    return undefined;
+  }
+
+  return normalizeChannelName(channelName);
+}
+
+export function parseConfirmReply(text: string): ConfirmReplyParse {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return { kind: 'none' };
+  }
+
+  const normalized = trimmed.toLowerCase();
+  if (normalized === 'yes' || normalized === 'y' || normalized === 'confirm') {
+    return { kind: 'confirm' };
+  }
+
+  const redirect = parseRedirectChannelName(trimmed);
+  if (redirect) {
+    return { kind: 'redirect', channelName: redirect };
+  }
+
+  return { kind: 'none' };
+}

--- a/packages/proactive/src/notify-channel-resolver.test.ts
+++ b/packages/proactive/src/notify-channel-resolver.test.ts
@@ -1,0 +1,180 @@
+import type { BotChannel } from '@agent-assistant/surfaces';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ChatFn, ProactivePayload } from './channel-picker.js';
+import {
+  getNotifyChannelPref,
+  setNotifyChannelPref,
+  type PrefStore,
+} from './notify-channel-prefs.js';
+import {
+  AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS,
+  resolveNotifyChannel,
+} from './notify-channel-resolver.js';
+
+function createInMemoryStore(): PrefStore {
+  const data = new Map<string, string>();
+  return {
+    async get(key) {
+      return data.get(key) ?? null;
+    },
+    async put(key, value) {
+      data.set(key, value);
+    },
+  };
+}
+
+const payload: ProactivePayload = { kind: 'follow-up', topic: 't', preview: 'p' };
+
+const channels: BotChannel[] = [
+  { id: 'C1', name: 'general' },
+  { id: 'C2', name: 'incidents' },
+];
+
+const deterministicChat: ChatFn = async () => ({
+  content: JSON.stringify({ channelId: 'C2', confidence: 0.9, reason: 'topic match' }),
+});
+
+describe('resolveNotifyChannel', () => {
+  it('bodyOverride wins over everything', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C-pref', true);
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => channels,
+      workspaceId: 'W1',
+      payload,
+      bodyOverride: 'C-override',
+    });
+    expect(result).toEqual({
+      channel: 'C-override',
+      shouldAppendConfirmPrompt: false,
+      source: 'body',
+    });
+  });
+
+  it('confirmed pref returns pref-confirmed with no prompt', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C-pref', true);
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => channels,
+      workspaceId: 'W1',
+      payload,
+    });
+    expect(result).toEqual({
+      channel: 'C-pref',
+      shouldAppendConfirmPrompt: false,
+      source: 'pref-confirmed',
+    });
+  });
+
+  it('unconfirmed pref returns pref-unconfirmed with prompt and increments counter', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C-pref', false);
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => channels,
+      workspaceId: 'W1',
+      payload,
+    });
+    expect(result).toEqual({
+      channel: 'C-pref',
+      shouldAppendConfirmPrompt: true,
+      source: 'pref-unconfirmed',
+    });
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref?.unconfirmedPosts).toBe(1);
+    expect(pref?.confirmed).toBe(false);
+  });
+
+  it('flips to confirmed on the post that hits the threshold', async () => {
+    const store = createInMemoryStore();
+    await setNotifyChannelPref(store, 'W1', 'C-pref', false);
+    // Prime unconfirmedPosts so the next resolve call is the one that hits the threshold
+    for (let i = 0; i < AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS - 1; i += 1) {
+      await resolveNotifyChannel({
+        store,
+        chat: deterministicChat,
+        listChannels: async () => channels,
+        workspaceId: 'W1',
+        payload,
+      });
+    }
+    // This call should increment to threshold and flip confirmed=true
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => channels,
+      workspaceId: 'W1',
+      payload,
+    });
+    expect(result?.source).toBe('pref-unconfirmed');
+    expect(result?.shouldAppendConfirmPrompt).toBe(true);
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref?.confirmed).toBe(true);
+    // setNotifyChannelPref resets unconfirmedPosts to 0
+    expect(pref?.unconfirmedPosts).toBe(0);
+  });
+
+  it('discovery path writes pref + increments + returns discovery', async () => {
+    const store = createInMemoryStore();
+    const listChannels = vi.fn(async () => channels);
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels,
+      workspaceId: 'W1',
+      payload,
+    });
+    expect(result).toEqual({
+      channel: 'C2',
+      shouldAppendConfirmPrompt: true,
+      source: 'discovery',
+    });
+    const pref = await getNotifyChannelPref(store, 'W1');
+    expect(pref).toMatchObject({ channel: 'C2', confirmed: false, unconfirmedPosts: 1 });
+    expect(listChannels).toHaveBeenCalledOnce();
+  });
+
+  it('returns null when no pref and discovery returns no channels', async () => {
+    const store = createInMemoryStore();
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => [],
+      workspaceId: 'W1',
+      payload,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when listChannels throws', async () => {
+    const store = createInMemoryStore();
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => {
+        throw new Error('invalid_auth');
+      },
+      workspaceId: 'W1',
+      payload,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when workspaceId is empty', async () => {
+    const store = createInMemoryStore();
+    const result = await resolveNotifyChannel({
+      store,
+      chat: deterministicChat,
+      listChannels: async () => channels,
+      workspaceId: '   ',
+      payload,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/proactive/src/notify-channel-resolver.ts
+++ b/packages/proactive/src/notify-channel-resolver.ts
@@ -1,0 +1,124 @@
+/**
+ * Resolves the target Slack channel for a proactive message with a
+ * precedence chain:
+ *
+ *   1. bodyOverride (caller-supplied)
+ *   2. confirmed pref in the pref store
+ *   3. unconfirmed pref in the pref store (with silent-fallback auto-confirm
+ *      after {@link AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS} posts)
+ *   4. discovery: list the channels the bot is a member of and pick one
+ *      via {@link ChatFn}
+ *
+ * Dependencies are injected so this module stays provider-agnostic: the
+ * pref store, the LLM, and the channel lister are all supplied by the
+ * caller.
+ */
+
+import type { BotChannel } from '@agent-assistant/surfaces';
+
+import { pickChannel, type ChatFn, type ProactivePayload } from './channel-picker.js';
+import {
+  getNotifyChannelPref,
+  incrementUnconfirmedPosts,
+  setNotifyChannelPref,
+  type PrefStore,
+} from './notify-channel-prefs.js';
+
+export const AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS = 3;
+
+export interface ResolvedNotifyChannel {
+  channel: string;
+  shouldAppendConfirmPrompt: boolean;
+  source: 'body' | 'pref-confirmed' | 'pref-unconfirmed' | 'discovery';
+}
+
+export type ListBotChannelsFn = () => Promise<BotChannel[]>;
+
+export interface ResolveNotifyChannelInput {
+  store: PrefStore;
+  chat: ChatFn;
+  listChannels: ListBotChannelsFn;
+  workspaceId: string;
+  payload: ProactivePayload;
+  bodyOverride?: string | null;
+}
+
+function readNonEmptyString(value: string | null | undefined): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export async function resolveNotifyChannel(
+  input: ResolveNotifyChannelInput,
+): Promise<ResolvedNotifyChannel | null> {
+  const { store, chat, listChannels, workspaceId, payload, bodyOverride } = input;
+
+  const override = readNonEmptyString(bodyOverride);
+  if (override) {
+    return {
+      channel: override,
+      shouldAppendConfirmPrompt: false,
+      source: 'body',
+    };
+  }
+
+  const resolvedWorkspaceId = readNonEmptyString(workspaceId);
+  if (!resolvedWorkspaceId) {
+    return null;
+  }
+
+  const pref = await getNotifyChannelPref(store, resolvedWorkspaceId);
+  const prefChannel = readNonEmptyString(pref?.channel);
+  if (pref && prefChannel) {
+    if (pref.confirmed) {
+      return {
+        channel: prefChannel,
+        shouldAppendConfirmPrompt: false,
+        source: 'pref-confirmed',
+      };
+    }
+
+    if (pref.unconfirmedPosts < AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS) {
+      const unconfirmedPosts = await incrementUnconfirmedPosts(store, resolvedWorkspaceId);
+      if (unconfirmedPosts >= AUTO_CONFIRM_AFTER_UNCONFIRMED_POSTS) {
+        await setNotifyChannelPref(store, resolvedWorkspaceId, prefChannel, true);
+      }
+
+      return {
+        channel: prefChannel,
+        shouldAppendConfirmPrompt: true,
+        source: 'pref-unconfirmed',
+      };
+    }
+
+    await setNotifyChannelPref(store, resolvedWorkspaceId, prefChannel, true);
+    return {
+      channel: prefChannel,
+      shouldAppendConfirmPrompt: false,
+      source: 'pref-confirmed',
+    };
+  }
+
+  let channels: BotChannel[];
+  try {
+    channels = await listChannels();
+  } catch {
+    return null;
+  }
+  if (channels.length === 0) {
+    return null;
+  }
+
+  const picked = await pickChannel(chat, channels, payload);
+  if (!picked) {
+    return null;
+  }
+
+  await setNotifyChannelPref(store, resolvedWorkspaceId, picked.channelId, false);
+  await incrementUnconfirmedPosts(store, resolvedWorkspaceId);
+
+  return {
+    channel: picked.channelId,
+    shouldAppendConfirmPrompt: true,
+    source: 'discovery',
+  };
+}

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/surfaces",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Surface connection registry, inbound normalization, and outbound dispatch for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -51,3 +51,6 @@ export type {
   SlackEventDedupInput,
   SlackEventDedupStore,
 } from "./slack-event-dedup.js";
+
+export { listBotChannels } from "./slack-bot-channels.js";
+export type { BotChannel } from "./slack-bot-channels.js";

--- a/packages/surfaces/src/slack-bot-channels.test.ts
+++ b/packages/surfaces/src/slack-bot-channels.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { listBotChannels } from './slack-bot-channels.js';
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchSequence(responses: Array<Record<string, unknown>>): void {
+  let call = 0;
+  globalThis.fetch = vi.fn(async () => {
+    const payload = responses[call] ?? responses[responses.length - 1];
+    call += 1;
+    return new Response(JSON.stringify(payload), { status: 200 });
+  }) as typeof fetch;
+}
+
+describe('listBotChannels', () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('maps a single page of channels', async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        channels: [
+          {
+            id: 'C1',
+            name: 'general',
+            topic: { value: 'chatter' },
+            purpose: { value: 'everyone' },
+            num_members: 42,
+          },
+          { id: 'C2', name: 'random' },
+        ],
+      },
+    ]);
+
+    const channels = await listBotChannels('xoxb-token', 'U_BOT');
+    expect(channels).toEqual([
+      { id: 'C1', name: 'general', topic: 'chatter', purpose: 'everyone', numMembers: 42 },
+      { id: 'C2', name: 'random' },
+    ]);
+  });
+
+  it('follows next_cursor up to 3 pages then stops', async () => {
+    mockFetchSequence([
+      { ok: true, channels: [{ id: 'C1', name: 'a' }], response_metadata: { next_cursor: 'p2' } },
+      { ok: true, channels: [{ id: 'C2', name: 'b' }], response_metadata: { next_cursor: 'p3' } },
+      { ok: true, channels: [{ id: 'C3', name: 'c' }], response_metadata: { next_cursor: 'p4' } },
+      { ok: true, channels: [{ id: 'C4', name: 'd' }] },
+    ]);
+
+    const channels = await listBotChannels('xoxb-token', 'U_BOT');
+    expect(channels.map((c) => c.id)).toEqual(['C1', 'C2', 'C3']);
+  });
+
+  it('throws when Slack returns ok:false', async () => {
+    mockFetchSequence([{ ok: false, error: 'invalid_auth' }]);
+
+    await expect(listBotChannels('xoxb-token', 'U_BOT')).rejects.toThrow(/invalid_auth/);
+  });
+
+  it('drops malformed channel entries', async () => {
+    mockFetchSequence([
+      {
+        ok: true,
+        channels: [
+          { id: 'C1', name: 'ok' },
+          null,
+          { id: 'C2' },
+          { name: 'no-id' },
+          'not-an-object',
+        ],
+      },
+    ]);
+
+    const channels = await listBotChannels('xoxb-token', 'U_BOT');
+    expect(channels).toEqual([{ id: 'C1', name: 'ok' }]);
+  });
+});

--- a/packages/surfaces/src/slack-bot-channels.ts
+++ b/packages/surfaces/src/slack-bot-channels.ts
@@ -1,0 +1,112 @@
+export interface BotChannel {
+  id: string;
+  name: string;
+  topic?: string;
+  purpose?: string;
+  numMembers?: number;
+}
+
+interface SlackChannel {
+  id?: unknown;
+  name?: unknown;
+  topic?: { value?: unknown };
+  purpose?: { value?: unknown };
+  num_members?: unknown;
+}
+
+interface SlackUsersConversationsResponse {
+  ok?: unknown;
+  error?: unknown;
+  channels?: unknown;
+  response_metadata?: {
+    next_cursor?: unknown;
+  };
+}
+
+const USERS_CONVERSATIONS_URL = 'https://slack.com/api/users.conversations';
+const MAX_PAGES = 3;
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function mapChannel(channel: unknown): BotChannel | null {
+  if (!channel || typeof channel !== 'object') {
+    return null;
+  }
+
+  const slackChannel = channel as SlackChannel;
+  const topic = readString(slackChannel.topic?.value);
+  const purpose = readString(slackChannel.purpose?.value);
+  const id = readString(slackChannel.id);
+  const name = readString(slackChannel.name);
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    id,
+    name,
+    ...(topic ? { topic } : {}),
+    ...(purpose ? { purpose } : {}),
+    ...(Number.isFinite(slackChannel.num_members)
+      ? { numMembers: slackChannel.num_members as number }
+      : {}),
+  };
+}
+
+/**
+ * List public and private Slack channels the given bot user is a member of.
+ * Follows `next_cursor` pagination up to 3 pages. Throws on `ok: false`.
+ */
+export async function listBotChannels(
+  token: string,
+  botUserId: string,
+): Promise<BotChannel[]> {
+  const channels: BotChannel[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const body = new URLSearchParams({
+      user: botUserId,
+      types: 'public_channel,private_channel',
+      exclude_archived: 'true',
+      limit: '200',
+    });
+    if (cursor) {
+      body.set('cursor', cursor);
+    }
+
+    const response = await fetch(USERS_CONVERSATIONS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      },
+      body,
+    });
+    const payload = (await response.json()) as SlackUsersConversationsResponse;
+
+    if (payload.ok === false) {
+      throw new Error(
+        `Slack users.conversations failed: ${readString(payload.error) ?? 'unknown_error'}`,
+      );
+    }
+
+    if (Array.isArray(payload.channels)) {
+      for (const channel of payload.channels) {
+        const mapped = mapChannel(channel);
+        if (mapped) {
+          channels.push(mapped);
+        }
+      }
+    }
+
+    cursor = readString(payload.response_metadata?.next_cursor);
+    if (!cursor) {
+      break;
+    }
+  }
+
+  return channels;
+}


### PR DESCRIPTION
## Summary
Extracts the dynamic proactive-channel primitives that shipped in [AgentWorkforce/sage#99](https://github.com/AgentWorkforce/sage/pull/99) into `@agent-assistant/surfaces` and `@agent-assistant/proactive` so any harness consumer gets them, not just sage. Sage will follow up with a PR that adopts these and deletes its local copies.

## What's new

### `@agent-assistant/surfaces`
- `listBotChannels(token, botUserId)` — `users.conversations` wrapper with cursor pagination up to 3 pages
- `BotChannel` type

### `@agent-assistant/proactive`
- `PrefStore` interface (pluggable `get`/`put`) + `get/set/incrementUnconfirmedPosts` keyed by `workspaceId`
- `ChatFn` interface for dependency-injected LLM calls
- `pickChannel` — topic-matched selection via injected classifier, deterministic single-channel fast path, safe fallback on invalid JSON / unknown channelId / throw
- `parseConfirmReply` / `parseRedirectChannelName` / `normalizeChannelName` for freeform reply parsing (`yes` / `#channel-name`)
- `resolveNotifyChannel` — precedence chain `bodyOverride → confirmed pref → unconfirmed pref (counter + auto-confirm after 3 posts) → discovery + LLM pick`

Adds `@agent-assistant/surfaces` as a dependency of `@agent-assistant/proactive` for the `BotChannel` type.

## Design notes
- Nothing is coupled to Cloudflare, OpenRouter, or sage. Consumers supply a `PrefStore`, a `ChatFn`, and a `listChannels` function.
- `PrefStore` lives in `@agent-assistant/proactive` for now — can be promoted to `@agent-assistant/core` if a second consumer wants it.
- `incrementUnconfirmedPosts` is a non-atomic read-modify-write. Under concurrent writers worst case is one extra confirm prompt before auto-confirm fires; documented inline.

## Test plan
- [x] `npm run build --workspaces --if-present` — clean across all packages
- [x] `npx vitest run` in `packages/proactive` — 86/86 (53 pre-existing, 33 new)
- [x] `npx vitest run` in `packages/surfaces` — 56/56 (52 pre-existing, 4 new)
- [ ] After merge + publish: sage follow-up PR swaps local copies for `@agent-assistant/*` imports and ships a `CloudflareKvPrefStore` adapter

## Follow-up
Sage PR to adopt: tracked via memory entry in this worktree; will open against `AgentWorkforce/sage` after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)