### PR TITLE
fix(webhook-runtime): build harness + specialists before tests

### DIFF
--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -27,6 +27,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "pretest": "npm --prefix ../harness run build && npm --prefix ../specialists run build",
     "test": "vitest run",
     "cli": "tsx examples/cli.ts",
     "worker": "tsx examples/byoh-worker.ts",


### PR DESCRIPTION
## Summary
`publish.yml`'s \"Run tests\" step runs `npm test` per package in order, without a global build step between them. When `webhook-runtime` tests run, three tests fail at module resolution because the packages they import don't have `dist/` built yet:

- `byoh-webhook-real-broker-e2e.test.ts` → imports `@agent-assistant/harness/agent-relay` (subpath export pointing at `dist/adapter/agent-relay-adapter.js`)
- `byoh-worker-bridge.test.ts` → same subpath
- `github-real-persona-e2e.test.ts` → imports `@agent-assistant/specialists` (main entry pointing at `dist/index.js`)

Vitest bails with `ERR_MODULE_NOT_FOUND` and `Failed to resolve entry for package "@agent-assistant/specialists"`.

Preexisting bug — visible in [publish run 24836170005](https://github.com/AgentWorkforce/agent-assistant/actions/runs/24836170005). Not caused by #42; just surfaced when publish was attempted after the merge.

## Fix
Adds a `pretest` hook to `packages/webhook-runtime/package.json`:

```json
"pretest": "npm --prefix ../harness run build && npm --prefix ../specialists run build"
```

Matches the existing pattern in `packages/coordination/package.json` (pretest builds `../routing` + `../connectivity`).

## Test plan
- [x] `cd packages/webhook-runtime && npm test` — all 8 suites / 28 tests pass locally (including the 3 that were failing)
- [ ] Publish workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
