### PR TITLE
feat(harness): workspace tool registry + hallucination prompt fragments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
         working-directory: packages/vfs
         run: npx vitest run
 
-      # Harness depends on traits, connectivity, coordination, and turn-context via
-      # workspace file: links. None of those dists (except turn-context's, which is
-      # stale and references a `memory-retriever.js` that isn't in the committed
-      # dist) are ready for vitest on a fresh checkout. Build them in dependency
-      # order before running harness tests.
+      # Harness depends on traits, connectivity, coordination, turn-context, and
+      # vfs via workspace file: links. None of those dists (except turn-context's,
+      # which is stale and references a `memory-retriever.js` that isn't in the
+      # committed dist) are ready for vitest on a fresh checkout. Build them in
+      # dependency order before running harness tests.
       #
       # Chain:
       #   traits        — leaf (no workspace deps)
@@ -57,6 +57,7 @@ jobs:
       #   connectivity  — leaf (no workspace deps)
       #   coordination  — needs connectivity
       #   turn-context  — needs memory + traits (type-only); rebuilt to refresh stale dist
+      #   vfs           — leaf; harness imports types from @agent-assistant/vfs
       - name: Build — traits (harness dep)
         working-directory: packages/traits
         run: npm run build
@@ -78,6 +79,10 @@ jobs:
         run: |
           rm -rf dist
           npm run build
+
+      - name: Build — vfs (harness dep)
+        working-directory: packages/vfs
+        run: npm run build
 
       - name: Run tests — harness
         working-directory: packages/harness

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "packages/sessions",
         "packages/surfaces",
         "packages/vfs",
+        "packages/github-vfs",
         "packages/routing",
         "packages/connectivity",
         "packages/coordination",
@@ -55,6 +56,10 @@
     },
     "node_modules/@agent-assistant/examples": {
       "resolved": "packages/examples",
+      "link": true
+    },
+    "node_modules/@agent-assistant/github-vfs": {
+      "resolved": "packages/github-vfs",
       "link": true
     },
     "node_modules/@agent-assistant/harness": {
@@ -246,6 +251,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3463,7 +3469,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3475,7 +3481,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -3484,9 +3490,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/continuation/node_modules/@agent-assistant/harness": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3500,7 +3519,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3518,15 +3537,28 @@
         "typescript": "^5.9.3"
       }
     },
+    "packages/github-vfs": {
+      "name": "@agent-assistant/github-vfs",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agent-assistant/harness": "^0.5.0",
+        "@agent-assistant/vfs": "^0.2.23"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/core": "^0.2.0",
         "@agent-assistant/traits": "^0.2.0",
         "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-assistant/vfs": "^0.2.23",
         "@agent-relay/sdk": "^4.0.22"
       },
       "devDependencies": {
@@ -3537,7 +3569,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4325,7 +4357,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4337,7 +4369,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4349,7 +4381,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4371,7 +4403,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4388,7 +4420,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4396,7 +4428,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4410,7 +4442,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4418,7 +4450,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -4428,9 +4460,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/telemetry/node_modules/@agent-assistant/harness": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4439,7 +4484,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.23",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0",
@@ -4451,9 +4496,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/turn-context/node_modules/@agent-assistant/harness": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4480,7 +4538,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@hono/node-server": "^2.0.0",
@@ -4500,6 +4558,20 @@
         "@agent-assistant/harness": {
           "optional": true
         }
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/harness": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
+      "dev": true,
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
       }
     }
   }

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -30,6 +30,10 @@ It exists to fill the gap between a thin one-shot assistant runtime and an unbou
 npm install @agent-assistant/harness
 ```
 
+## Workspace VFS Tools
+
+`createWorkspaceToolRegistry` exposes provider-neutral `workspace_search`, `workspace_list`, `workspace_read`, and `workspace_read_json` tools for assistants that have a `VfsProvider` from `@agent-assistant/vfs`. The tools emit VFS paths, including `sourcePath`-style structured outputs for JSON reads, so callers can cite file paths in user-visible replies instead of answering workspace questions from memory.
+
 ## Quick Example
 
 ```ts

--- a/packages/harness/dist/index.d.ts
+++ b/packages/harness/dist/index.d.ts
@@ -5,6 +5,9 @@ export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/
 export type { OpenRouterModelAdapterConfig } from './adapter/openrouter-model-adapter.js';
 export { BashToolRegistry, createBashToolRegistry } from './tools/bash-tool-registry.js';
 export type { BashToolConfig } from './tools/bash-tool-registry.js';
+export { CITE_SOURCE_PATHS_CLAUSE, EMPTY_RESULT_HONESTY_CLAUSE, HALLUCINATION_PREVENTION_CLAUSES, SURFACE_TOOL_ERRORS_CLAUSE, } from './tools/prompt-fragments.js';
+export { createWorkspaceToolRegistry, WORKSPACE_LIST_TOOL_NAME, WORKSPACE_READ_JSON_TOOL_NAME, WORKSPACE_READ_TOOL_NAME, WORKSPACE_SEARCH_TOOL_NAME, WORKSPACE_TOOL_NAMES, } from './tools/workspace-tool-registry.js';
+export type { WorkspaceToolRegistryOptions } from './tools/workspace-tool-registry.js';
 export { OpenRouterSingleShotAdapter, createOpenRouterSingleShotAdapter } from './router/openrouter-singleshot-adapter.js';
 export type { OpenRouterSingleShotAdapterConfig } from './router/openrouter-singleshot-adapter.js';
 export { createTieredRunner } from './router/tiered-runner.js';

