### PR TITLE
webhook-runtime: BYOH worker bridge (Level A) — claude / codex / opencode / gemini

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   ],
   "scripts": {
     "build:sdk": "npm run build -w @agent-assistant/sdk",
-    "agent": "RELAY_AUTO_SPAWN=true RELAY_CHANNEL=specialists RELAY_WORKER=specialist-worker RELAY_CLI=claude RELAY_MODEL=claude-sonnet-4-6 npm run cli -w @agent-assistant/webhook-runtime"
+    "agent": "RELAY_AUTO_SPAWN=false RELAY_CHANNEL=specialists RELAY_WORKER=specialist-worker RELAY_CLI=claude RELAY_MODEL=claude-sonnet-4-6 npm run cli -w @agent-assistant/webhook-runtime",
+    "worker": "npm run worker -w @agent-assistant/webhook-runtime --"
   },
   "devDependencies": {
     "@agentworkforce/workload-router": "^0.2.0"

--- a/packages/webhook-runtime/README.md
+++ b/packages/webhook-runtime/README.md
@@ -69,7 +69,7 @@ with `use <id>`.
 Environment prerequisites for the non-default personas:
 
 - **`github-real`** — `@agent-assistant/specialists` built and its runtime deps resolvable.
-- **`byoh-relay`** — install `@agent-assistant/harness` (declared as an optional peer dep; the persona dynamic-imports `@agent-assistant/harness/agent-relay`). Needs a running Relay broker and a worker already registered on the channel (the adapter rejects `sendMessage` to unknown agent names with `Agent "<name>" not found`). Either spawn the worker yourself before POSTing or set `RELAY_AUTO_SPAWN=true`. Env vars: `RELAY_CHANNEL`, `RELAY_WORKER`, `RELAY_AUTO_SPAWN`, `RELAY_CLI`, `RELAY_MODEL`.
+- **`byoh-relay`** — install `@agent-assistant/harness` (declared as an optional peer dep; the persona dynamic-imports `@agent-assistant/harness/agent-relay`). Needs a running Relay broker and a worker already registered on the channel (the adapter rejects `sendMessage` to unknown agent names with `Agent "<name>" not found`). Easiest path: run the bundled worker bridge in a separate terminal — see "BYOH end-to-end locally" below. Env vars: `RELAY_CHANNEL`, `RELAY_WORKER`, `RELAY_AUTO_SPAWN`, `RELAY_CLI`, `RELAY_MODEL`.
 - **`http-forward`** — `HTTP_FORWARD_URL` pointing at any JSON-accepting endpoint.
 
 Example session:
@@ -82,6 +82,79 @@ webhook> drop failer
 webhook> use http-forward          # HTTP_FORWARD_URL must be set before this
 webhook> mention ping              # same event now fans out to the HTTP target too
 ```
+
+## BYOH end-to-end locally
+
+The `byoh-relay` persona publishes an `agent-assistant.execution-request.v1`
+message over a real Relay broker to a **named worker** that must be registered
+on the channel before the request arrives. The bundled bridge at
+`examples/byoh-worker.ts` is that worker — it listens, invokes a
+non-interactive CLI session (claude / codex / opencode / gemini), and emits a
+protocol-compliant `agent-assistant.execution-result.v1` back.
+
+Run it alongside the REPL in two terminals:
+
+**Terminal 1 — the worker:**
+
+```bash
+# from the repo root
+npm run worker -- --cli claude --model claude-sonnet-4-6
+
+# or whichever CLI you have installed:
+npm run worker -- --cli codex
+npm run worker -- --cli opencode --model anthropic/claude-sonnet-4-5
+npm run worker -- --cli gemini
+```
+
+You'll see:
+
+```
+[byoh-worker] registered as 'specialist-worker' on channel 'specialists' (cli=claude, cwd=/Users/you/...)
+[byoh-worker] invoking 'claude' per request; timeout=120000ms
+```
+
+**Terminal 2 — the webhook runtime:**
+
+```bash
+# from the repo root
+npm run agent
+```
+
+That starts the REPL with `RELAY_AUTO_SPAWN=false` (the worker you started in
+terminal 1 owns that responsibility) and env set for the `specialists` channel
+and `specialist-worker` name. Then at the prompt:
+
+```
+webhook> use byoh-relay
+webhook> mention summarize the open github issues
+```
+
+The `byoh-relay` persona's `createAgentRelayExecutionAdapter` will publish
+the request to `specialist-worker`. The worker in terminal 1 receives it,
+invokes the configured CLI with the instruction as the prompt, captures stdout,
+and replies with the result. You'll see the final response logged back in
+terminal 2 as `[byoh-relay] channel=C_CLI eventType=app_mention -> <CLI output>`.
+
+### Bash stub for testing without spending API tokens
+
+```bash
+npm run worker -- --cli bash --cli-args 'read -d "" prompt; echo "stub echoed: ${prompt:0:40}"'
+```
+
+Useful for validating the transport without invoking any real AI. The same
+pattern drives the `src/byoh-worker-bridge.test.ts` smoke tests.
+
+### Worker flags
+
+| flag | meaning | default |
+|---|---|---|
+| `--cli <name>` | `claude` / `codex` / `opencode` / `gemini` / `bash` | `claude` |
+| `--cli-args <string>` | shell-split extra args, only meaningful for `--cli bash` | (empty) |
+| `--channel <id>` | Relay channel to listen on | `$RELAY_CHANNEL` or `specialists` |
+| `--worker-name <name>` | agent name registered with broker | `$RELAY_WORKER` or `specialist-worker` |
+| `--cwd <path>` | broker cwd (for `.agent-relay/connection.json` discovery) | `process.cwd()` |
+| `--model <id>` | model passed to the CLI | `$RELAY_MODEL` or CLI default |
+| `--timeout-ms <n>` | per-invocation CLI subprocess timeout | `120000` |
 
 ## What the CLI proves
 

--- a/packages/webhook-runtime/examples/byoh-worker.ts
+++ b/packages/webhook-runtime/examples/byoh-worker.ts
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+/**
+ * BYOH worker bridge. Long-running process that:
+ *
+ *   1. Registers with a local agent-relay broker under --worker-name on --channel.
+ *   2. Listens for `agent-assistant.execution-request.v1` messages.
+ *   3. Invokes the configured CLI (claude / codex / opencode / gemini / bash)
+ *      non-interactively with the request text as the prompt.
+ *   4. Wraps the CLI's stdout in `agent-assistant.execution-result.v1` and
+ *      sends it back to the sender on the same thread.
+ *
+ * Exists as an example for local experimentation. The `runWorkerBridge`
+ * helper is also exported so tests can drive the loop with an injected
+ * RelayAdapter — avoiding cross-process broker-sharing pitfalls.
+ *
+ * Level B will migrate the CliRunner + bridge logic into
+ * @agent-assistant/harness/worker-bridge.
+ */
+import { spawn as spawnChild } from "node:child_process";
+import process from "node:process";
+
+import { RelayAdapter, type BrokerEvent } from "@agent-relay/sdk";
+import {
+  AGENT_RELAY_EXECUTION_REQUEST_TYPE,
+  AGENT_RELAY_EXECUTION_RESULT_TYPE,
+  type AgentRelayExecutionRequestMessage,
+} from "@agent-assistant/harness/agent-relay";
+import type { ExecutionResult } from "@agent-assistant/harness";
+
+export type CliName = "claude" | "codex" | "opencode" | "gemini" | "bash";
+
+export type WorkerBridgeOptions = {
+  cli: CliName;
+  /** Only meaningful with --cli bash; appended to `bash -c`. */
+  cliArgs: string[];
+  channel: string;
+  workerName: string;
+  /** Used as subprocess cwd for CLI invocations. RelayAdapter cwd is supplied separately. */
+  cwd: string;
+  model?: string;
+  timeoutMs: number;
+};
+
+type CliInvocation = {
+  command: string;
+  args: string[];
+  promptViaStdin: boolean;
+};
+
+type CliRunnerResult =
+  | { status: "completed"; text: string }
+  | { status: "failed"; error: string; stderr?: string };
+
+const HELP = `
+Usage: byoh-worker [options]
+
+Options:
+  --cli <name>            claude | codex | opencode | gemini | bash (default: claude)
+  --cli-args <string>     Extra args appended to the CLI invocation (one shell-like string).
+                          Only used with --cli bash; ignored otherwise.
+  --channel <id>          Relay channel to listen on (default: $RELAY_CHANNEL or 'specialists')
+  --worker-name <name>    Agent name to register (default: $RELAY_WORKER or 'specialist-worker')
+  --cwd <path>            Working directory for the RelayAdapter (default: process.cwd())
+  --model <id>            Model passed to the CLI (default: unset; CLI's own default)
+  --timeout-ms <n>        Per-invocation timeout for the CLI subprocess (default: 120000)
+  -h, --help              Show this help
+
+Env var fallbacks: RELAY_CHANNEL, RELAY_WORKER, RELAY_MODEL, BYOH_WORKER_TIMEOUT_MS
+
+Example (claude):
+  npm run worker -- --cli claude --model claude-sonnet-4-6
+
+Example (bash stub, useful for smoke testing):
+  npm run worker -- --cli bash --cli-args 'echo "stub response"'
+`;
+
+function isCliName(value: string): value is CliName {
+  return (
+    value === "claude" ||
+    value === "codex" ||
+    value === "opencode" ||
+    value === "gemini" ||
+    value === "bash"
+  );
+}
+
+function splitShellArgs(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (const ch of input) {
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (!inQuotes && /\s/.test(ch)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+export function parseArgs(argv: readonly string[]): WorkerBridgeOptions {
+  let cli: CliName = "claude";
+  let cliArgs: string[] = [];
+  let channel = process.env.RELAY_CHANNEL ?? "specialists";
+  let workerName = process.env.RELAY_WORKER ?? "specialist-worker";
+  let cwd = process.cwd();
+  let model = process.env.RELAY_MODEL;
+  let timeoutMs = Number(process.env.BYOH_WORKER_TIMEOUT_MS ?? "120000");
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = (): string => {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      i += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case "-h":
+      case "--help":
+        console.log(HELP);
+        process.exit(0);
+      case "--cli": {
+        const value = next();
+        if (!isCliName(value)) {
+          throw new Error(
+            `--cli must be one of claude|codex|opencode|gemini|bash (got '${value}')`,
+          );
+        }
+        cli = value;
+        break;
+      }
+      case "--cli-args":
+        cliArgs = splitShellArgs(next());
+        break;
+      case "--channel":
+        channel = next();
+        break;
+      case "--worker-name":
+        workerName = next();
+        break;
+      case "--cwd":
+        cwd = next();
+        break;
+      case "--model":
+        model = next();
+        break;
+      case "--timeout-ms":
+        timeoutMs = Number(next());
+        if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+          throw new Error(`--timeout-ms must be a positive integer`);
+        }
+        break;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return { cli, cliArgs, channel, workerName, cwd, model, timeoutMs };
+}
+
+export function buildInvocation(
+  opts: WorkerBridgeOptions,
+  prompt: string,
+): CliInvocation {
+  switch (opts.cli) {
+    case "claude": {
+      const args = ["-p", "--output-format", "text"];
+      if (opts.model) args.push("--model", opts.model);
+      args.push(prompt);
+      return { command: "claude", args, promptViaStdin: false };
+    }
+    case "codex": {
+      const args = ["exec"];
+      if (opts.model) args.push("-m", opts.model);
+      args.push(prompt);
+      return { command: "codex", args, promptViaStdin: false };
+    }
+    case "opencode": {
+      const args = ["run"];
+      if (opts.model) args.push("-m", opts.model);
+      args.push(prompt);
+      return { command: "opencode", args, promptViaStdin: false };
+    }
+    case "gemini": {
+      const args = ["-p", prompt];
+      if (opts.model) args.push("-m", opts.model);
+      return { command: "gemini", args, promptViaStdin: false };
+    }
+    case "bash": {
+      const scriptBody =
+        opts.cliArgs.length > 0 ? opts.cliArgs.join(" ") : "cat";
+      return {
+        command: "bash",
+        args: ["-c", scriptBody],
+        promptViaStdin: true,
+      };
+    }
+  }
+}
+
+export async function runCli(
+  opts: WorkerBridgeOptions,
+  prompt: string,
+): Promise<CliRunnerResult> {
+  const invocation = buildInvocation(opts, prompt);
+  return new Promise((resolve) => {
+    const child = spawnChild(invocation.command, invocation.args, {
+      cwd: opts.cwd,
+      env: process.env,
+      stdio: [invocation.promptViaStdin ? "pipe" : "ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const settle = (result: CliRunnerResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      settle({
+        status: "failed",
+        error: `CLI '${opts.cli}' timed out after ${opts.timeoutMs}ms`,
+        stderr: stderr.slice(-2000),
+      });
+    }, opts.timeoutMs);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (error) => {
+      settle({
+        status: "failed",
+        error: `Failed to spawn '${invocation.command}': ${error.message}`,
+      });
+    });
+    child.on("close", (code) => {
+      if (code === 0) {
+        settle({ status: "completed", text: stdout.trimEnd() });
+        return;
+      }
+      settle({
+        status: "failed",
+        error: `CLI '${opts.cli}' exited with code ${code}`,
+        stderr: stderr.slice(-2000),
+      });
+    });
+
+    if (invocation.promptViaStdin && child.stdin) {
+      child.stdin.write(prompt);
+      child.stdin.end();
+    }
+  });
+}
+
+export function toExecutionResult(
+  runnerResult: CliRunnerResult,
+  backendId: string,
+): ExecutionResult {
+  if (runnerResult.status === "completed") {
+    return {
+      backendId,
+      status: "completed",
+      output: { text: runnerResult.text },
+    };
+  }
+  return {
+    backendId,
+    status: "failed",
+    error: {
+      code: "backend_execution_error",
+      message: runnerResult.error,
+      retryable: false,
+      ...(runnerResult.stderr
+        ? { metadata: { stderr: runnerResult.stderr } }
+        : {}),
+    },
+  };
+}
+
+export function extractPrompt(
+  request: AgentRelayExecutionRequestMessage,
+): string {
+  const messageText =
+    typeof request.request?.message?.text === "string"
+      ? request.request.message.text
+      : "";
+  const systemPrompt =
+    typeof request.request?.instructions?.systemPrompt === "string"
+      ? request.request.instructions.systemPrompt
+      : "";
+  if (systemPrompt && messageText) {
+    return `${systemPrompt}\n\n${messageText}`;
+  }
+  return messageText || systemPrompt;
+}
+
+export type WorkerBridgeHandle = {
+  /** Unsubscribe from the relay and stop handling new requests. */
+  dispose(): void;
+};
+
+/**
+ * Register the worker on the given relay and start handling execution
+ * requests. Caller is responsible for relay lifecycle (start/shutdown).
+ * Intended for both the CLI entrypoint and tests — tests can inject a
+ * single RelayAdapter shared with the orchestrator, avoiding the
+ * cross-process broker-discovery issue where each Node process spawns
+ * its own broker subprocess.
+ */
+export async function runWorkerBridge(
+  relay: RelayAdapter,
+  opts: WorkerBridgeOptions,
+): Promise<WorkerBridgeHandle> {
+  const backendId = `byoh-worker:${opts.cli}`;
+
+  const spawnResult = await relay.spawn({
+    name: opts.workerName,
+    cli: "bash",
+    task: "cat >/dev/null",
+    includeWorkflowConventions: false,
+  });
+  if (!spawnResult.success) {
+    throw new Error(
+      `Failed to register worker '${opts.workerName}' with broker: ${spawnResult.error ?? "unknown error"}`,
+    );
+  }
+
+  console.log(
+    `[byoh-worker] registered as '${opts.workerName}' on channel '${opts.channel}' (cli=${opts.cli}, cwd=${opts.cwd})`,
+  );
+  if (opts.cli !== "bash") {
+    console.log(
+      `[byoh-worker] invoking '${opts.cli}' per request; timeout=${opts.timeoutMs}ms`,
+    );
+  }
+
+  let disposed = false;
+
+  const handleEvent = async (event: BrokerEvent): Promise<void> => {
+    if (disposed) return;
+    if (event.kind !== "relay_inbound") return;
+    if (event.target !== opts.workerName) return;
+
+    let parsed: AgentRelayExecutionRequestMessage;
+    try {
+      parsed = JSON.parse(event.body) as AgentRelayExecutionRequestMessage;
+    } catch {
+      return;
+    }
+    if (parsed.type !== AGENT_RELAY_EXECUTION_REQUEST_TYPE) return;
+
+    const prompt = extractPrompt(parsed);
+    console.log(
+      `[byoh-worker] turn=${parsed.turnId} thread=${parsed.threadId} prompt=${JSON.stringify(prompt.slice(0, 80))}...`,
+    );
+
+    const runnerResult = await runCli(opts, prompt);
+    if (runnerResult.status === "completed") {
+      console.log(
+        `[byoh-worker] turn=${parsed.turnId} completed (${runnerResult.text.length} chars)`,
+      );
+    } else {
+      console.error(
+        `[byoh-worker] turn=${parsed.turnId} failed: ${runnerResult.error}`,
+      );
+    }
+
+    const executionResult = toExecutionResult(runnerResult, backendId);
+
+    try {
+      await relay.sendMessage({
+        to: parsed.replyTo.agentId,
+        from: opts.workerName,
+        threadId: parsed.threadId,
+        text: JSON.stringify({
+          type: AGENT_RELAY_EXECUTION_RESULT_TYPE,
+          turnId: parsed.turnId,
+          threadId: parsed.threadId,
+          executionResult,
+        }),
+      });
+    } catch (error) {
+      console.error(
+        `[byoh-worker] failed to publish result for turn=${parsed.turnId}:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+  };
+
+  const unsubscribe = relay.onEvent((event) => {
+    void handleEvent(event);
+  });
+
+  return {
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      unsubscribe();
+    },
+  };
+}
+
+async function runCliEntrypoint(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const relay = new RelayAdapter({
+    cwd: opts.cwd,
+    channels: [opts.channel],
+  });
+  await relay.start();
+
+  const handle = await runWorkerBridge(relay, opts);
+
+  let shuttingDown = false;
+  const shutdown = async (signal: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`\n[byoh-worker] shutting down (${signal})...`);
+    handle.dispose();
+    await relay.release(opts.workerName).catch(() => {});
+    await relay.shutdown().catch(() => {});
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => void shutdown("SIGINT"));
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+}
+
+// Only auto-run when invoked directly. Importing this file (from tests or
+// Level B's harness migration) should not spin up a broker.
+const invokedAsScript = process.argv[1]?.endsWith("byoh-worker.ts");
+if (invokedAsScript) {
+  runCliEntrypoint().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : error);
+    process.exit(1);
+  });
+}

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -29,6 +29,7 @@
     "build": "tsc",
     "test": "vitest run",
     "cli": "tsx examples/cli.ts",
