### PR TITLE
chore(webhook-runtime): harden for multi-persona reuse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "workspaces": [
         "packages/traits",
         "packages/core",
+        "packages/vfs",
         "packages/harness",
         "packages/memory",
         "packages/inbox",
@@ -17,7 +18,6 @@
         "packages/turn-context",
         "packages/sessions",
         "packages/surfaces",
-        "packages/vfs",
         "packages/routing",
         "packages/connectivity",
         "packages/coordination",
@@ -3464,7 +3464,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3476,7 +3476,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -3486,9 +3486,9 @@
       }
     },
     "packages/continuation/node_modules/@agent-assistant/harness": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
-      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3500,7 +3500,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3512,9 +3512,18 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/coordination/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3547,7 +3556,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3563,9 +3572,81 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/harness/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/harness/node_modules/@agent-assistant/turn-context": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/turn-context/-/turn-context-0.2.25.tgz",
+      "integrity": "sha512-+OrCZgTYrtXQu+UG/9PiYrsdyoZ6naJDWQRAt2QCN/fVW+ag3Gs2WUKjT5W/zjukQ4VrR4rhQAx8ASNwX4bR4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/harness": "^0.4.0",
+        "@agent-assistant/memory": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4353,7 +4434,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4365,7 +4446,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4377,7 +4458,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.25",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4399,7 +4480,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4416,7 +4497,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4424,7 +4505,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.3.12",
+      "version": "0.4.0",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4436,9 +4517,34 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/specialists/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/specialists/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/specialists/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.25",
+      "version": "0.3.0",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4446,7 +4552,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.1.13",
+      "version": "0.2.0",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -4457,9 +4563,9 @@
       }
     },
     "packages/telemetry/node_modules/@agent-assistant/harness": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
-      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -4471,7 +4577,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4480,7 +4586,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.25",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0",
@@ -4493,9 +4599,9 @@
       }
     },
     "packages/turn-context/node_modules/@agent-assistant/harness": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
-      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -4505,9 +4611,24 @@
         "@agent-relay/sdk": "^4.0.22"
       }
     },
+    "packages/turn-context/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4534,9 +4655,10 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.1.7",
+      "version": "0.2.1",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
+        "@agent-assistant/surfaces": "^0.2.25",
         "@hono/node-server": "^2.0.0",
         "hono": "^4"
       },
@@ -4556,10 +4678,29 @@
         }
       }
     },
+    "packages/webhook-runtime/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
     "packages/webhook-runtime/node_modules/@agent-assistant/harness": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
-      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.2.tgz",
+      "integrity": "sha512-aqzdJ/4fxscRba6Er0GRFOzqmb/QLDa5LBiY4icgBVlvMHKk7T8e371MNAr/nieNbuGJ6/yX06DRYizJiMRA0w==",
       "dev": true,
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -4569,6 +4710,28 @@
         "@agent-assistant/turn-context": "^0.2.0",
         "@agent-relay/sdk": "^4.0.22"
       }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/specialists": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/specialists/-/specialists-0.3.12.tgz",
+      "integrity": "sha512-fkra1GvuAvI8n2aHLvV/bnbrS7w5UAAeUW8hoSDOn6lil4ToWzoMSTp2oeEvplicYSibQkVrbvKkFQPGddYLrw==",
+      "dependencies": {
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/vfs": "^0.2.6",
+        "@relayfile/adapter-github": "^0.1.6",
+        "@relayfile/adapter-linear": "^0.1.7"
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/surfaces": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/surfaces/-/surfaces-0.2.25.tgz",
+      "integrity": "sha512-Kvi05Hkee2eiteSOCAakOynprV+ADksD9fsRWZuKpyy/BKi/A/LJRWX9NhgjvgBdu5EsITp2MluueQLTirLJ7A=="
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4658,7 +4657,7 @@
       "version": "0.2.1",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
-        "@agent-assistant/surfaces": "^0.2.25",
+        "@agent-assistant/surfaces": "^0.3.0",
         "@hono/node-server": "^2.0.0",
         "hono": "^4"
       },
@@ -4721,11 +4720,6 @@
         "@relayfile/adapter-github": "^0.1.6",
         "@relayfile/adapter-linear": "^0.1.7"
       }
