### PR TITLE
fix(lock): sync workspace package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3463,7 +3463,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3475,7 +3475,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -3486,7 +3486,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3500,7 +3500,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3520,7 +3520,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3537,7 +3537,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4325,7 +4325,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4337,7 +4337,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4349,7 +4349,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4371,7 +4371,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4388,7 +4388,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4396,7 +4396,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4410,7 +4410,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4418,7 +4418,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -4439,7 +4439,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0",
@@ -4453,7 +4453,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4480,7 +4480,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@hono/node-server": "^2.0.0",


### PR DESCRIPTION
## Summary
- sync `package-lock.json` to the actual current workspace package versions on `main`

## Why
A post-merge lock drift remains in `main`: running `npm install --package-lock-only` rewrites several workspace package version entries in `package-lock.json`. This follow-up captures the honest lockfile state instead of leaving automation to dirty the tree.

## Validation
- `npm install --package-lock-only`