+    "worker": "tsx examples/byoh-worker.ts",
     "example:sim": "tsx examples/slack-to-github-sim.ts"
   },
   "dependencies": {

--- a/packages/webhook-runtime/src/byoh-worker-bridge.test.ts
+++ b/packages/webhook-runtime/src/byoh-worker-bridge.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { RelayAdapter } from "@agent-relay/sdk";
+import { createAgentRelayExecutionAdapter } from "@agent-assistant/harness/agent-relay";
+import type { ExecutionRequest } from "@agent-assistant/harness";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  runWorkerBridge,
+  type WorkerBridgeHandle,
+  type WorkerBridgeOptions,
+} from "../examples/byoh-worker.js";
+
+const CHANNEL_ID = "wf-byoh-worker-smoke";
+const WORKER_NAME = "byoh-worker-smoke";
+const ORCHESTRATOR_NAME = "agent-assistant";
+
+type Harness = {
+  cwd: string;
+  relay: RelayAdapter;
+  bridge: WorkerBridgeHandle;
+};
+
+async function startHarness(cliArgsScript: string): Promise<Harness> {
+  const cwd = mkdtempSync(join(tmpdir(), "byoh-worker-smoke-"));
+  const relay = new RelayAdapter({ cwd, channels: [CHANNEL_ID] });
+  await relay.start();
+
+  // Register orchestrator so the worker can reply to it.
+  const orchestrator = await relay.spawn({
+    name: ORCHESTRATOR_NAME,
+    cli: "bash",
+    task: "cat >/dev/null",
+    includeWorkflowConventions: false,
+  });
+  if (!orchestrator.success) {
+    throw new Error(
+      `Failed to register orchestrator: ${orchestrator.error ?? "unknown"}`,
+    );
+  }
+
+  const opts: WorkerBridgeOptions = {
+    cli: "bash",
+    cliArgs: [cliArgsScript],
+    channel: CHANNEL_ID,
+    workerName: WORKER_NAME,
+    cwd,
+    timeoutMs: 10_000,
+  };
+
+  const bridge = await runWorkerBridge(relay, opts);
+  return { cwd, relay, bridge };
+}
+
+async function teardown(harness: Harness | undefined): Promise<void> {
+  if (!harness) return;
+  harness.bridge.dispose();
+  await harness.relay.release(WORKER_NAME).catch(() => {});
+  await harness.relay.release(ORCHESTRATOR_NAME).catch(() => {});
+  await harness.relay.shutdown().catch(() => {});
+  rmSync(harness.cwd, { recursive: true, force: true });
+}
+
+describe("byoh-worker bridge smoke test (bash stub)", () => {
+  let harness: Harness | undefined;
+
+  beforeEach(() => {
+    harness = undefined;
+  });
+
+  afterEach(async () => {
+    await teardown(harness);
+    harness = undefined;
+  });
+
+  it(
+    "receives an ExecutionRequest via real broker, invokes bash stub, returns ExecutionResult",
+    async () => {
+      harness = await startHarness('read -d "" prompt; echo "stub echoed: ${prompt:0:40}"');
+
+      const adapter = createAgentRelayExecutionAdapter({
+        cwd: harness.cwd,
+        channelId: CHANNEL_ID,
+        workerName: WORKER_NAME,
+        orchestratorName: ORCHESTRATOR_NAME,
+        spawnWorker: { enabled: false, cli: "bash" },
+        timeoutMs: 25_000,
+        relay: harness.relay,
+      });
+
+      const request: ExecutionRequest = {
+        assistantId: "smoke-test",
+        turnId: "turn-smoke-1",
+        threadId: "thread-smoke-1",
+        message: {
+          id: "m-smoke-1",
+          text: "hello from smoke test",
+          receivedAt: new Date().toISOString(),
+        },
+        instructions: {
+          systemPrompt: "You are a smoke-test responder.",
+        },
+      };
+
+      const result = await adapter.execute(request);
+
+      expect(result.status).toBe("completed");
+      expect(result.output?.text).toMatch(/^stub echoed: /);
+      expect(result.metadata?.relay).toMatchObject({
+        channelId: CHANNEL_ID,
+        target: WORKER_NAME,
+        threadId: "thread-smoke-1",
+      });
+    },
+    45_000,
+  );
+
+  it(
+    "reports backend_execution_error when the CLI exits non-zero",
+    async () => {
+      harness = await startHarness('echo "failing stub" >&2; exit 3');
+
+      const adapter = createAgentRelayExecutionAdapter({
+        cwd: harness.cwd,
+        channelId: CHANNEL_ID,
+        workerName: WORKER_NAME,
+        orchestratorName: ORCHESTRATOR_NAME,
+        spawnWorker: { enabled: false, cli: "bash" },
+        timeoutMs: 25_000,
+        relay: harness.relay,
+      });
+
+      const result = await adapter.execute({
+        assistantId: "smoke-test",
+        turnId: "turn-smoke-fail",
+        threadId: "thread-smoke-fail",
+        message: {
+          id: "m-smoke-fail",
+          text: "this should fail",
+          receivedAt: new Date().toISOString(),
+        },
+        instructions: { systemPrompt: "sys" },
+      });
+
+      expect(result.status).toBe("failed");
+      // The worker replied with a properly shaped ExecutionResult whose
+      // own status was 'failed'. The adapter surfaces that via its own
+      // error field on the outer result.
+      expect(result.output).toBeUndefined();
+      expect(result.error?.code ?? "").toMatch(/backend_execution_error|execution_failed/);
+    },
+    45_000,
+  );
+});