-    },
-    "packages/webhook-runtime/node_modules/@agent-assistant/surfaces": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/surfaces/-/surfaces-0.2.25.tgz",
-      "integrity": "sha512-Kvi05Hkee2eiteSOCAakOynprV+ADksD9fsRWZuKpyy/BKi/A/LJRWX9NhgjvgBdu5EsITp2MluueQLTirLJ7A=="
     },
     "packages/webhook-runtime/node_modules/@agent-assistant/vfs": {
       "version": "0.2.24",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "workspaces": [
     "packages/traits",
     "packages/core",
+    "packages/vfs",
     "packages/harness",
     "packages/memory",
     "packages/inbox",
@@ -12,7 +13,6 @@
     "packages/turn-context",
     "packages/sessions",
     "packages/surfaces",
-    "packages/vfs",
     "packages/routing",
     "packages/connectivity",
     "packages/coordination",

--- a/packages/webhook-runtime/README.md
+++ b/packages/webhook-runtime/README.md
@@ -6,6 +6,54 @@ local or HTTP consumers, and fanning events out consistently.
 This package removes duplicated webhook plumbing that sage / nightcto /
 my-senior-dev all hand-roll today.
 
+## Persona contract (cf-runtime)
+
+Every persona package that targets the Cloudflare runtime exports two functions
+per ingress surface:
+
+```ts
+// Ingress side: signature verify + parse + persona-side policy
+// (rate-limit, thread-gate, etc.). Returns a turn descriptor that is safe to
+// enqueue, or an "ack-only" sentinel.
+export function parseSlackWebhook(
+  req: Request,
+  env: PersonaBindings,
+): Promise<PersonaTurnDescriptor | PersonaAckResponse>;
+
+// Consumer side: runs the harness work synchronously relative to the queue
+// handler. Any internal ctx.waitUntil is for legitimately out-of-band telemetry
+// only; the turn itself is awaited.
+export function runPersonaTurn(
+  descriptor: PersonaTurnDescriptor,
+  env: PersonaBindings,
+  ctx: ExecutionContext,
+): Promise<void>;
+```
+
+Why this shape, matching `cloud/workflows/cf-runtime/SPEC.md` invariant 6:
+
+- Dedup is owned by the cf-runtime ingress wrapper, once per delivery. Personas
+  must not re-implement Slack/GitHub event dedup. A descriptor that arrives at
+  `runPersonaTurn` is deduped by construction. Use `SlackEventDedupGate`
+  (re-exported here from `@agent-assistant/surfaces`) as the canonical
+  primitive, with your own KV-backed `SlackEventDedupStore`.
+- Signature verification stays inside `parseSlackWebhook` because the persona
+  owns the per-workspace signing-secret lookup.
+- `runPersonaTurn` must not orphan promises past return. The fake
+  `ExecutionContext` provided by cf-runtime collects `waitUntil` promises and
+  awaits them before the consumer returns, which fixes the Slack-silence bug.
+
+The first concrete example is sage's W0 split: `parseSlackWebhook` plus
+`runSageTurn` shipped in `@agentworkforce/sage@1.5.0`. New personas
+(`nightcto`, `my-senior-dev`) follow the same pattern.
+
+Do not wire personas via `registerSlackSpecialistConsumer` from
+`./specialist-bridge` in the cf-runtime architecture. That bridge runs the
+specialist call synchronously inside the webhook fanout, which is the
+orphaned-promise pattern the cf-runtime is designed to remove. Enqueue a
+`specialist_call` queue message and resume on a
+`specialist_result:<turnId>` trigger instead.
+
 ## Interactive CLI
 
 The fastest way to exercise the runtime end-to-end is the REPL at

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -35,7 +35,7 @@
     "example:sim": "tsx examples/slack-to-github-sim.ts"
   },
   "dependencies": {
-    "@agent-assistant/surfaces": "^0.2.25",
+    "@agent-assistant/surfaces": "^0.3.0",
     "@agent-assistant/specialists": "^0.3.5",
     "@hono/node-server": "^2.0.0",
     "hono": "^4"

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/webhook-runtime",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,6 +35,7 @@
     "example:sim": "tsx examples/slack-to-github-sim.ts"
   },
   "dependencies": {
+    "@agent-assistant/surfaces": "^0.2.25",
     "@agent-assistant/specialists": "^0.3.5",
     "@hono/node-server": "^2.0.0",
     "hono": "^4"

--- a/packages/webhook-runtime/src/index.ts
+++ b/packages/webhook-runtime/src/index.ts
@@ -1,6 +1,17 @@
 export { WebhookRegistry, createWebhookRegistry } from "./webhook-registry.js";
 
 export { parseSlackEvent } from "./slack-parser.js";
+export {
+  SlackEventDedupGate,
+  getSlackDeduplicationKey,
+} from "@agent-assistant/surfaces";
+export type {
+  SlackEventDedupDecision,
+  SlackEventDedupDropReason,
+  SlackEventDedupGateOptions,
+  SlackEventDedupInput,
+  SlackEventDedupStore,
+} from "@agent-assistant/surfaces";
 export { registerSlackSpecialistConsumer } from "./specialist-bridge.js";
 export type {
   RegisterSlackSpecialistConsumerOptions,

--- a/packages/webhook-runtime/src/slack-event-dedup-reexport.test.ts
+++ b/packages/webhook-runtime/src/slack-event-dedup-reexport.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SlackEventDedupGate,
+  getSlackDeduplicationKey,
+  type SlackEventDedupStore,
+} from "./index.js";
+import * as surfaces from "@agent-assistant/surfaces";
+
+function createMemoryStore(): SlackEventDedupStore & { keys: Map<string, number> } {
+  const keys = new Map<string, number>();
+  return {
+    keys,
+    async hasBeenProcessed(key) {
+      return keys.has(key);
+    },
+    async markProcessed(key, ttlSeconds) {
+      keys.set(key, ttlSeconds);
+    },
+  };
+}
+
+describe("webhook-runtime re-exports SlackEventDedupGate from @agent-assistant/surfaces", () => {
+  it("exposes the canonical SlackEventDedupGate class identity (no fork)", () => {
+    expect(SlackEventDedupGate).toBe(surfaces.SlackEventDedupGate);
+    expect(getSlackDeduplicationKey).toBe(surfaces.getSlackDeduplicationKey);
+  });
+
+  it("derives a dedup key from event_id, falling back to ts, then undefined", () => {
+    expect(getSlackDeduplicationKey({ eventId: "Ev123", ts: "1700.0001" })).toBe(
+      "Ev123",
+    );
+    expect(getSlackDeduplicationKey({ ts: "1700.0001" })).toBe("1700.0001");
+    expect(getSlackDeduplicationKey({})).toBeUndefined();
+    expect(getSlackDeduplicationKey({ eventId: "" })).toBeUndefined();
+  });
+
+  it("claims a dedup slot once and reports duplicates on retry", async () => {
+    const store = createMemoryStore();
+    const gate = new SlackEventDedupGate({ store, ttlSeconds: 60 });
+
+    const first = await gate.claim({ eventId: "Ev_first" });
+    expect(first).toEqual({ proceed: true, key: "Ev_first" });
+    expect(store.keys.get("Ev_first")).toBe(60);
+
+    const second = await gate.claim({ eventId: "Ev_first" });
+    expect(second).toEqual({
+      proceed: false,
+      reason: "duplicate-event",
+      key: "Ev_first",
+    });
+  });
+
+  it("lets events without a dedup key proceed and reports the no-dedup-key reason", async () => {
+    const store = createMemoryStore();
+    const gate = new SlackEventDedupGate({ store });
+
+    const decision = await gate.claim({});
+    expect(decision).toEqual({ proceed: true, reason: "no-dedup-key" });
+    expect(store.keys.size).toBe(0);
+  });
+
+  it("defaults the dedup TTL to SlackEventDedupGate.DEFAULT_TTL_SECONDS when omitted", async () => {
+    const store = createMemoryStore();
+    const gate = new SlackEventDedupGate({ store });
+
+    await gate.claim({ eventId: "Ev_default_ttl" });
+    expect(store.keys.get("Ev_default_ttl")).toBe(
+      SlackEventDedupGate.DEFAULT_TTL_SECONDS,
+    );
+  });
+});

--- a/packages/webhook-runtime/src/specialist-bridge.ts
+++ b/packages/webhook-runtime/src/specialist-bridge.ts
@@ -99,6 +99,13 @@ async function defaultSpecialistFactory({
   throw new Error(`Unsupported Slack specialist kind: ${specialistKind}`);
 }
 
+/**
+ * Register an in-process Slack fanout consumer for local/BYOH deployments.
+ *
+ * cf-runtime personas should not use this bridge: enqueue a `specialist_call`
+ * queue message and resume on `specialist_result:<turnId>` instead, so the
+ * persona turn is awaited by the runtime rather than orphaned inside fanout.
+ */
 export function registerSlackSpecialistConsumer(
   registry: SlackSpecialistConsumerRegistry,
   opts: RegisterSlackSpecialistConsumerOptions,


### PR DESCRIPTION
## Summary
W4 of the cf-runtime bundle. Small audit-driven fixes to @agent-assistant/webhook-runtime so the new cloudflare-runtime package can reuse it cleanly across sage / nightcto / future personas.

Scope is intentionally tiny — audit-driven patches only. See AUDIT-04.md on the branch for the full list.

## Test evidence
- npx vitest run in packages/webhook-runtime/ — all green (8 files, 31 tests).
- VERDICT-04.md: KEEP.

## Order
Independent of W1/W2/W3 — any merge order is fine.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
