### PR TITLE
fix(core): increase default handler timeout to 5 minutes

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -10,7 +10,7 @@ import type {
   RelayOutboundAdapter,
 } from './types.js';
 
-const DEFAULT_HANDLER_TIMEOUT_MS = 30_000;
+const DEFAULT_HANDLER_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_MAX_CONCURRENT_HANDLERS = 10;
 const STOP_DRAIN_TIMEOUT_MS = 30_000;
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -12,7 +12,7 @@ import type {
 
 const DEFAULT_HANDLER_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_MAX_CONCURRENT_HANDLERS = 10;
-const STOP_DRAIN_TIMEOUT_MS = 30_000;
+const DRAIN_MARGIN_MS = 5_000;
 
 type RuntimeLifecycleState = 'created' | 'started' | 'stopped';
 
@@ -318,6 +318,7 @@ export function createAssistant(
     }
 
     drainWaiter ??= createDeferred();
+    const drainTimeoutMs = constraints.handlerTimeoutMs + DRAIN_MARGIN_MS;
 
     await Promise.race([
       drainWaiter.promise,
@@ -325,10 +326,10 @@ export function createAssistant(
         setTimeout(() => {
           reject(
             new Error(
-              `Timed out waiting ${STOP_DRAIN_TIMEOUT_MS}ms for in-flight handlers to drain`,
+              `Timed out waiting ${drainTimeoutMs}ms for in-flight handlers to drain`,
             ),
           );
-        }, STOP_DRAIN_TIMEOUT_MS);
+        }, drainTimeoutMs);
       }),
     ]);
   }


### PR DESCRIPTION
## Summary

- **Bug:** The 30-second `DEFAULT_HANDLER_TIMEOUT_MS` silently kills any handler that makes LLM calls. In Sage's Slack handler, the runtime timed out `processSlackEvent`, the dispatch promise resolved (as timed-out), the Cloudflare Worker `waitUntil` drained because there was nothing left to wait on, and the worker shut down before a reply was ever posted. The user only saw the :eyes: reaction but never received a response.
- **Fix:** Increase the default from `30_000` (30 s) to `5 * 60_000` (5 min). This is a safe ceiling for AI-assistant runtimes where LLM round-trips routinely take 10-60 seconds. Consumers that need a tighter limit can still pass an explicit `handlerTimeoutMs` override.

## Test plan

- [x] All 40 existing tests in `packages/core` pass (`npm test`)
- [ ] Verify Sage Slack handler completes successfully without timeout in staging
- [ ] Confirm any consumer that sets an explicit `handlerTimeoutMs` is unaffected (their override takes precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