### PR DESCRIPTION
## Summary

Adds `packages/webhook-runtime/examples/byoh-worker.ts` — a long-running bridge that turns the `byoh-relay` persona from "import path reaches the adapter" (what PR #37 delivered) into "end-to-end round-trip through a real CLI worker" (what this PR delivers).

The bridge:

1. Registers as a named Relay agent (so the broker will route messages to it — without this, `sendMessage` 404s with `Agent "<name>" not found`, which is what was happening in practice post-#37).
2. Listens via `relay.onEvent` for `agent-assistant.execution-request.v1` messages targeted at it.
3. Invokes the configured non-interactive CLI with the request text as the prompt:
   - `claude -p --output-format text [--model X] <prompt>`
   - `codex exec [-m X] <prompt>`
   - `opencode run [-m X] <prompt>`
   - `gemini -p <prompt> [-m X]`
   - `bash -c <script>` with prompt piped on stdin (token-free testing stub)
4. Wraps stdout in `agent-assistant.execution-result.v1` with matching `turnId`/`threadId` and sends back.

The `runWorkerBridge(relay, opts)` helper is exported so tests can run the loop in-process with an injected `RelayAdapter` — avoiding the cross-process broker-discovery pitfall where separate Node processes each spawn their own broker instead of sharing one via `{cwd}/.agent-relay/connection.json`.

## Two-terminal flow

```bash
# terminal 1 — the worker
npm run worker -- --cli claude --model claude-sonnet-4-6

# terminal 2 — the webhook runtime
npm run agent
webhook> use byoh-relay
webhook> mention summarize the open github issues
```

`npm run agent` is flipped to `RELAY_AUTO_SPAWN=false` since the worker is now user-managed. README gains a "BYOH end-to-end locally" section walking through this per CLI.

## What this unlocks

Before this PR, running `npm run agent` → `use byoh-relay` → `mention X` always timed out because the auto-spawned CLI had no protocol translation. Now you can exercise the real BYOH path end-to-end with any of the four CLIs, and the smoke test proves the transport works independent of any specific CLI installation.

## What's NOT in this PR (deferred to Level B)

- Migration of `CliRunner` + bridge logic into `@agent-assistant/harness/worker-bridge` as a proper subsystem exported at a dedicated subpath.
- Per-CLI runner unit tests (currently only the bash stub is tested — real CLI invocations cost tokens and are validated manually in the two-terminal flow).
- Update to `AgentRelayExecutionAdapter.ensureWorker` so `spawnWorker.enabled=true` invokes the bridge instead of a bare CLI. This would make `RELAY_AUTO_SPAWN=true` actually work out of the box without a separate terminal.

## Test plan

- [x] `npm --prefix packages/webhook-runtime test` — 8 files / 28 tests passing locally (2 new smoke tests using the bash stub).
- [x] `npm --prefix packages/webhook-runtime run build` — clean tsc
- [x] Manual verification of the two-terminal flow with `--cli bash --cli-args 'echo "response"'` (token-free) works.
- [ ] Reviewer tries the flow with at least one real CLI (claude / codex / opencode / gemini) to validate the invocation args match installed versions.
- [ ] Reviewer sanity-checks the README "BYOH end-to-end locally" instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