--- a/packages/harness/dist/index.js
+++ b/packages/harness/dist/index.js
@@ -3,5 +3,7 @@ export { HarnessConfigError } from './types.js';
 export * from './adapter/index.js';
 export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/openrouter-model-adapter.js';
 export { BashToolRegistry, createBashToolRegistry } from './tools/bash-tool-registry.js';
+export { CITE_SOURCE_PATHS_CLAUSE, EMPTY_RESULT_HONESTY_CLAUSE, HALLUCINATION_PREVENTION_CLAUSES, SURFACE_TOOL_ERRORS_CLAUSE, } from './tools/prompt-fragments.js';
+export { createWorkspaceToolRegistry, WORKSPACE_LIST_TOOL_NAME, WORKSPACE_READ_JSON_TOOL_NAME, WORKSPACE_READ_TOOL_NAME, WORKSPACE_SEARCH_TOOL_NAME, WORKSPACE_TOOL_NAMES, } from './tools/workspace-tool-registry.js';
 export { OpenRouterSingleShotAdapter, createOpenRouterSingleShotAdapter } from './router/openrouter-singleshot-adapter.js';
 export { createTieredRunner } from './router/tiered-runner.js';

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -39,6 +39,7 @@
     "@agent-assistant/coordination": "^0.2.6",
     "@agent-assistant/traits": "^0.2.0",
     "@agent-assistant/turn-context": "^0.2.0",
+    "@agent-assistant/vfs": "^0.2.23",
     "@agent-relay/sdk": "^4.0.22"
   },
   "devDependencies": {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -6,6 +6,21 @@ export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/
 export type { OpenRouterModelAdapterConfig } from './adapter/openrouter-model-adapter.js';
 export { BashToolRegistry, createBashToolRegistry } from './tools/bash-tool-registry.js';
 export type { BashToolConfig } from './tools/bash-tool-registry.js';
+export {
+  CITE_SOURCE_PATHS_CLAUSE,
+  EMPTY_RESULT_HONESTY_CLAUSE,
+  HALLUCINATION_PREVENTION_CLAUSES,
+  SURFACE_TOOL_ERRORS_CLAUSE,
+} from './tools/prompt-fragments.js';
+export {
+  createWorkspaceToolRegistry,
+  WORKSPACE_LIST_TOOL_NAME,
+  WORKSPACE_READ_JSON_TOOL_NAME,
+  WORKSPACE_READ_TOOL_NAME,
+  WORKSPACE_SEARCH_TOOL_NAME,
+  WORKSPACE_TOOL_NAMES,
+} from './tools/workspace-tool-registry.js';
+export type { WorkspaceToolRegistryOptions } from './tools/workspace-tool-registry.js';
 
 export { OpenRouterSingleShotAdapter, createOpenRouterSingleShotAdapter } from './router/openrouter-singleshot-adapter.js';
 export type { OpenRouterSingleShotAdapterConfig } from './router/openrouter-singleshot-adapter.js';

--- a/packages/harness/src/tools/prompt-fragments.test.ts
+++ b/packages/harness/src/tools/prompt-fragments.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CITE_SOURCE_PATHS_CLAUSE,
+  EMPTY_RESULT_HONESTY_CLAUSE,
+  HALLUCINATION_PREVENTION_CLAUSES,
+  SURFACE_TOOL_ERRORS_CLAUSE,
+} from './prompt-fragments.js';
+
+describe('hallucination-prevention prompt fragments', () => {
+  it('exports non-empty clauses in append-ready order', () => {
+    expect(HALLUCINATION_PREVENTION_CLAUSES).toEqual([
+      CITE_SOURCE_PATHS_CLAUSE,
+      EMPTY_RESULT_HONESTY_CLAUSE,
+      SURFACE_TOOL_ERRORS_CLAUSE,
+    ]);
+    expect(HALLUCINATION_PREVENTION_CLAUSES.every((clause) => clause.length > 0)).toBe(
+      true,
+    );
+  });
+
+  it('keeps the load-bearing source citation phrase', () => {
+    expect(CITE_SOURCE_PATHS_CLAUSE.toLowerCase()).toContain('cite');
+    expect(CITE_SOURCE_PATHS_CLAUSE).toContain('path');
+  });
+
+  it('keeps the load-bearing empty result phrase', () => {
+    expect(EMPTY_RESULT_HONESTY_CLAUSE.toLowerCase()).toContain('empty');
+    expect(EMPTY_RESULT_HONESTY_CLAUSE.toLowerCase()).toContain('not found');
+  });
+
+  it('keeps the load-bearing tool error phrase', () => {
+    expect(SURFACE_TOOL_ERRORS_CLAUSE.toLowerCase()).toContain('error');
+    expect(SURFACE_TOOL_ERRORS_CLAUSE.toLowerCase()).toContain('tool');
+  });
+});

