### PR TITLE
fix(core): clear drain timeout timer on successful drain

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -319,19 +319,26 @@ export function createAssistant(
 
     drainWaiter ??= createDeferred();
     const drainTimeoutMs = constraints.handlerTimeoutMs + DRAIN_MARGIN_MS;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
-    await Promise.race([
-      drainWaiter.promise,
-      new Promise<void>((_, reject) => {
-        setTimeout(() => {
-          reject(
-            new Error(
-              `Timed out waiting ${drainTimeoutMs}ms for in-flight handlers to drain`,
-            ),
-          );
-        }, drainTimeoutMs);
-      }),
-    ]);
+    try {
+      await Promise.race([
+        drainWaiter.promise,
+        new Promise<void>((_, reject) => {
+          timeoutHandle = setTimeout(() => {
+            reject(
+              new Error(
+                `Timed out waiting ${drainTimeoutMs}ms for in-flight handlers to drain`,
+              ),
+            );
+          }, drainTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
   }
 
   function runNext(): void {


### PR DESCRIPTION
## Summary

- Follow-up to #38 — the `setTimeout` in `waitForDrain` was never cleared when handlers drained successfully before the timeout fired
- With the drain timeout now at 5+ minutes (derived from handler timeout), this kept the Node.js event loop alive long after `stop()` completed, preventing clean process exit
- Applies the same `try/finally + clearTimeout` pattern already used by `withTimeout`

## Test plan

- [x] All 40 core tests pass
- [ ] Verify process exits cleanly after `runtime.stop()` with in-flight handlers that complete before timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
