### PR TITLE
feat(harness): ship using-relayfile-vfs skill as importable string

### DIFF
--- a/.agents/skills/using-relayfile-vfs/SKILL.md
+++ b/.agents/skills/using-relayfile-vfs/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: using-relayfile-vfs
+description: Use when the assistant has a workspace VFS (via @agent-assistant/harness workspace_* tools) backed by RelayFile. Covers path conventions per provider and the cite-your-source discipline. Provider-specific rows are populated at runtime from /_conventions/*.json written by cataloging agents; hand-written rows below are the fallback.
+---
+
+## When to use
+
+The assistant has `workspace_list`, `workspace_read`, `workspace_read_json`, and
+`workspace_search` tools available, backed by a RelayFile VFS that's been synced
+by cataloging agents. Prefer these generic tools to any provider-specific
+API when the answer is a lookup from synced state.
+
+## Rules
+
+- Every factual claim about workspace data must cite the VFS path or
+  `sourcePath` returned by a tool. No path, no claim.
+- Empty result is an empty result. If `workspace_list` or
+  `workspace_read_json` returns nothing for path X, don't substitute
+  prior knowledge — say X returned no data and stop.
+- Tool errors surface verbatim (with tool name), not rephrased into a
+  plausible answer.
+
+## Path conventions
+
+### GitHub (`/github/...`)
+
+| Shape | Example | Contents |
+|---|---|---|
+| `/github/repos/{owner}/{repo}/metadata.json` | repo | repo metadata |
+| `/github/repos/{owner}/{repo}/pulls/{n}/metadata.json` | PR | PR metadata incl. `state: open\|closed` |
+| `/github/repos/{owner}/{repo}/issues/{n}/metadata.json` | issue | issue metadata |
+| `/github/repos/{owner}/{repo}/commits/{sha}/metadata.json` | commit | commit metadata |
+
+Worked example — list open PRs in `{owner}/{repo}`:
+1. `workspace_list('/github/repos/{owner}/{repo}/pulls', depth=2)`
+2. For each returned `metadata.json` path, `workspace_read_json(path)`
+3. Filter where `json.state === 'open'`
+4. Sort by `json.updated_at` descending
+
+Cite each `metadata.json` path in the reply.
+
+### Other providers
+
+Provider conventions published to `/_conventions/<provider>.json` by their
+cataloging agents. Assistant runtimes should list `/_conventions` at turn
+start and fold those rows into this skill. Stubs:
+
+- `slack`: TBD (populated by `cataloging-agent-slack`)
+- `linear`: TBD (populated by `cataloging-agent-linear`)
+- `notion`: TBD (populated by `cataloging-agent-notion`)
+- `teams`: TBD (populated by `cataloging-agent-teams`)
+- `gitlab`: TBD (populated by `cataloging-agent-gitlab`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,6 +246,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3463,7 +3464,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3475,7 +3476,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -3484,9 +3485,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/continuation/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3500,7 +3514,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3520,7 +3534,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3537,7 +3551,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4325,7 +4339,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4337,7 +4351,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4349,7 +4363,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.23",
+      "version": "0.2.25",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4371,7 +4385,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4388,7 +4402,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4396,7 +4410,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.3.10",
+      "version": "0.3.12",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4410,7 +4424,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.23",
+      "version": "0.2.25",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4418,7 +4432,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -4428,9 +4442,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/telemetry/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4439,7 +4466,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.23",
+      "version": "0.2.25",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0",
@@ -4451,9 +4478,22 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/turn-context/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.22",
+      "version": "0.2.24",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4480,7 +4520,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@hono/node-server": "^2.0.0",
@@ -4500,6 +4540,20 @@
         "@agent-assistant/harness": {
           "optional": true
         }
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dev": true,
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
       }
     }
   }

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,4 +1,5 @@
 export { createHarness } from './harness.js';
+export { USING_RELAYFILE_VFS_SKILL } from './skills/using-relayfile-vfs.js';
 export { HarnessConfigError } from './types.js';
 export * from './adapter/index.js';
 

--- a/packages/harness/src/skills/using-relayfile-vfs.test.ts
+++ b/packages/harness/src/skills/using-relayfile-vfs.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { USING_RELAYFILE_VFS_SKILL } from './using-relayfile-vfs.js';
+
+describe('USING_RELAYFILE_VFS_SKILL', () => {
+  it('is a non-empty string', () => {
+    expect(typeof USING_RELAYFILE_VFS_SKILL).toBe('string');
+    expect(USING_RELAYFILE_VFS_SKILL.length).toBeGreaterThan(0);
+  });
+
+  it('contains the load-bearing phrases', () => {
+    expect(USING_RELAYFILE_VFS_SKILL).toContain('workspace_list');
+    expect(USING_RELAYFILE_VFS_SKILL).toContain('/github/repos');
+    expect(USING_RELAYFILE_VFS_SKILL).toContain('cite');
+    expect(USING_RELAYFILE_VFS_SKILL).toContain('/_conventions/');
+  });
+});

--- a/packages/harness/src/skills/using-relayfile-vfs.ts
+++ b/packages/harness/src/skills/using-relayfile-vfs.ts
@@ -1,0 +1,55 @@
+// Content is authored in .agents/skills/using-relayfile-vfs/SKILL.md.
+// This file is the runtime-importable mirror so harness consumers can
+// inject the skill into their system prompt without repo access.
+//
+// TODO: wire a build-time mirror that reads SKILL.md directly so this
+// constant cannot drift from the markdown source.
+
+export const USING_RELAYFILE_VFS_SKILL = `## When to use
+
+The assistant has \`workspace_list\`, \`workspace_read\`, \`workspace_read_json\`, and
+\`workspace_search\` tools available, backed by a RelayFile VFS that's been synced
+by cataloging agents. Prefer these generic tools to any provider-specific
+API when the answer is a lookup from synced state.
+
+## Rules
+
+- Every factual claim about workspace data must cite the VFS path or
+  \`sourcePath\` returned by a tool. No path, no claim.
+- Empty result is an empty result. If \`workspace_list\` or
+  \`workspace_read_json\` returns nothing for path X, don't substitute
+  prior knowledge — say X returned no data and stop.
+- Tool errors surface verbatim (with tool name), not rephrased into a
+  plausible answer.
+
+## Path conventions
+
+### GitHub (\`/github/...\`)
+
+| Shape | Example | Contents |
+|---|---|---|
+| \`/github/repos/{owner}/{repo}/metadata.json\` | repo | repo metadata |
+| \`/github/repos/{owner}/{repo}/pulls/{n}/metadata.json\` | PR | PR metadata incl. \`state: open\\|closed\` |
+| \`/github/repos/{owner}/{repo}/issues/{n}/metadata.json\` | issue | issue metadata |
+| \`/github/repos/{owner}/{repo}/commits/{sha}/metadata.json\` | commit | commit metadata |
+
+Worked example — list open PRs in \`{owner}/{repo}\`:
+1. \`workspace_list('/github/repos/{owner}/{repo}/pulls', depth=2)\`
+2. For each returned \`metadata.json\` path, \`workspace_read_json(path)\`
+3. Filter where \`json.state === 'open'\`
+4. Sort by \`json.updated_at\` descending
+
+Cite each \`metadata.json\` path in the reply.
+
+### Other providers
+
+Provider conventions published to \`/_conventions/<provider>.json\` by their
+cataloging agents. Assistant runtimes should list \`/_conventions\` at turn
+start and fold those rows into this skill. Stubs:
+
+- \`slack\`: TBD (populated by \`cataloging-agent-slack\`)
+- \`linear\`: TBD (populated by \`cataloging-agent-linear\`)
+- \`notion\`: TBD (populated by \`cataloging-agent-notion\`)
+- \`teams\`: TBD (populated by \`cataloging-agent-teams\`)
+- \`gitlab\`: TBD (populated by \`cataloging-agent-gitlab\`)
+`;


### PR DESCRIPTION
## Summary
- Adds `.agents/skills/using-relayfile-vfs/SKILL.md` documenting the RelayFile VFS path conventions (GitHub rows authoritative; slack/linear/notion/teams/gitlab stubbed) and the cite-your-source discipline.
- Mirrors the SKILL.md body (without frontmatter) as `USING_RELAYFILE_VFS_SKILL`, exported from `@agent-assistant/harness` so downstream consumers can inject the skill into their system prompt without repo access.
- Bumps `@agent-assistant/harness` 0.4.3 -> 0.5.0.

Background: post-#52 plan — instead of per-provider VFS packages, we ship one always-current skill and let cataloging agents publish convention fragments to `/_conventions/<provider>.json`. The hand-written GitHub rows here are the fallback.

## Test plan
- [x] `npm run build -w @agent-assistant/harness` — green
- [x] `npx vitest run src/skills/using-relayfile-vfs.test.ts` — 2 tests passing (non-empty + load-bearing phrases: `workspace_list`, `/github/repos`, `cite`, `/_conventions/`)
- [x] Full harness suite: 116/116 unit tests pass; one pre-existing failure in `src/adapter/proof/byoh-local-proof.test.ts` due to `@agent-assistant/connectivity` resolution — confirmed identical failure on `origin/main` without these changes, so it is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