--- a/packages/harness/src/tools/prompt-fragments.ts
+++ b/packages/harness/src/tools/prompt-fragments.ts
@@ -1,0 +1,14 @@
+export const CITE_SOURCE_PATHS_CLAUSE =
+  'For every factual claim about workspace data, cite the tool-returned VFS path or sourcePath that supports it. If a tool result has no path/sourcePath, say what tool result you used.';
+
+export const EMPTY_RESULT_HONESTY_CLAUSE =
+  'If a tool returns an empty array, null, or a "not found" message, do not substitute prior knowledge. Say exactly what could not be verified and name the path/query that returned no data.';
+
+export const SURFACE_TOOL_ERRORS_CLAUSE =
+  'If a tool returns an error, include the redacted tool name and error message in the answer instead of inventing a plausible result.';
+
+export const HALLUCINATION_PREVENTION_CLAUSES = [
+  CITE_SOURCE_PATHS_CLAUSE,
+  EMPTY_RESULT_HONESTY_CLAUSE,
+  SURFACE_TOOL_ERRORS_CLAUSE,
+] as const;

--- a/packages/harness/src/tools/workspace-tool-registry.test.ts
+++ b/packages/harness/src/tools/workspace-tool-registry.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { VfsEntry, VfsProvider, VfsReadResult, VfsSearchResult } from '@agent-assistant/vfs';
+import type {
+  HarnessToolAvailabilityInput,
+  HarnessToolCall,
+  HarnessToolExecutionContext,
+} from '../types.js';
+import { createWorkspaceToolRegistry } from './workspace-tool-registry.js';
+
+const AVAILABILITY_INPUT: HarnessToolAvailabilityInput = {
+  assistantId: 'assistant-1',
+  turnId: 'turn-1',
+  sessionId: 'session-1',
+  userId: 'user-1',
+};
+
+const EXECUTION_CONTEXT: HarnessToolExecutionContext = {
+  assistantId: 'assistant-1',
+  turnId: 'turn-1',
+  sessionId: 'session-1',
+  userId: 'user-1',
+  threadId: 'thread-1',
+  iteration: 0,
+  toolCallIndex: 0,
+};
+
+function makeProvider(overrides: Partial<VfsProvider> = {}): VfsProvider {
+  return {
+    search: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue([]),
+    read: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+function makeCall(name: string, input: Record<string, unknown>): HarnessToolCall {
+  return {
+    id: `${name}-call-1`,
+    name,
+    input,
+  };
+}
+
+function readResult(path: string, content: string): VfsReadResult {
+  return { path, content, provider: 'github' };
+}
+
+function parseOutputArray(result: { output?: string }): Array<Record<string, unknown>> {
+  expect(result.output).toEqual(expect.any(String));
+  return JSON.parse(result.output ?? 'null') as Array<Record<string, unknown>>;
+}
+
+describe('createWorkspaceToolRegistry listAvailable', () => {
+  it('returns exactly the four workspace tools when the provider is configured', async () => {
+    const provider = makeProvider();
+    const registry = createWorkspaceToolRegistry({ provider });
+
+    const tools = await registry.listAvailable(AVAILABILITY_INPUT);
+
+    expect(tools).toHaveLength(4);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'workspace_search',
+      'workspace_list',
+      'workspace_read',
+      'workspace_read_json',
+    ]);
+  });
+
+  it('returns no workspace tools when the provider is unavailable', async () => {
+    const registry = createWorkspaceToolRegistry({ provider: null });
+
+    const tools = await registry.listAvailable(AVAILABILITY_INPUT);
+
+    expect(tools).toEqual([]);
+  });
+});
+
+describe('createWorkspaceToolRegistry execute workspace_search', () => {
+  it('calls provider.search with query, provider, and limit then returns parseable JSON', async () => {
+    const searchResults: VfsSearchResult[] = [
+      {
+        path: '/github/repos/acme/widgets/src/index.ts',
+        type: 'file',
+        provider: 'github',
+        title: 'src/index.ts',
+        snippet: 'export function widget() {}',
+        revision: 'rev-1',
+        properties: {
+          score: '42',
+        },
+      },
+    ];
+    const provider = makeProvider({
+      search: vi.fn().mockResolvedValue(searchResults),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_search', {
+      query: 'widget',
+      provider: 'github',
+      limit: 7,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(provider.search).toHaveBeenCalledWith('widget', {
+      provider: 'github',
+      limit: 7,
+    });
+    expect(result.status).toBe('success');
+    const output = parseOutputArray(result);
+    expect(output[0]).toMatchObject({
+      path: searchResults[0]?.path,
+      provider: searchResults[0]?.provider,
+      score: 42,
+    });
+  });
+
+  it("returns invalid_input when query is missing and doesn't call provider.search", async () => {
+    const provider = makeProvider();
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_search', {
+      provider: 'github',
+      limit: 7,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'invalid_input',
+      retryable: false,
+    });
+    expect(provider.search).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWorkspaceToolRegistry execute workspace_list', () => {
+  it('calls provider.list with path, depth, and limit then returns parseable JSON', async () => {
+    const listEntries: VfsEntry[] = [
+      {
+        path: '/github/repos/acme/widgets/src',
+        type: 'dir',
+        provider: 'github',
+        title: 'src',
+        revision: 'rev-1',
+      },
+      {
+        path: '/github/repos/acme/widgets/src/index.ts',
+        type: 'file',
+        provider: 'github',
+        title: 'index.ts',
+        revision: 'rev-2',
+        size: 1234,
+      },
+    ];
+    const provider = makeProvider({
+      list: vi.fn().mockResolvedValue(listEntries),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_list', {
+      path: '/github/repos/acme/widgets',
+      depth: 2,
+      limit: 25,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(provider.list).toHaveBeenCalledWith('/github/repos/acme/widgets', {
+      depth: 2,
+      limit: 25,
+    });
+    expect(result.status).toBe('success');
+    expect(parseOutputArray(result)).toEqual([
+      expect.objectContaining({
+        path: listEntries[0]?.path,
+        provider: listEntries[0]?.provider,
+      }),
+      expect.objectContaining({
+        path: listEntries[1]?.path,
+        provider: listEntries[1]?.provider,
+      }),
+    ]);
+  });
+});
+
+describe('createWorkspaceToolRegistry execute workspace_read', () => {
+  it('returns file content when the path exists', async () => {
+    const fileContent = 'const answer = 42;\n';
+    const provider = makeProvider({
+      read: vi
+        .fn()
+        .mockResolvedValue(readResult('/github/repos/acme/widgets/src/index.ts', fileContent)),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read', {
+      path: '/github/repos/acme/widgets/src/index.ts',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(provider.read).toHaveBeenCalledWith('/github/repos/acme/widgets/src/index.ts');
+    expect(result.status).toBe('success');
+    expect(result.output).toBe(fileContent);
+  });
+
+  it('returns not_found when the provider returns null for the path', async () => {
+    const provider = makeProvider({
+      read: vi.fn().mockResolvedValue(null),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read', {
+      path: '/github/repos/acme/widgets/src/missing.ts',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(provider.read).toHaveBeenCalledWith('/github/repos/acme/widgets/src/missing.ts');
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'not_found',
+      retryable: false,
+    });
+  });
+});
+
+describe('createWorkspaceToolRegistry execute workspace_read_json', () => {
+  it('returns parsed JSON with the source path when the file exists', async () => {
+    const provider = makeProvider({
+      read: vi
+        .fn()
+        .mockResolvedValue(
+          readResult('/github/repos/acme/widgets/pulls/1/metadata.json', '{"title":"Widget","state":"open"}'),
+        ),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read_json', {
+      path: '/github/repos/acme/widgets/pulls/1/metadata.json',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(provider.read).toHaveBeenCalledWith('/github/repos/acme/widgets/pulls/1/metadata.json');
+    expect(result.status).toBe('success');
+    expect(JSON.parse(result.output ?? 'null')).toEqual({
+      path: '/github/repos/acme/widgets/pulls/1/metadata.json',
+      json: { title: 'Widget', state: 'open' },
+    });
+  });
+
+  it('returns invalid_json when the file content cannot be parsed', async () => {
+    const provider = makeProvider({
+      read: vi
+        .fn()
+        .mockResolvedValue(readResult('/github/repos/acme/widgets/pulls/1/metadata.json', '{')),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read_json', {
+      path: '/github/repos/acme/widgets/pulls/1/metadata.json',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'invalid_json',
+      retryable: false,
+    });
+  });
+});
+
+describe('createWorkspaceToolRegistry execute disabled and unknown tools', () => {
+  it.each([
+    ['workspace_search', { query: 'widget' }],
+    ['workspace_list', { path: '/github/repos/acme/widgets' }],
+    ['workspace_read', { path: '/github/repos/acme/widgets/src/index.ts' }],
+    ['workspace_read_json', { path: '/github/repos/acme/widgets/pulls/1/metadata.json' }],
+  ])('returns workspace_unavailable for %s when the provider is unavailable', async (name, input) => {
+    const registry = createWorkspaceToolRegistry({ provider: null });
+    const call = makeCall(name, input);
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'workspace_unavailable',
+      retryable: false,
+    });
+  });
+
+  it('returns unknown_tool for an unrecognized tool name', async () => {
+    const provider = makeProvider();
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_delete', {
+      path: '/github/repos/acme/widgets/src/index.ts',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'unknown_tool',
+      retryable: false,
+    });
+    expect(provider.read).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWorkspaceToolRegistry output truncation', () => {
+  it('truncates output larger than 50KB and includes a _truncated marker', async () => {
+    const largePreview = 'x'.repeat(2048);
+    const searchResults: VfsSearchResult[] = Array.from({ length: 40 }, (_, index) => ({
+      path: `/github/repos/acme/widgets/src/file-${index}.ts`,
+      type: 'file',
+      provider: 'github',
+      snippet: largePreview,
+      revision: `rev-${index}`,
+    }));
+    const provider = makeProvider({
+      search: vi.fn().mockResolvedValue(searchResults),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_search', {
+      query: 'widget',
+      provider: 'github',
+      limit: 40,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('success');
+    expect(result.output).toEqual(expect.any(String));
+    expect(new TextEncoder().encode(result.output ?? '').byteLength).toBeLessThanOrEqual(
+      50 * 1024,
+    );
+    expect(result.output).toContain('"_truncated": true');
+  });
+});

--- a/packages/harness/src/tools/workspace-tool-registry.test.ts
+++ b/packages/harness/src/tools/workspace-tool-registry.test.ts
@@ -203,7 +203,7 @@ describe('createWorkspaceToolRegistry execute workspace_read', () => {
     expect(result.output).toBe(fileContent);
   });
 
-  it('returns not_found when the provider returns null for the path', async () => {
+  it('returns retryable not_found when the provider returns null for the path', async () => {
     const provider = makeProvider({
       read: vi.fn().mockResolvedValue(null),
     });
@@ -218,8 +218,49 @@ describe('createWorkspaceToolRegistry execute workspace_read', () => {
     expect(result.status).toBe('error');
     expect(result.error).toMatchObject({
       code: 'not_found',
-      retryable: false,
+      retryable: true,
     });
+  });
+
+  it('truncates content larger than 50KB and emits a _truncated marker', async () => {
+    const largeContent = 'x'.repeat(60 * 1024);
+    const provider = makeProvider({
+      read: vi
+        .fn()
+        .mockResolvedValue(readResult('/github/repos/acme/widgets/src/big.ts', largeContent)),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read', {
+      path: '/github/repos/acme/widgets/src/big.ts',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('success');
+    expect(result.output).toEqual(expect.any(String));
+    expect(new TextEncoder().encode(result.output ?? '').byteLength).toBeLessThanOrEqual(
+      50 * 1024,
+    );
+    expect(result.output).not.toBe(largeContent);
+    expect(result.output).toContain('"_truncated": true');
+  });
+
+  it('returns raw content unchanged when the file is well under the 50KB cap', async () => {
+    const fileContent = 'tiny payload';
+    const provider = makeProvider({
+      read: vi
+        .fn()
+        .mockResolvedValue(readResult('/github/repos/acme/widgets/src/tiny.ts', fileContent)),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read', {
+      path: '/github/repos/acme/widgets/src/tiny.ts',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('success');
+    expect(result.output).toBe(fileContent);
   });
 });
 
@@ -244,6 +285,24 @@ describe('createWorkspaceToolRegistry execute workspace_read_json', () => {
     expect(JSON.parse(result.output ?? 'null')).toEqual({
       path: '/github/repos/acme/widgets/pulls/1/metadata.json',
       json: { title: 'Widget', state: 'open' },
+    });
+  });
+
+  it('returns retryable not_found when the provider returns null for the path', async () => {
+    const provider = makeProvider({
+      read: vi.fn().mockResolvedValue(null),
+    });
+    const registry = createWorkspaceToolRegistry({ provider });
+    const call = makeCall('workspace_read_json', {
+      path: '/github/repos/acme/widgets/pulls/999/metadata.json',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'not_found',
+      retryable: true,
     });
   });
 

--- a/packages/harness/src/tools/workspace-tool-registry.ts
+++ b/packages/harness/src/tools/workspace-tool-registry.ts
@@ -196,6 +196,16 @@ function stringifyObjectOutput(value: unknown): string {
   });
 }
 
+function truncateRawContent(content: string): string {
+  if (byteLength(content) <= MAX_OUTPUT_BYTES) {
+    return content;
+  }
+  return stringifyOutput({
+    _truncated: true,
+    message: 'Output exceeded 50KB; narrow the query or read a smaller file.',
+  });
+}
+
 function successResult(call: HarnessToolCall, output: string): HarnessToolResult {
   return {
     callId: call.id,
@@ -241,7 +251,11 @@ function invalidInputResult(call: HarnessToolCall, message: string): HarnessTool
 }
 
 function notFoundResult(call: HarnessToolCall, path: string): HarnessToolResult {
-  return errorResult(call, 'not_found', `Workspace file not found: ${path}`, false);
+  // Mark `not_found` as retryable so the model can recover by trying a
+  // different path. harness `runTurn` treats any tool error with
+  // `retryable !== true` as `tool_error_unrecoverable` and ends the turn —
+  // a routine missing-file lookup should not be terminal.
+  return errorResult(call, 'not_found', `Workspace file not found: ${path}`, true);
 }
 
 function thrownErrorResult(call: HarnessToolCall, error: unknown): HarnessToolResult {
@@ -522,7 +536,7 @@ export function createWorkspaceToolRegistry(
           return successResult(call, stringifyObjectOutput(output));
         }
 
-        return successResult(call, result.content);
+        return successResult(call, truncateRawContent(result.content));
       } catch (error) {
         return thrownErrorResult(call, error);
       }

--- a/packages/harness/src/tools/workspace-tool-registry.ts
+++ b/packages/harness/src/tools/workspace-tool-registry.ts
@@ -1,0 +1,531 @@
+import type { VfsEntry, VfsProvider, VfsSearchResult } from '@agent-assistant/vfs';
+import type {
+  HarnessToolCall,
+  HarnessToolDefinition,
+  HarnessToolRegistry,
+  HarnessToolResult,
+} from '../types.js';
+
+export interface WorkspaceToolRegistryOptions {
+  provider?: VfsProvider | null;
+  defaultSearchLimit?: number;
+  maxListDepth?: number;
+}
+
+type WorkspaceProvider = 'github' | 'slack' | 'notion' | 'linear';
+
+interface WorkspaceSearchOutput {
+  path: string;
+  provider: string;
+  score?: number;
+  preview?: string;
+}
+
+interface WorkspaceReadJsonOutput {
+  path: string;
+  json: unknown;
+}
+
+interface ValidationSuccess<T> {
+  ok: true;
+  value: T;
+}
+
+interface ValidationFailure {
+  ok: false;
+  message: string;
+}
+
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+const DEFAULT_SEARCH_LIMIT = 20;
+const DEFAULT_LIST_LIMIT = 50;
+const DEFAULT_MAX_LIST_DEPTH = 3;
+const MAX_SEARCH_LIMIT = 100;
+const MAX_LIST_LIMIT = 200;
+const MAX_SCHEMA_LIST_DEPTH = 5;
+const MAX_OUTPUT_BYTES = 50 * 1024;
+
+const WORKSPACE_PROVIDERS = ['github', 'slack', 'notion', 'linear'] as const;
+
+export const WORKSPACE_SEARCH_TOOL_NAME = 'workspace_search';
+export const WORKSPACE_LIST_TOOL_NAME = 'workspace_list';
+export const WORKSPACE_READ_TOOL_NAME = 'workspace_read';
+export const WORKSPACE_READ_JSON_TOOL_NAME = 'workspace_read_json';
+export const WORKSPACE_TOOL_NAMES = [
+  WORKSPACE_SEARCH_TOOL_NAME,
+  WORKSPACE_LIST_TOOL_NAME,
+  WORKSPACE_READ_TOOL_NAME,
+  WORKSPACE_READ_JSON_TOOL_NAME,
+] as const;
+
+const WORKSPACE_SEARCH_TOOL: HarnessToolDefinition = {
+  name: WORKSPACE_SEARCH_TOOL_NAME,
+  description:
+    'Search the workspace VFS across all providers (github, slack, notion, linear). Use for enumeration and keyword queries.',
+  inputSchema: {
+    type: 'object',
+    required: ['query'],
+    properties: {
+      query: { type: 'string', minLength: 1 },
+      provider: { type: 'string', enum: WORKSPACE_PROVIDERS },
+      limit: { type: 'number', minimum: 1, maximum: MAX_SEARCH_LIMIT },
+    },
+  },
+};
+
+const WORKSPACE_LIST_TOOL: HarnessToolDefinition = {
+  name: WORKSPACE_LIST_TOOL_NAME,
+  description:
+    'List entries under a VFS path. Use to browse provider namespaces (e.g. /github, /linear/issues).',
+  inputSchema: {
+    type: 'object',
+    required: ['path'],
+    properties: {
+      path: { type: 'string', minLength: 1 },
+      depth: { type: 'number', minimum: 1, maximum: MAX_SCHEMA_LIST_DEPTH },
+      limit: { type: 'number', minimum: 1, maximum: MAX_LIST_LIMIT },
+    },
+  },
+};
+
+const WORKSPACE_READ_TOOL: HarnessToolDefinition = {
+  name: WORKSPACE_READ_TOOL_NAME,
+  description: 'Read a single file from the VFS by full path.',
+  inputSchema: {
+    type: 'object',
+    required: ['path'],
+    properties: {
+      path: { type: 'string', minLength: 1 },
+    },
+  },
+};
+
+const WORKSPACE_READ_JSON_TOOL: HarnessToolDefinition = {
+  name: WORKSPACE_READ_JSON_TOOL_NAME,
+  description:
+    'Read one JSON file from the workspace VFS by full path and return parsed JSON with its source path. Use when factual claims need exact structured data and cite the returned path.',
+  inputSchema: {
+    type: 'object',
+    required: ['path'],
+    properties: {
+      path: { type: 'string', minLength: 1 },
+    },
+  },
+};
+
+const WORKSPACE_TOOLS = [
+  WORKSPACE_SEARCH_TOOL,
+  WORKSPACE_LIST_TOOL,
+  WORKSPACE_READ_TOOL,
+  WORKSPACE_READ_JSON_TOOL,
+] satisfies HarnessToolDefinition[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isWorkspaceProvider(value: unknown): value is WorkspaceProvider {
+  return (
+    typeof value === 'string' &&
+    (WORKSPACE_PROVIDERS as readonly string[]).includes(value)
+  );
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+function normalizeOption(value: number | undefined, fallback: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.min(max, Math.floor(value));
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function stringifyOutput(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function stringifyArrayOutput(items: readonly unknown[]): string {
+  const fullOutput = stringifyOutput(items);
+  if (byteLength(fullOutput) <= MAX_OUTPUT_BYTES) {
+    return fullOutput;
+  }
+
+  const truncatedItems = [...items];
+  while (truncatedItems.length > 0) {
+    const omitted = items.length - truncatedItems.length;
+    const candidate = stringifyOutput([
+      ...truncatedItems,
+      {
+        _truncated: true,
+        omitted,
+        message: 'Output exceeded 50KB; narrow the query or lower the limit.',
+      },
+    ]);
+
+    if (byteLength(candidate) <= MAX_OUTPUT_BYTES) {
+      return candidate;
+    }
+
+    truncatedItems.pop();
+  }
+
+  return stringifyOutput([
+    {
+      _truncated: true,
+      omitted: items.length,
+      message: 'Output exceeded 50KB; narrow the query or lower the limit.',
+    },
+  ]);
+}
+
+function stringifyObjectOutput(value: unknown): string {
+  const fullOutput = stringifyOutput(value);
+  if (byteLength(fullOutput) <= MAX_OUTPUT_BYTES) {
+    return fullOutput;
+  }
+  return stringifyOutput({
+    _truncated: true,
+    message: 'Output exceeded 50KB; narrow the query or lower the limit.',
+  });
+}
+
+function successResult(call: HarnessToolCall, output: string): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'success',
+    output,
+  };
+}
+
+function errorResult(
+  call: HarnessToolCall,
+  code: string,
+  message: string,
+  retryable: boolean,
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'error',
+    error: {
+      code,
+      message,
+      retryable,
+    },
+  };
+}
+
+function workspaceUnavailableResult(call: HarnessToolCall): HarnessToolResult {
+  return errorResult(
+    call,
+    'workspace_unavailable',
+    'Workspace VFS not configured',
+    false,
+  );
+}
+
+function unknownToolResult(call: HarnessToolCall): HarnessToolResult {
+  return errorResult(call, 'unknown_tool', `Unknown tool: ${call.name}`, false);
+}
+
+function invalidInputResult(call: HarnessToolCall, message: string): HarnessToolResult {
+  return errorResult(call, 'invalid_input', message, false);
+}
+
+function notFoundResult(call: HarnessToolCall, path: string): HarnessToolResult {
+  return errorResult(call, 'not_found', `Workspace file not found: ${path}`, false);
+}
+
+function thrownErrorResult(call: HarnessToolCall, error: unknown): HarnessToolResult {
+  return errorResult(call, 'tool_error', toErrorMessage(error), true);
+}
+
+function readRequiredString(
+  input: Record<string, unknown>,
+  key: string,
+): ValidationResult<string> {
+  const value = input[key];
+  if (typeof value !== 'string' || value.trim().length < 1) {
+    return { ok: false, message: `input.${key} must be a non-empty string` };
+  }
+  return { ok: true, value };
+}
+
+function readOptionalInteger(
+  input: Record<string, unknown>,
+  key: string,
+  fallback: number,
+  min: number,
+  max: number,
+): ValidationResult<number> {
+  const value = input[key];
+  if (value === undefined) {
+    return { ok: true, value: fallback };
+  }
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < min ||
+    value > max
+  ) {
+    return {
+      ok: false,
+      message: `input.${key} must be an integer between ${min} and ${max}`,
+    };
+  }
+  return { ok: true, value };
+}
+
+function validateSearchInput(
+  input: unknown,
+  defaultSearchLimit: number,
+): ValidationResult<{
+  query: string;
+  provider?: WorkspaceProvider;
+  limit: number;
+}> {
+  if (!isRecord(input)) {
+    return { ok: false, message: 'input must be an object' };
+  }
+
+  const query = readRequiredString(input, 'query');
+  if (!query.ok) {
+    return query;
+  }
+
+  if (input.provider !== undefined && !isWorkspaceProvider(input.provider)) {
+    return {
+      ok: false,
+      message: 'input.provider must be one of: github, slack, notion, linear',
+    };
+  }
+
+  const limit = readOptionalInteger(
+    input,
+    'limit',
+    defaultSearchLimit,
+    1,
+    MAX_SEARCH_LIMIT,
+  );
+  if (!limit.ok) {
+    return limit;
+  }
+
+  return {
+    ok: true,
+    value: {
+      query: query.value,
+      ...(input.provider ? { provider: input.provider } : {}),
+      limit: limit.value,
+    },
+  };
+}
+
+function validateListInput(
+  input: unknown,
+): ValidationResult<{
+  path: string;
+  depth: number;
+  limit: number;
+}> {
+  if (!isRecord(input)) {
+    return { ok: false, message: 'input must be an object' };
+  }
+
+  const path = readRequiredString(input, 'path');
+  if (!path.ok) {
+    return path;
+  }
+
+  const depth = readOptionalInteger(input, 'depth', 1, 1, MAX_SCHEMA_LIST_DEPTH);
+  if (!depth.ok) {
+    return depth;
+  }
+
+  const limit = readOptionalInteger(input, 'limit', DEFAULT_LIST_LIMIT, 1, MAX_LIST_LIMIT);
+  if (!limit.ok) {
+    return limit;
+  }
+
+  return {
+    ok: true,
+    value: {
+      path: path.value,
+      depth: depth.value,
+      limit: limit.value,
+    },
+  };
+}
+
+function validateReadInput(input: unknown): ValidationResult<{ path: string }> {
+  if (!isRecord(input)) {
+    return { ok: false, message: 'input must be an object' };
+  }
+
+  const path = readRequiredString(input, 'path');
+  if (!path.ok) {
+    return path;
+  }
+
+  return { ok: true, value: { path: path.value } };
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function readScore(result: VfsSearchResult): number | undefined {
+  const rawScore = result.properties?.score;
+  if (rawScore === undefined) {
+    return undefined;
+  }
+
+  const score = Number(rawScore);
+  return Number.isFinite(score) ? score : undefined;
+}
+
+function mapSearchResult(result: VfsSearchResult): WorkspaceSearchOutput {
+  const score = readScore(result);
+  const preview = result.snippet ?? result.title;
+  return {
+    path: result.path,
+    provider: result.provider ?? 'unknown',
+    ...(score !== undefined ? { score } : {}),
+    ...(preview ? { preview } : {}),
+  };
+}
+
+function listOutputEntry(entry: VfsEntry): Record<string, unknown> {
+  return {
+    path: entry.path,
+    type: entry.type,
+    ...(entry.provider ? { provider: entry.provider } : {}),
+    ...(entry.title ? { title: entry.title } : {}),
+    ...(entry.revision ? { revision: entry.revision } : {}),
+    ...(entry.updatedAt ? { updatedAt: entry.updatedAt } : {}),
+    ...(entry.size !== undefined ? { size: entry.size } : {}),
+  };
+}
+
+function knownToolName(name: string): boolean {
+  return WORKSPACE_TOOLS.some((tool) => tool.name === name);
+}
+
+export function createWorkspaceToolRegistry(
+  options: WorkspaceToolRegistryOptions,
+): HarnessToolRegistry {
+  const defaultSearchLimit = normalizeOption(
+    options.defaultSearchLimit,
+    DEFAULT_SEARCH_LIMIT,
+    MAX_SEARCH_LIMIT,
+  );
+  const maxListDepth = normalizeOption(
+    options.maxListDepth,
+    DEFAULT_MAX_LIST_DEPTH,
+    MAX_SCHEMA_LIST_DEPTH,
+  );
+
+  return {
+    async listAvailable(input) {
+      if (!options.provider) {
+        return [];
+      }
+
+      if (!input.allowedToolNames || input.allowedToolNames.length === 0) {
+        return [...WORKSPACE_TOOLS];
+      }
+
+      const allowedToolNames = new Set(input.allowedToolNames);
+      return WORKSPACE_TOOLS.filter((tool) => allowedToolNames.has(tool.name));
+    },
+
+    async execute(call) {
+      if (!knownToolName(call.name)) {
+        return unknownToolResult(call);
+      }
+
+      const provider = options.provider;
+      if (!provider) {
+        return workspaceUnavailableResult(call);
+      }
+
+      try {
+        if (call.name === WORKSPACE_SEARCH_TOOL_NAME) {
+          const validation = validateSearchInput(call.input, defaultSearchLimit);
+          if (!validation.ok) {
+            return invalidInputResult(call, validation.message);
+          }
+
+          const results = await provider.search(validation.value.query, {
+            ...(validation.value.provider ? { provider: validation.value.provider } : {}),
+            limit: validation.value.limit,
+          });
+          return successResult(
+            call,
+            stringifyArrayOutput(results.map((result) => mapSearchResult(result))),
+          );
+        }
+
+        if (call.name === WORKSPACE_LIST_TOOL_NAME) {
+          const validation = validateListInput(call.input);
+          if (!validation.ok) {
+            return invalidInputResult(call, validation.message);
+          }
+
+          const entries = await provider.list(validation.value.path, {
+            depth: Math.min(validation.value.depth, maxListDepth),
+            limit: validation.value.limit,
+          });
+          return successResult(
+            call,
+            stringifyArrayOutput(entries.map((entry) => listOutputEntry(entry))),
+          );
+        }
+
+        const validation = validateReadInput(call.input);
+        if (!validation.ok) {
+          return invalidInputResult(call, validation.message);
+        }
+
+        const result = await provider.read(validation.value.path);
+        if (result === null) {
+          return notFoundResult(call, validation.value.path);
+        }
+
+        if (call.name === WORKSPACE_READ_JSON_TOOL_NAME) {
+          const parsed = parseJson(result.content);
+          if (parsed === undefined) {
+            return errorResult(
+              call,
+              'invalid_json',
+              `Workspace file is not valid JSON: ${validation.value.path}`,
+              false,
+            );
+          }
+          const output: WorkspaceReadJsonOutput = {
+            path: validation.value.path,
+            json: parsed,
+          };
+          return successResult(call, stringifyObjectOutput(output));
+        }
+
+        return successResult(call, result.content);
+      } catch (error) {
+        return thrownErrorResult(call, error);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extracts generic VFS tooling from [sage#117](https://github.com/AgentWorkforce/sage/pull/117) into `@agent-assistant/harness` so any consumer with a `VfsProvider` gets the same surface.
- `createWorkspaceToolRegistry` exposes `workspace_search` / `workspace_list` / `workspace_read` / `workspace_read_json` over any `VfsProvider` from `@agent-assistant/vfs`. Emits `sourcePath` fields so callers can cite file paths in user-visible replies.
- `HALLUCINATION_PREVENTION_CLAUSES` + individual clause constants (`CITE_SOURCE_PATHS_CLAUSE`, `EMPTY_RESULT_HONESTY_CLAUSE`, `SURFACE_TOOL_ERRORS_CLAUSE`) for reuse in harness tool-instructions.

## Rationale
Per project convention, harness adapters / tool registries / prompt fragments live in `@agent-assistant/*` and sage consumes via semver. Sage#117 landed these locally to fix a production outage; this PR extracts the generic parts. Provider-specific GitHub helpers land in a follow-up PR (`@agent-assistant/github-vfs`). Sage then replaces its local copies with semver deps.

## Changes
- `packages/harness/src/tools/workspace-tool-registry.ts` (+ test)
- `packages/harness/src/tools/prompt-fragments.ts` (+ test)
- `packages/harness/src/index.ts` — export the new surfaces
- `packages/harness/package.json` — bump `0.4.2 → 0.5.0` (additive), add `@agent-assistant/vfs` workspace dep
- `packages/harness/README.md` — brief doc note

## Test plan
- [x] `npm run build -w @agent-assistant/harness`
- [x] `npm test -w @agent-assistant/harness` — 141 passed (15 new workspace-tool-registry, 4 new prompt-fragments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
