### PR TITLE
fix(packages): restore publishable build surfaces

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && npm --prefix ../routing run build && npm --prefix ../connectivity run build && npm --prefix ../traits run build && npm --prefix ../coordination run build && tsc -p tsconfig.proof.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -24,7 +24,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json && npm --prefix ../routing run build && npm --prefix ../connectivity run build && npm --prefix ../traits run build && npm --prefix ../coordination run build && tsc -p tsconfig.proof.json",
+    "build": "tsc -p tsconfig.json",
+    "build:proof": "npm --prefix ../routing run build && npm --prefix ../connectivity run build && npm --prefix ../traits run build && npm --prefix ../coordination run build && tsc -p tsconfig.proof.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/packages/harness/src/adapter/proof/validation-specialist.ts
+++ b/packages/harness/src/adapter/proof/validation-specialist.ts
@@ -177,7 +177,7 @@ export function createValidationSpecialist(
     description: 'Validates BYOH execution results and emits connectivity signals.',
     capabilities: ['execution-validation', 'proof-signals'],
     handler: {
-      async execute(instruction, context) {
+      async execute(instruction: string, context: { threadId?: string }) {
         const result = validateExecutionResult(instruction, {
           ...config,
           threadId: context.threadId || config.threadId,

--- a/packages/harness/tsconfig.json
+++ b/packages/harness/tsconfig.json
@@ -17,6 +17,8 @@
   ],
   "exclude": [
     "src/**/*.test.ts",
+    "src/adapter/proof/**/*.ts",
+    "src/proof.ts",
     "dist"
   ]
 }

--- a/packages/harness/tsconfig.proof.json
+++ b/packages/harness/tsconfig.proof.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/proof.ts",
+    "src/adapter/proof/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "dist"
+  ]
+}

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -14,6 +14,7 @@
     "dist"
   ],
   "scripts": {
+    "prebuild": "npm --prefix ../coordination run build && npm --prefix ../vfs run build",
     "build": "tsc -p tsconfig.json",
     "test": "vitest run"
   },


### PR DESCRIPTION
## Summary
- split harness proof compilation from the main runtime-safe harness build
- ensure harness proof builds its dependent package surfaces in the right order
- ensure specialists builds its dependencies before emitting its package surface

## Why
Publish/test was failing in `@agent-assistant/webhook-runtime` because:
- `@agent-assistant/harness/agent-relay` export existed but the target build surface was not materializing reliably
- `@agent-assistant/specialists` entry resolution failed because its dist surface was not built before downstream tests

## Validation
- `npm run build -w @agent-assistant/harness`
- `npm run build -w @agent-assistant/specialists`
- `npm test --workspace @agent-assistant/webhook-runtime`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
