### PR TITLE
feat(cloudflare-runtime): full package (W1+W2+W3 consolidated)

### DIFF
--- a/docs/specs/v1-cloudflare-runtime-spec.md
+++ b/docs/specs/v1-cloudflare-runtime-spec.md
@@ -1,0 +1,233 @@
+# v1 Cloudflare Runtime Spec — `@agent-assistant/cloudflare-runtime`
+
+**Status:** IMPLEMENTATION_READY
+**Date:** 2026-04-25
+**Package:** `@agent-assistant/cloudflare-runtime`
+**Version target:** v0.1.0 (pre-1.0, provisional)
+**Adoption posture:** direct-import / Cloudflare-Workers adapter for personas built on `@agent-assistant/continuation`
+
+---
+
+## 1. Responsibilities
+
+`@agent-assistant/cloudflare-runtime` is the platform-specific bridge that lets a persona
+built on `@agent-assistant/continuation` run on Cloudflare Workers without each persona
+re-implementing webhook ingress, queue dispatch, dedup, ExecutionContext lifetime
+management, signature verification, or the wiring that ties the continuation runtime
+into Workers Queues + Durable Objects + KV.
+
+**Owns:**
+
+- `wrapCloudflareWorker(opts)` — a `fetch` handler that intercepts persona-declared
+  webhook routes, delegates signature-verification + parsing to the persona, runs
+  ingress dedup against `@agent-assistant/surfaces`'s `SlackEventDedupGate`, and
+  enqueues a turn descriptor onto the persona's Turn Queue. Non-webhook routes fall
+  through to `opts.inner.fetch`.
+- `handleCfQueue(batch, env, ctx, opts)` — a queue consumer that wraps every
+  message in a fake `ExecutionContext` whose `waitUntil(p)` collects `p` onto an
+  internal array; the wrapper awaits all collected promises **before** the message
+  is acked. This is the direct fix for the production Slack-silence bug where
+  Cloudflare cancels `waitUntil` ~30s after the originating fetch returns.
+- `createFakeExecutionContext()` — the standalone shim used by `handleCfQueue`,
+  exposed so personas writing their own consumers get the same guarantee.
+- `CfContinuationStore` — implements `ContinuationStore` from
+  `@agent-assistant/continuation` against a Durable Object's storage (primary) plus
+  an optional KV namespace acting as the trigger index for cross-DO `findByTrigger`
+  lookups. The DO is the single writer for its conversation; KV is a secondary,
+  eventually-consistent index.
+- `CfContinuationScheduler` — implements `ContinuationSchedulerAdapter` against
+  DO alarms (same-DO wakeups) and a Workers Queue with `delaySeconds` (cross-DO
+  wakeups).
+- `CfDeliveryAdapter` — implements `ContinuationDeliveryAdapter` and dispatches to
+  persona-supplied delivery callbacks for `slack`, `github`, and `a2a-callback`
+  delivery targets. Returns `{ delivered: false, failureReason }` when the
+  matching handler is not registered or when the target kind is unknown — never
+  silently swallows.
+- `CfSpecialistClient` — typed helper for the async sage↔specialist bridge: enqueue
+  a `specialist_call` message and wait for the matching `specialist_result` message
+  via the continuation runtime's resume path.
+- `TurnExecutorDO` — abstract Durable Object base class personas extend. Owns the
+  per-conversation lock that keeps the continuation store consistent under
+  concurrent webhooks.
+- `verifySlackSignature` / `verifyGitHubSignature` — helpers personas import inside
+  their own `parseSlackWebhook` / `parseGitHubWebhook`. The runtime never verifies
+  signatures itself (it has no access to the per-workspace signing secrets).
+- Observability primitives — `CfLogger` interface plus `consoleJsonLogger`,
+  `nullLogger`, `createConsoleJsonLogger`, and `createCapturingLogger` for tests.
+  Wired through `wrapCloudflareWorker` and `handleCfQueue` so every step in a
+  turn's lifecycle emits a structured event.
+
+**Does NOT own:**
+
+- Persona-specific signature verification logic. Personas hold the signing secrets
+  and call the helpers inside their `parse*Webhook` returning a `ParseResult`.
+- The shape of `TurnDescriptor`. Personas define their own descriptor type and
+  return it from their `parseWebhook`. The runtime treats descriptors as opaque
+  payloads inside the queue message.
+- The harness loop. Persona packages export `run<Persona>Turn(descriptor, env, ctx)`
+  which the runtime invokes from inside the fake `ExecutionContext`.
+- Cloudflare Worker secrets, bindings, or SST infra. Those live in the consuming
+  repo (e.g. `cloud/packages/cloudflare-agent-bindings`,
+  `cloud/infra/agent-persona.ts`).
+- Cloudflare-specific app coupling. The package treats `Env` as a generic and only
+  reaches into bindings the caller names.
+
+## 2. Invariants
+
+These are load-bearing — violations are bugs the runtime must fail closed on.
+
+1. **`waitUntil` never orphans.** Inside `handleCfQueue`, `ctx.waitUntil(p)` is
+   equivalent to `await p` — the consumer awaits all collected promises before the
+   message is acked. Direct regression test for the production Slack-silence bug.
+2. **Continuation writes are synchronous on suspend.** A turn that suspends MUST
+   write its continuation to the store before the consumer returns; losing the
+   write loses the turn.
+3. **Signature verification belongs to the persona.** `wrapCloudflareWorker` does
+   not call signature helpers itself. Each `WebhookRouteConfig` provides
+   `verify(req, env)`; if it returns `{ ok: false }` the runtime returns 401.
+4. **Dedup runs exactly once, at ingress.** Personas MUST NOT re-implement Slack /
+   GitHub event dedup; `wrapCloudflareWorker` claims the dedup key against the
+   `dedupBinding` KV via `SlackEventDedupGate` from `@agent-assistant/surfaces`.
+5. **The DO is the single writer for its conversation's continuation records.**
+   The KV trigger index is eventually consistent and is only used for cross-DO
+   `findByTrigger` lookups; record state always lives in DO storage.
+6. **The dedup primitive is the upstream `SlackEventDedupGate`** from
+   `@agent-assistant/surfaces`. The runtime imports it; it does not fork the gate
+   class.
+7. **Personas expose a two-function contract** — `parse<Surface>Webhook(req, env)`
+   returning a `ParseResult` and `run<Persona>Turn(descriptor, env, ctx)` running
+   the harness. The runtime composes them.
+
+## 3. Persona contract
+
+Each persona built on this runtime exports two functions per surface (Slack,
+GitHub, Nango, …) plus a `<Persona>TurnDescriptor` type:
+
+```ts
+export interface ParseResult {
+  kind: 'ack' | 'dispatch';
+  response: Response;            // sent back to the caller (challenge, ack, dispatch)
+  turn?: unknown;                // present when kind === 'dispatch'
+  dedupKey?: { eventId?: string; ts?: string };  // for ingress dedup
+}
+
+export async function parseSlackWebhook(
+  req: Request,
+  env: PersonaEnv,
+): Promise<ParseResult>;
+
+export async function runSageTurn(
+  descriptor: SageTurnDescriptor,
+  env: SageEnv,
+  ctx: ExecutionContext,   // may be the fake-ctx in queue consumers
+): Promise<void>;
+```
+
+`parseSlackWebhook` is responsible for signature verification, Slack URL-verification
+challenge handling, persona policy gates (rate limit, mention/thread gate), and
+returning either an ack-only `Response` or a `dispatch` payload that the runtime
+will dedup-claim and enqueue.
+
+`run<Persona>Turn` runs the harness work synchronously relative to its caller. Any
+internal use of `ctx.waitUntil` is for genuinely out-of-band work (telemetry,
+status reactions); the **turn itself** must be awaited.
+
+## 4. Queue message shape
+
+```ts
+type WebhookQueueMessage = {
+  type: 'webhook';
+  provider: 'slack' | 'github' | 'nango';
+  descriptor: unknown;       // persona-defined TurnDescriptor
+  receivedAt: string;
+};
+
+type ResumeQueueMessage = {
+  type: 'resume';
+  continuationId: string;
+  trigger: ContinuationResumeTrigger;
+};
+
+type SpecialistCallQueueMessage = { ... };
+type SpecialistResultQueueMessage = { ... };
+
+type TurnQueueMessage =
+  | WebhookQueueMessage
+  | ResumeQueueMessage
+  | SpecialistCallQueueMessage
+  | SpecialistResultQueueMessage;
+```
+
+`handleCfQueue` is generic over message type so personas can extend the union
+with their own variants.
+
+## 5. Trigger index keying
+
+`CfContinuationStore.findByTrigger(trigger)` looks up continuations via a KV
+secondary index. Both sides of the lookup (`continuationTriggerIndexKey` and
+`resumeTriggerIndexKey`) **must agree on key shape**. Today:
+
+| Trigger type | Key | Notes |
+| --- | --- | --- |
+| `approval_resolution` | `trigger:approval_resolution:${approvalId}` | symmetric |
+| `external_result` | `trigger:external_result:${operationId}` | symmetric |
+| `scheduled_wake` | `trigger:scheduled_wake:${wakeUpId ?? recordId-or-empty}` | wake by id or fallback |
+| `user_reply` | `trigger:user_reply:${correlationKey}` (if set) | **see below** |
+
+For `user_reply`: the upstream `ContinuationResumeTrigger` does not carry a
+`correlationKey` field — only the `waitFor` side has one. `findByTrigger` for
+user_reply therefore returns `null` unless callers wire correlation themselves
+(e.g. via `listBySession`). Both `continuationTriggerIndexKey` and
+`resumeTriggerIndexKey` return `undefined` for user_reply when no correlation key
+is available; the lookup is a no-op rather than a false miss against a synthetic
+key. Personas with thread/channel correlation should either extend the trigger
+shape upstream or use `listBySession` to fan out.
+
+When `put` updates an existing record whose trigger key has changed, the store
+deletes the prior trigger index entry before writing the new one, so stale keys
+never resolve to the wrong record.
+
+## 6. Observability
+
+`wrapCloudflareWorker` and `handleCfQueue` both accept an optional `logger:
+CfLogger`. When omitted, they default to `consoleJsonLogger` which emits one
+structured JSON line per event to stdout (renders cleanly in
+`wrangler tail --format json`).
+
+Lifecycle events emitted:
+
+- `webhook received` — info — at every webhook ingress
+- `signature verification failed` — warn — verify returned ok: false
+- `parse complete` — debug — kind, hasDedupKey
+- `ack-only response` — info — when parse returns `kind: 'ack'`
+- `duplicate event — skipping enqueue` — info — dedup gate said skip
+- `turn enqueued` — info — message sent to Turn Queue
+- `dispatch start` — debug — queue consumer began running runTurn
+- `dispatch complete` — info — runTurn returned, includes `durationMs`,
+  `waitUntilCount`
+- `dispatch failed` — error — runTurn threw
+
+Persona-injectable hatches:
+
+- Custom `CfLogger` ships events anywhere (Workers Analytics Engine, Datadog).
+- `child(bindings)` correlates log lines by turnId / conversationId / component.
+- `resolveTurnId(message)` extracts a stable id so every log line for one turn
+  greps with the same key.
+- `nullLogger` silences in tests; `createCapturingLogger()` returns the logger +
+  a records array for assertions.
+
+## 7. Out of scope for v1
+
+- Cloudflare Workflows. Continuations + DO alarms cover the same ground without
+  a second checkpointed-step abstraction.
+- Cron-driven workloads (cataloging agents). Different shape; reusable
+  `CfContinuationStore` / `CfContinuationScheduler` only if a sync truly outgrows
+  a single DO alarm.
+- Per-workspace rate limiting at the runtime layer. Personas own rate limiting
+  inside `parse*Webhook` (they own the workspace identity).
+
+## 8. Reference
+
+Full architecture and workflow runbook live in the consuming repo at
+`workflows/cf-runtime/SPEC.md` and `workflows/cf-runtime/ARCHITECTURE.md`
+(`AgentWorkforce/cloud`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "packages/specialists",
         "packages/telemetry",
         "packages/examples",
+        "packages/cloudflare-runtime",
         "packages/webhook-runtime"
       ],
       "dependencies": {
@@ -36,6 +37,10 @@
       "devDependencies": {
         "@agentworkforce/workload-router": "^0.2.0"
       }
+    },
+    "node_modules/@agent-assistant/cloudflare-runtime": {
+      "resolved": "packages/cloudflare-runtime",
+      "link": true
     },
     "node_modules/@agent-assistant/connectivity": {
       "resolved": "packages/connectivity",
@@ -254,6 +259,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260425.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260425.1.tgz",
+      "integrity": "sha512-f6dlo3SsA+TNqjveavPDN73nxRfCOOd0iMdf8iEosgR/RJtQlrGwfr5L5Vf7x/5cpeeguxScKevuaMmdjpOECw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -3461,9 +3473,98 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "packages/cloudflare-runtime": {
+      "name": "@agent-assistant/cloudflare-runtime",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agent-assistant/continuation": "^0.2.24",
+        "@agent-assistant/surfaces": "^0.3.0",
+        "@agent-assistant/webhook-runtime": "^0.2.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260417.1",
+        "@types/node": "^24.6.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/continuation": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/continuation/-/continuation-0.2.24.tgz",
+      "integrity": "sha512-J6usB7wVtBhiJ4rLO05tkq/1t7/RFLLtoofMpzuSl7I6Srk18xR86t+HyGmfPZrKuuKmpib8+z5+b7LogCNAyg==",
+      "dependencies": {
+        "@agent-assistant/harness": "^0.4.0"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
+      }
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/cloudflare-runtime/node_modules/@agent-assistant/turn-context": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/turn-context/-/turn-context-0.2.25.tgz",
+      "integrity": "sha512-+OrCZgTYrtXQu+UG/9PiYrsdyoZ6naJDWQRAt2QCN/fVW+ag3Gs2WUKjT5W/zjukQ4VrR4rhQAx8ASNwX4bR4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/harness": "^0.4.0",
+        "@agent-assistant/memory": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0"
+      }
+    },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3475,7 +3576,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -3499,7 +3600,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3511,9 +3612,18 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/coordination/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3546,7 +3656,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3562,9 +3672,81 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/harness/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/harness": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
+      "integrity": "sha512-P3eGE/SGui2+KOX4wQbbDs87wgxwcPQajG//v/kpdzmjk10OZmFuiWMkCWRVVyuBhe2ILI/0ud0/6geQjeY9sw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.2.0",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/harness/node_modules/@agent-assistant/turn-context": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/turn-context/-/turn-context-0.2.25.tgz",
+      "integrity": "sha512-+OrCZgTYrtXQu+UG/9PiYrsdyoZ6naJDWQRAt2QCN/fVW+ag3Gs2WUKjT5W/zjukQ4VrR4rhQAx8ASNwX4bR4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/harness": "^0.4.0",
+        "@agent-assistant/memory": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4352,7 +4534,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4364,7 +4546,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4376,7 +4558,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.2.25",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4398,7 +4580,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4415,7 +4597,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4423,7 +4605,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.3.12",
+      "version": "0.4.0",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4435,9 +4617,34 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/specialists/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/specialists/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/specialists/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.2.25",
+      "version": "0.3.0",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4445,7 +4652,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.1.13",
+      "version": "0.2.0",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0"
       },
@@ -4470,7 +4677,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4479,7 +4686,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.2.25",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0",
@@ -4504,9 +4711,24 @@
         "@agent-relay/sdk": "^4.0.22"
       }
     },
+    "packages/turn-context/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.2.24",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4533,7 +4755,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@hono/node-server": "^2.0.0",
@@ -4555,6 +4777,25 @@
         }
       }
     },
+    "packages/webhook-runtime/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
     "packages/webhook-runtime/node_modules/@agent-assistant/harness": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.3.tgz",
@@ -4568,6 +4809,23 @@
         "@agent-assistant/turn-context": "^0.2.0",
         "@agent-relay/sdk": "^4.0.22"
       }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/specialists": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/specialists/-/specialists-0.3.12.tgz",
+      "integrity": "sha512-fkra1GvuAvI8n2aHLvV/bnbrS7w5UAAeUW8hoSDOn6lil4ToWzoMSTp2oeEvplicYSibQkVrbvKkFQPGddYLrw==",
+      "dependencies": {
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/vfs": "^0.2.6",
+        "@relayfile/adapter-github": "^0.1.6",
+        "@relayfile/adapter-linear": "^0.1.7"
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "packages/specialists",
     "packages/telemetry",
     "packages/examples",
+    "packages/cloudflare-runtime",
     "packages/webhook-runtime"
   ],
   "scripts": {

--- a/packages/cloudflare-runtime/README.md
+++ b/packages/cloudflare-runtime/README.md
@@ -1,0 +1,12 @@
+# @agent-assistant/cloudflare-runtime
+
+Cloudflare-specific runtime adapters for Agent Assistant persona workers.
+
+This package will host the ingress wrapper, queue executor, continuation
+adapters, signature verification helpers, and Durable Object base classes used
+by Sage, Specialist, and future personas. It is ESM-only and intentionally keeps
+Cloudflare Worker types as development-only type dependencies.
+
+The initial scaffold exposes shared binding and queue message types. Downstream
+workflow steps will add the runtime implementation modules described in
+`SPEC.md`.

--- a/packages/cloudflare-runtime/README.md
+++ b/packages/cloudflare-runtime/README.md
@@ -2,11 +2,14 @@
 
 Cloudflare-specific runtime adapters for Agent Assistant persona workers.
 
-This package will host the ingress wrapper, queue executor, continuation
-adapters, signature verification helpers, and Durable Object base classes used
-by Sage, Specialist, and future personas. It is ESM-only and intentionally keeps
-Cloudflare Worker types as development-only type dependencies.
+Hosts the ingress wrapper, queue executor, continuation adapters (DO storage +
+KV trigger index), DO alarm scheduler, delivery adapter, signature
+verification helpers, the abstract `TurnExecutorDO` base class, and structured
+observability primitives used by Sage, Specialist, and future personas built
+on `@agent-assistant/continuation`. ESM-only; Cloudflare Worker types are a
+development-only type dependency.
 
-The initial scaffold exposes shared binding and queue message types. Downstream
-workflow steps will add the runtime implementation modules described in
-`SPEC.md`.
+See
+[`docs/specs/v1-cloudflare-runtime-spec.md`](../../docs/specs/v1-cloudflare-runtime-spec.md)
+for the package contract, invariants, persona two-function contract, queue
+message shape, and observability surface.

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@agent-assistant/cloudflare-runtime",
+  "version": "0.1.0",
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@agent-assistant/continuation": "workspace:*",
+    "@agent-assistant/webhook-runtime": "workspace:*",
+    "@agent-assistant/surfaces": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260417.1",
+    "@types/node": "^24.6.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AgentWorkforce/agent-assistant"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -18,9 +18,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agent-assistant/continuation": "workspace:*",
-    "@agent-assistant/webhook-runtime": "workspace:*",
-    "@agent-assistant/surfaces": "workspace:*"
+    "@agent-assistant/continuation": "^0.2.24",
+    "@agent-assistant/webhook-runtime": "^0.2.0",
+    "@agent-assistant/surfaces": "^0.3.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260417.1",

--- a/packages/cloudflare-runtime/src/adapters/cf-continuation-scheduler.test.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-continuation-scheduler.test.ts
@@ -1,0 +1,39 @@
+import type { Queue } from '@cloudflare/workers-types';
+import { describe, expect, it } from 'vitest';
+
+import { CfContinuationScheduler } from './cf-continuation-scheduler.js';
+import type { TurnQueueMessage } from '../types.js';
+
+describe('CfContinuationScheduler', () => {
+  it('uses DO alarms when storage is provided', async () => {
+    let alarmAt: number | Date | undefined;
+    const scheduler = new CfContinuationScheduler({
+      storage: {
+        async setAlarm(value) {
+          alarmAt = value;
+        },
+      },
+    });
+
+    await expect(
+      scheduler.scheduleWake({ continuationId: 'cont-1', wakeAtMs: 1_000 }),
+    ).resolves.toEqual({ wakeUpId: 'wake:cont-1:1000' });
+    expect(alarmAt).toBe(1_000);
+  });
+
+  it('sends delayed resume messages when queue scheduling is used', async () => {
+    const sent: { message: TurnQueueMessage; options?: unknown }[] = [];
+    const queue = {
+      async send(message: TurnQueueMessage, options?: unknown) {
+        sent.push({ message, options });
+      },
+    } as Queue<TurnQueueMessage>;
+
+    const scheduler = new CfContinuationScheduler({ queue, now: () => 500 });
+    await scheduler.scheduleWake({ continuationId: 'cont-1', wakeAtMs: 2_500 });
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.message.type).toBe('resume');
+    expect(sent[0]?.options).toEqual({ delaySeconds: 2 });
+  });
+});

--- a/packages/cloudflare-runtime/src/adapters/cf-continuation-scheduler.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-continuation-scheduler.ts
@@ -1,0 +1,62 @@
+import type { Queue } from '@cloudflare/workers-types';
+import type { ContinuationSchedulerAdapter } from '@agent-assistant/continuation';
+
+import type { TurnQueueMessage } from '../types.js';
+
+export interface AlarmStorageLike {
+  setAlarm(scheduledTime: number | Date): Promise<void>;
+  deleteAlarm?(): Promise<void>;
+}
+
+export interface CfContinuationSchedulerOptions {
+  storage?: AlarmStorageLike;
+  queue?: Queue<TurnQueueMessage>;
+  now?: () => number;
+}
+
+export class CfContinuationScheduler implements ContinuationSchedulerAdapter {
+  private readonly storage?: AlarmStorageLike;
+  private readonly queue?: Queue<TurnQueueMessage>;
+  private readonly now: () => number;
+
+  constructor(options: CfContinuationSchedulerOptions) {
+    this.storage = options.storage;
+    this.queue = options.queue;
+    this.now = options.now ?? Date.now;
+  }
+
+  async scheduleWake(input: {
+    continuationId: string;
+    wakeAtMs: number;
+  }): Promise<{ wakeUpId: string }> {
+    const wakeUpId = `wake:${input.continuationId}:${input.wakeAtMs}`;
+
+    if (this.storage) {
+      await this.storage.setAlarm(input.wakeAtMs);
+      return { wakeUpId };
+    }
+
+    if (!this.queue) {
+      throw new Error('CfContinuationScheduler requires storage or queue');
+    }
+
+    await this.queue.send(
+      {
+        type: 'resume',
+        continuationId: input.continuationId,
+        trigger: {
+          type: 'scheduled_wake',
+          wakeUpId,
+          firedAt: new Date(input.wakeAtMs).toISOString(),
+        },
+      },
+      { delaySeconds: Math.max(0, Math.ceil((input.wakeAtMs - this.now()) / 1000)) },
+    );
+
+    return { wakeUpId };
+  }
+
+  async cancelWake(): Promise<void> {
+    await this.storage?.deleteAlarm?.();
+  }
+}

--- a/packages/cloudflare-runtime/src/adapters/cf-continuation-store.test.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-continuation-store.test.ts
@@ -1,0 +1,69 @@
+import type { ContinuationRecord } from '@agent-assistant/continuation';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CfContinuationStore,
+  type DurableObjectStorageLike,
+} from './cf-continuation-store.js';
+
+function makeStorage(): DurableObjectStorageLike {
+  const entries = new Map<string, unknown>();
+  return {
+    async get(key) {
+      return entries.get(key);
+    },
+    async put(key, value) {
+      entries.set(key, value);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async list(options) {
+      return new Map(
+        [...entries.entries()].filter(([key]) => !options?.prefix || key.startsWith(options.prefix)),
+      );
+    },
+  };
+}
+
+function makeRecord(id: string, sessionId = 'session-1'): ContinuationRecord {
+  return {
+    id,
+    assistantId: 'sage',
+    sessionId,
+    origin: {
+      turnId: `turn-${id}`,
+      outcome: 'deferred',
+      stopReason: 'runtime_error',
+      createdAt: '2026-04-24T00:00:00.000Z',
+    },
+    status: 'pending',
+    waitFor: { type: 'external_result', operationId: `op-${id}` },
+    continuation: { token: id },
+    delivery: { status: 'pending_delivery' },
+    bounds: {
+      expiresAt: '2026-04-25T00:00:00.000Z',
+      maxResumeAttempts: 3,
+      resumeAttempts: 0,
+    },
+    createdAt: '2026-04-24T00:00:00.000Z',
+    updatedAt: '2026-04-24T00:00:00.000Z',
+  };
+}
+
+describe('CfContinuationStore', () => {
+  it('stores, retrieves, lists, and deletes continuation records', async () => {
+    const store = new CfContinuationStore({ storage: makeStorage() });
+    const record = makeRecord('1');
+
+    await store.put(record);
+
+    expect(await store.get('1')).toEqual(record);
+    expect(await store.listBySession?.('session-1')).toEqual([record]);
+
+    await store.delete?.('1');
+
+    expect(await store.get('1')).toBeNull();
+    expect(await store.listBySession?.('session-1')).toEqual([]);
+  });
+});

--- a/packages/cloudflare-runtime/src/adapters/cf-continuation-store.test.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-continuation-store.test.ts
@@ -1,8 +1,13 @@
-import type { ContinuationRecord } from '@agent-assistant/continuation';
+import type {
+  ContinuationRecord,
+  ContinuationResumeTrigger,
+} from '@agent-assistant/continuation';
 import { describe, expect, it } from 'vitest';
 
 import {
   CfContinuationStore,
+  continuationTriggerIndexKey,
+  resumeTriggerIndexKey,
   type DurableObjectStorageLike,
 } from './cf-continuation-store.js';
 
@@ -51,6 +56,19 @@ function makeRecord(id: string, sessionId = 'session-1'): ContinuationRecord {
   };
 }
 
+function makeKv(): {
+  kv: { get: (k: string) => Promise<string | null>; put: (k: string, v: string) => Promise<void>; delete: (k: string) => Promise<void> };
+  entries: Map<string, string>;
+} {
+  const entries = new Map<string, string>();
+  const kv = {
+    async get(k: string) { return entries.get(k) ?? null; },
+    async put(k: string, v: string) { entries.set(k, v); },
+    async delete(k: string) { entries.delete(k); },
+  };
+  return { kv, entries };
+}
+
 describe('CfContinuationStore', () => {
   it('stores, retrieves, lists, and deletes continuation records', async () => {
     const store = new CfContinuationStore({ storage: makeStorage() });
@@ -65,5 +83,127 @@ describe('CfContinuationStore', () => {
 
     expect(await store.get('1')).toBeNull();
     expect(await store.listBySession?.('session-1')).toEqual([]);
+  });
+
+  it('removes the prior trigger index when waitFor changes on update', async () => {
+    const { kv, entries } = makeKv();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = new CfContinuationStore({ storage: makeStorage(), triggerIndex: kv as any });
+    const record = makeRecord('1');
+
+    await store.put(record);
+    expect(entries.get('trigger:external_result:op-1')).toBe('1');
+
+    // Update the record's waitFor to a different operationId — emulates a
+    // continuation re-pending on a new external operation.
+    const updated: ContinuationRecord = {
+      ...record,
+      waitFor: { type: 'external_result', operationId: 'op-2' },
+    };
+    await store.put(updated);
+
+    // Old key gone, new key written. findByTrigger on the OLD key resolves to null.
+    expect(entries.has('trigger:external_result:op-1')).toBe(false);
+    expect(entries.get('trigger:external_result:op-2')).toBe('1');
+
+    const stale: ContinuationResumeTrigger = {
+      type: 'external_result',
+      operationId: 'op-1',
+      resolvedAt: 'now',
+    };
+    expect(await store.findByTrigger(stale)).toBeNull();
+
+    const fresh: ContinuationResumeTrigger = {
+      type: 'external_result',
+      operationId: 'op-2',
+      resolvedAt: 'now',
+    };
+    expect((await store.findByTrigger(fresh))?.id).toBe('1');
+  });
+});
+
+describe('trigger index key symmetry', () => {
+  it('approval_resolution: create-side and resume-side keys match', () => {
+    const record = makeRecord('1');
+    record.waitFor = { type: 'approval_resolution', approvalId: 'A1' };
+    const trigger: ContinuationResumeTrigger = {
+      type: 'approval_resolution',
+      approvalId: 'A1',
+      decision: 'approved',
+      resolvedAt: 'now',
+    };
+    expect(continuationTriggerIndexKey(record)).toBe('trigger:approval_resolution:A1');
+    expect(resumeTriggerIndexKey(trigger)).toBe('trigger:approval_resolution:A1');
+  });
+
+  it('external_result: create-side and resume-side keys match', () => {
+    const record = makeRecord('1');
+    record.waitFor = { type: 'external_result', operationId: 'OP1' };
+    const trigger: ContinuationResumeTrigger = {
+      type: 'external_result',
+      operationId: 'OP1',
+      resolvedAt: 'now',
+    };
+    expect(continuationTriggerIndexKey(record)).toBe('trigger:external_result:OP1');
+    expect(resumeTriggerIndexKey(trigger)).toBe('trigger:external_result:OP1');
+  });
+
+  it('scheduled_wake: only emits a key when wakeUpId is set on both sides', () => {
+    const recWithId = makeRecord('1');
+    recWithId.waitFor = { type: 'scheduled_wake', wakeUpId: 'W1' };
+    const recNoId = makeRecord('2');
+    recNoId.waitFor = { type: 'scheduled_wake' };
+
+    const trigWithId: ContinuationResumeTrigger = {
+      type: 'scheduled_wake',
+      wakeUpId: 'W1',
+      firedAt: 'now',
+    };
+    const trigNoId: ContinuationResumeTrigger = {
+      type: 'scheduled_wake',
+      firedAt: 'now',
+    };
+
+    expect(continuationTriggerIndexKey(recWithId)).toBe('trigger:scheduled_wake:W1');
+    expect(resumeTriggerIndexKey(trigWithId)).toBe('trigger:scheduled_wake:W1');
+    expect(continuationTriggerIndexKey(recNoId)).toBeUndefined();
+    expect(resumeTriggerIndexKey(trigNoId)).toBeUndefined();
+  });
+
+  it('user_reply: refuses to synthesize a key from message.id (asymmetric upstream)', () => {
+    // Upstream waitFor side has correlationKey, resume side has message.id —
+    // they don't overlap, so the cf-runtime returns undefined on both sides
+    // rather than synthesize a fake key that would never match.
+    const recWithCorr = makeRecord('1');
+    recWithCorr.waitFor = { type: 'user_reply', correlationKey: 'channel:thread' };
+    const recNoCorr = makeRecord('2');
+    recNoCorr.waitFor = { type: 'user_reply' };
+
+    const trigger: ContinuationResumeTrigger = {
+      type: 'user_reply',
+      message: { id: 'msg-1', role: 'user', content: [] } as never,
+      receivedAt: 'now',
+    };
+
+    expect(continuationTriggerIndexKey(recWithCorr)).toBe('trigger:user_reply:channel:thread');
+    expect(continuationTriggerIndexKey(recNoCorr)).toBeUndefined();
+    // resume side never emits — there's no symmetric correlation field.
+    expect(resumeTriggerIndexKey(trigger)).toBeUndefined();
+  });
+
+  it('findByTrigger returns null for user_reply triggers (no symmetric key)', async () => {
+    const { kv } = makeKv();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const store = new CfContinuationStore({ storage: makeStorage(), triggerIndex: kv as any });
+    const record = makeRecord('1');
+    record.waitFor = { type: 'user_reply', correlationKey: 'channel:thread' };
+    await store.put(record);
+
+    const trigger: ContinuationResumeTrigger = {
+      type: 'user_reply',
+      message: { id: 'msg-1', role: 'user', content: [] } as never,
+      receivedAt: 'now',
+    };
+    expect(await store.findByTrigger(trigger)).toBeNull();
   });
 });

--- a/packages/cloudflare-runtime/src/adapters/cf-continuation-store.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-continuation-store.ts
@@ -1,0 +1,116 @@
+import type { KVNamespace } from '@cloudflare/workers-types';
+import type {
+  ContinuationRecord,
+  ContinuationResumeTrigger,
+  ContinuationStore,
+} from '@agent-assistant/continuation';
+
+export interface DurableObjectStorageLike {
+  get<T = unknown>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  list<T = unknown>(options?: { prefix?: string }): Promise<Map<string, T>>;
+}
+
+export interface CfContinuationStoreOptions {
+  storage: DurableObjectStorageLike;
+  triggerIndex?: KVNamespace;
+}
+
+export class CfContinuationStore implements ContinuationStore {
+  private readonly storage: DurableObjectStorageLike;
+  private readonly triggerIndex?: KVNamespace;
+
+  constructor(options: CfContinuationStoreOptions) {
+    this.storage = options.storage;
+    this.triggerIndex = options.triggerIndex;
+  }
+
+  async put(record: ContinuationRecord): Promise<void> {
+    await this.storage.put(recordKey(record.id), record);
+
+    if (record.sessionId) {
+      await this.storage.put(sessionKey(record.sessionId, record.id), record.id);
+    }
+
+    const triggerKey = continuationTriggerIndexKey(record);
+    if (triggerKey) {
+      await this.triggerIndex?.put(triggerKey, record.id);
+    }
+  }
+
+  async get(continuationId: string): Promise<ContinuationRecord | null> {
+    return (await this.storage.get<ContinuationRecord>(recordKey(continuationId))) ?? null;
+  }
+
+  async delete(continuationId: string): Promise<void> {
+    const existing = await this.get(continuationId);
+    await this.storage.delete(recordKey(continuationId));
+
+    if (existing?.sessionId) {
+      await this.storage.delete(sessionKey(existing.sessionId, continuationId));
+    }
+
+    const triggerKey = existing ? continuationTriggerIndexKey(existing) : undefined;
+    if (triggerKey) {
+      await this.triggerIndex?.delete(triggerKey);
+    }
+  }
+
+  async listBySession(sessionId: string): Promise<ContinuationRecord[]> {
+    const sessionEntries = await this.storage.list<string>({ prefix: sessionPrefix(sessionId) });
+    const records = await Promise.all(
+      [...sessionEntries.values()].map((continuationId) => this.get(continuationId)),
+    );
+    return records.filter((record): record is ContinuationRecord => record !== null);
+  }
+
+  async findByTrigger(trigger: ContinuationResumeTrigger): Promise<ContinuationRecord | null> {
+    if (!this.triggerIndex) {
+      return null;
+    }
+
+    const continuationId = await this.triggerIndex.get(resumeTriggerIndexKey(trigger));
+    return continuationId ? this.get(continuationId) : null;
+  }
+}
+
+export function continuationTriggerIndexKey(record: ContinuationRecord): string | undefined {
+  switch (record.waitFor.type) {
+    case 'approval_resolution':
+      return `trigger:approval_resolution:${record.waitFor.approvalId}`;
+    case 'external_result':
+      return `trigger:external_result:${record.waitFor.operationId}`;
+    case 'scheduled_wake':
+      return `trigger:scheduled_wake:${record.waitFor.wakeUpId ?? record.id}`;
+    case 'user_reply':
+      return record.waitFor.correlationKey
+        ? `trigger:user_reply:${record.waitFor.correlationKey}`
+        : undefined;
+  }
+}
+
+export function resumeTriggerIndexKey(trigger: ContinuationResumeTrigger): string {
+  switch (trigger.type) {
+    case 'approval_resolution':
+      return `trigger:approval_resolution:${trigger.approvalId}`;
+    case 'external_result':
+      return `trigger:external_result:${trigger.operationId}`;
+    case 'scheduled_wake':
+      return `trigger:scheduled_wake:${trigger.wakeUpId ?? ''}`;
+    case 'user_reply':
+      return `trigger:user_reply:${trigger.message.id}`;
+  }
+}
+
+function recordKey(continuationId: string): string {
+  return `continuation:${continuationId}`;
+}
+
+function sessionPrefix(sessionId: string): string {
+  return `session:${sessionId}:`;
+}
+
+function sessionKey(sessionId: string, continuationId: string): string {
+  return `${sessionPrefix(sessionId)}${continuationId}`;
+}

--- a/packages/cloudflare-runtime/src/adapters/cf-continuation-store.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-continuation-store.ts
@@ -27,15 +27,29 @@ export class CfContinuationStore implements ContinuationStore {
   }
 
   async put(record: ContinuationRecord): Promise<void> {
+    // Read prior record so we can detect waitFor changes that invalidate the
+    // existing trigger index entry. Without this, an update that changes the
+    // trigger key would leave the old key still pointing at this record, and
+    // findByTrigger could return a stale match for an unrelated trigger.
+    const prior = await this.storage.get<ContinuationRecord>(recordKey(record.id));
+
     await this.storage.put(recordKey(record.id), record);
 
     if (record.sessionId) {
       await this.storage.put(sessionKey(record.sessionId, record.id), record.id);
     }
 
-    const triggerKey = continuationTriggerIndexKey(record);
-    if (triggerKey) {
-      await this.triggerIndex?.put(triggerKey, record.id);
+    const newTriggerKey = continuationTriggerIndexKey(record);
+    const priorTriggerKey = prior ? continuationTriggerIndexKey(prior) : undefined;
+
+    if (priorTriggerKey && priorTriggerKey !== newTriggerKey) {
+      // Old trigger no longer matches the record — clear it so findByTrigger
+      // can't resolve a now-incorrect continuation.
+      await this.triggerIndex?.delete(priorTriggerKey);
+    }
+
+    if (newTriggerKey) {
+      await this.triggerIndex?.put(newTriggerKey, record.id);
     }
   }
 
@@ -70,7 +84,19 @@ export class CfContinuationStore implements ContinuationStore {
       return null;
     }
 
-    const continuationId = await this.triggerIndex.get(resumeTriggerIndexKey(trigger));
+    const key = resumeTriggerIndexKey(trigger);
+    if (!key) {
+      // user_reply triggers have no symmetric correlation field today; the
+      // upstream ContinuationResumeTrigger user_reply variant carries
+      // `message: HarnessUserMessage` while the waitFor side keys on
+      // `correlationKey?: string`. Until the trigger shape carries a
+      // correlationKey, findByTrigger can't resolve user_reply lookups via
+      // the KV index — callers should use listBySession or extend the
+      // trigger themselves. Return null explicitly rather than synthesize
+      // a key that would never match.
+      return null;
+    }
+    const continuationId = await this.triggerIndex.get(key);
     return continuationId ? this.get(continuationId) : null;
   }
 }
@@ -82,7 +108,13 @@ export function continuationTriggerIndexKey(record: ContinuationRecord): string 
     case 'external_result':
       return `trigger:external_result:${record.waitFor.operationId}`;
     case 'scheduled_wake':
-      return `trigger:scheduled_wake:${record.waitFor.wakeUpId ?? record.id}`;
+      // Only emit a key when wakeUpId is present so create-side and resume-
+      // side stay symmetric. If wakeUpId is absent, the trigger has nothing
+      // to look up against — findByTrigger returns null rather than match a
+      // wrong record.
+      return record.waitFor.wakeUpId
+        ? `trigger:scheduled_wake:${record.waitFor.wakeUpId}`
+        : undefined;
     case 'user_reply':
       return record.waitFor.correlationKey
         ? `trigger:user_reply:${record.waitFor.correlationKey}`
@@ -90,16 +122,31 @@ export function continuationTriggerIndexKey(record: ContinuationRecord): string 
   }
 }
 
-export function resumeTriggerIndexKey(trigger: ContinuationResumeTrigger): string {
+// Returns the KV index key for a resume trigger, or `undefined` when the
+// trigger type doesn't carry enough information to form a key that matches
+// what `continuationTriggerIndexKey` produced at create time. The two
+// functions are symmetric: a trigger that returns `undefined` here would
+// have produced `undefined` from `continuationTriggerIndexKey` too, so
+// findByTrigger correctly returns null instead of false-matching.
+export function resumeTriggerIndexKey(
+  trigger: ContinuationResumeTrigger,
+): string | undefined {
   switch (trigger.type) {
     case 'approval_resolution':
       return `trigger:approval_resolution:${trigger.approvalId}`;
     case 'external_result':
       return `trigger:external_result:${trigger.operationId}`;
     case 'scheduled_wake':
-      return `trigger:scheduled_wake:${trigger.wakeUpId ?? ''}`;
+      return trigger.wakeUpId
+        ? `trigger:scheduled_wake:${trigger.wakeUpId}`
+        : undefined;
     case 'user_reply':
-      return `trigger:user_reply:${trigger.message.id}`;
+      // Upstream ContinuationResumeTrigger user_reply variant has no
+      // correlationKey. continuationTriggerIndexKey only emits a key when
+      // record.waitFor.correlationKey is set, so the only safe behavior is
+      // to refuse to synthesize a key from message.id (which would never
+      // match the create-side key).
+      return undefined;
   }
 }
 

--- a/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.test.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.test.ts
@@ -63,4 +63,51 @@ describe('CfDeliveryAdapter', () => {
 
     expect(seen).toEqual(['slack', 'github', 'a2a-callback']);
   });
+
+  it('returns failure when the matching handler is not registered', async () => {
+    const adapter = new CfDeliveryAdapter({});
+
+    expect(await adapter.deliver(makeInput('slack'))).toEqual({
+      delivered: false,
+      failureReason: 'no_slack_handler',
+    });
+    expect(await adapter.deliver(makeInput('github'))).toEqual({
+      delivered: false,
+      failureReason: 'no_github_handler',
+    });
+    expect(await adapter.deliver(makeInput('a2a-callback'))).toEqual({
+      delivered: false,
+      failureReason: 'no_a2a_callback_handler',
+    });
+  });
+
+  it('returns failure for unknown target kinds', async () => {
+    const adapter = new CfDeliveryAdapter({
+      slack: () => undefined,
+    });
+    const input = makeInput('slack');
+    // Force the target into an unknown kind that still has a kind field —
+    // simulates a future delivery target that the adapter doesn't yet understand.
+    (input.continuation.delivery.target as { kind: string }).kind = 'unknown-future-channel';
+
+    const result = await adapter.deliver(input);
+    expect(result).toEqual({
+      delivered: false,
+      failureReason: 'unsupported_target_kind:unknown-future-channel',
+    });
+  });
+
+  it('still surfaces handler exceptions as failure (not delivered:true)', async () => {
+    const adapter = new CfDeliveryAdapter({
+      slack: () => {
+        throw new Error('upstream slack 500');
+      },
+    });
+
+    const result = await adapter.deliver(makeInput('slack'));
+    expect(result).toEqual({
+      delivered: false,
+      failureReason: 'upstream slack 500',
+    });
+  });
 });

--- a/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.test.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.test.ts
@@ -1,0 +1,66 @@
+import type { ContinuationDeliveryInput } from '@agent-assistant/continuation';
+import { describe, expect, it } from 'vitest';
+
+import { CfDeliveryAdapter } from './cf-delivery-adapter.js';
+
+function makeInput(kind: 'slack' | 'github' | 'a2a-callback'): ContinuationDeliveryInput {
+  return {
+    continuation: {
+      id: 'cont-1',
+      assistantId: 'sage',
+      origin: {
+        turnId: 'turn-1',
+        outcome: 'deferred',
+        stopReason: 'runtime_error',
+        createdAt: '2026-04-24T00:00:00.000Z',
+      },
+      status: 'completed',
+      waitFor: { type: 'external_result', operationId: 'op-1' },
+      continuation: {},
+      delivery: {
+        status: 'pending_delivery',
+        target: kind === 'slack'
+          ? { kind, channel: 'C123' }
+          : kind === 'github'
+            ? { kind, repository: 'owner/repo', issueNumber: 1 }
+            : { kind, url: 'https://example.test/callback' },
+      },
+      bounds: {
+        expiresAt: '2026-04-25T00:00:00.000Z',
+        maxResumeAttempts: 3,
+        resumeAttempts: 0,
+      },
+      createdAt: '2026-04-24T00:00:00.000Z',
+      updatedAt: '2026-04-24T00:00:00.000Z',
+    },
+    harnessResult: {
+      outcome: 'completed',
+      stopReason: 'answer_finalized',
+      turnId: 'turn-2',
+      traceSummary: {
+        iterationCount: 1,
+        toolCallCount: 0,
+        hadContinuation: false,
+        finalEventType: 'turn_finished',
+      },
+      usage: { modelCalls: 0, toolCalls: 0 },
+    },
+  };
+}
+
+describe('CfDeliveryAdapter', () => {
+  it('dispatches by target kind', async () => {
+    const seen: string[] = [];
+    const adapter = new CfDeliveryAdapter({
+      slack: () => { seen.push('slack'); },
+      github: () => { seen.push('github'); },
+      a2aCallback: () => { seen.push('a2a-callback'); },
+    });
+
+    await adapter.deliver(makeInput('slack'));
+    await adapter.deliver(makeInput('github'));
+    await adapter.deliver(makeInput('a2a-callback'));
+
+    expect(seen).toEqual(['slack', 'github', 'a2a-callback']);
+  });
+});

--- a/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.ts
@@ -1,0 +1,46 @@
+import type {
+  ContinuationDeliveryAdapter,
+  ContinuationDeliveryInput,
+  ContinuationDeliveryResult,
+} from '@agent-assistant/continuation';
+
+export type CfDeliveryTarget =
+  | ({ kind: 'slack'; channel: string; text?: string } & Record<string, unknown>)
+  | ({ kind: 'github'; repository: string; issueNumber: number; body?: string } & Record<string, unknown>)
+  | ({ kind: 'a2a-callback'; url: string; payload?: unknown } & Record<string, unknown>);
+
+export interface CfDeliveryAdapterOptions {
+  slack?: (target: Extract<CfDeliveryTarget, { kind: 'slack' }>, input: ContinuationDeliveryInput) => Promise<void> | void;
+  github?: (target: Extract<CfDeliveryTarget, { kind: 'github' }>, input: ContinuationDeliveryInput) => Promise<void> | void;
+  a2aCallback?: (target: Extract<CfDeliveryTarget, { kind: 'a2a-callback' }>, input: ContinuationDeliveryInput) => Promise<void> | void;
+}
+
+export class CfDeliveryAdapter implements ContinuationDeliveryAdapter {
+  constructor(private readonly options: CfDeliveryAdapterOptions = {}) {}
+
+  async deliver(input: ContinuationDeliveryInput): Promise<ContinuationDeliveryResult> {
+    const target = input.continuation.delivery.target as CfDeliveryTarget | undefined;
+    if (!target?.kind) {
+      return { delivered: false, failureReason: 'missing_delivery_target' };
+    }
+
+    try {
+      switch (target.kind) {
+        case 'slack':
+          await this.options.slack?.(target, input);
+          return { delivered: true };
+        case 'github':
+          await this.options.github?.(target, input);
+          return { delivered: true };
+        case 'a2a-callback':
+          await this.options.a2aCallback?.(target, input);
+          return { delivered: true };
+      }
+    } catch (error) {
+      return {
+        delivered: false,
+        failureReason: error instanceof Error ? error.message : 'delivery_failed',
+      };
+    }
+  }
+}

--- a/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-delivery-adapter.ts
@@ -27,14 +27,31 @@ export class CfDeliveryAdapter implements ContinuationDeliveryAdapter {
     try {
       switch (target.kind) {
         case 'slack':
-          await this.options.slack?.(target, input);
+          if (!this.options.slack) {
+            return { delivered: false, failureReason: 'no_slack_handler' };
+          }
+          await this.options.slack(target, input);
           return { delivered: true };
         case 'github':
-          await this.options.github?.(target, input);
+          if (!this.options.github) {
+            return { delivered: false, failureReason: 'no_github_handler' };
+          }
+          await this.options.github(target, input);
           return { delivered: true };
         case 'a2a-callback':
-          await this.options.a2aCallback?.(target, input);
+          if (!this.options.a2aCallback) {
+            return { delivered: false, failureReason: 'no_a2a_callback_handler' };
+          }
+          await this.options.a2aCallback(target, input);
           return { delivered: true };
+        default: {
+          // Unknown / future delivery target kind. Don't silently succeed.
+          const unknownKind = (target as { kind?: string }).kind;
+          return {
+            delivered: false,
+            failureReason: `unsupported_target_kind:${unknownKind ?? 'unknown'}`,
+          };
+        }
       }
     } catch (error) {
       return {

--- a/packages/cloudflare-runtime/src/adapters/cf-specialist-client.test.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-specialist-client.test.ts
@@ -1,0 +1,31 @@
+import type { Queue } from '@cloudflare/workers-types';
+import { describe, expect, it } from 'vitest';
+
+import { CfSpecialistClient } from './cf-specialist-client.js';
+import type { TurnQueueMessage } from '../types.js';
+
+describe('CfSpecialistClient', () => {
+  it('enqueues specialist calls and results', async () => {
+    const sent: TurnQueueMessage[] = [];
+    const client = new CfSpecialistClient({
+      async send(message: TurnQueueMessage) {
+        sent.push(message);
+      },
+    } as Queue<TurnQueueMessage>);
+    const trigger = {
+      type: 'external_result',
+      operationId: 'specialist_result:turn-1',
+      resolvedAt: '2026-04-24T00:00:00.000Z',
+    } as const;
+
+    await client.callSpecialist({
+      turnId: 'turn-1',
+      capability: 'github',
+      input: { query: 'status' },
+      callbackTrigger: trigger,
+    });
+    await client.publishResult({ callbackTrigger: trigger, result: { ok: true } });
+
+    expect(sent.map((message) => message.type)).toEqual(['specialist_call', 'specialist_result']);
+  });
+});

--- a/packages/cloudflare-runtime/src/adapters/cf-specialist-client.ts
+++ b/packages/cloudflare-runtime/src/adapters/cf-specialist-client.ts
@@ -1,0 +1,43 @@
+import type { Queue } from '@cloudflare/workers-types';
+import type { ContinuationResumeTrigger } from '@agent-assistant/continuation';
+
+import type { TurnQueueMessage } from '../types.js';
+
+export interface SpecialistCallInput {
+  turnId: string;
+  capability: string;
+  input: unknown;
+  callbackTrigger: ContinuationResumeTrigger;
+}
+
+export interface SpecialistResultInput {
+  callbackTrigger: ContinuationResumeTrigger;
+  result: unknown;
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+export class CfSpecialistClient {
+  constructor(private readonly queue: Queue<TurnQueueMessage>) {}
+
+  async callSpecialist(input: SpecialistCallInput): Promise<void> {
+    await this.queue.send({
+      type: 'specialist_call',
+      turnId: input.turnId,
+      capability: input.capability,
+      input: input.input,
+      callbackTrigger: input.callbackTrigger,
+    });
+  }
+
+  async publishResult(input: SpecialistResultInput): Promise<void> {
+    await this.queue.send({
+      type: 'specialist_result',
+      callbackTrigger: input.callbackTrigger,
+      result: input.result,
+      error: input.error,
+    });
+  }
+}

--- a/packages/cloudflare-runtime/src/do/turn-executor-do.test.ts
+++ b/packages/cloudflare-runtime/src/do/turn-executor-do.test.ts
@@ -1,0 +1,42 @@
+import type { DurableObjectState, ExecutionContext } from '@cloudflare/workers-types';
+import { describe, expect, it } from 'vitest';
+
+import { TurnExecutorDO } from './turn-executor-do.js';
+import type { TurnQueueMessage } from '../types.js';
+
+const state = {} as DurableObjectState;
+
+function makeMessage(receivedAt: string): TurnQueueMessage {
+  return {
+    type: 'webhook',
+    provider: 'slack',
+    descriptor: { channel: 'C123', text: 'hello' },
+    receivedAt,
+  };
+}
+
+describe('TurnExecutorDO', () => {
+  it('serializes turn execution and awaits waitUntil work', async () => {
+    const events: string[] = [];
+
+    class TestDO extends TurnExecutorDO {
+      protected override async runTurn(message: TurnQueueMessage, ctx: ExecutionContext) {
+        events.push(`start:${message.type === 'webhook' ? message.receivedAt : 'other'}`);
+        ctx.waitUntil(
+          Promise.resolve().then(() => {
+            events.push(`wait:${message.type === 'webhook' ? message.receivedAt : 'other'}`);
+          }),
+        );
+      }
+    }
+
+    const durableObject = new TestDO(state, {});
+
+    await Promise.all([
+      durableObject.runSerialized(makeMessage('1')),
+      durableObject.runSerialized(makeMessage('2')),
+    ]);
+
+    expect(events).toEqual(['start:1', 'wait:1', 'start:2', 'wait:2']);
+  });
+});

--- a/packages/cloudflare-runtime/src/do/turn-executor-do.ts
+++ b/packages/cloudflare-runtime/src/do/turn-executor-do.ts
@@ -1,0 +1,54 @@
+import type { DurableObjectState, ExecutionContext } from '@cloudflare/workers-types';
+
+import type { TurnQueueMessage } from '../types.js';
+import { createFakeExecutionContext } from '../executor/fake-execution-context.js';
+
+export interface TurnExecutorDORequest<Message extends TurnQueueMessage = TurnQueueMessage> {
+  message: Message;
+}
+
+export abstract class TurnExecutorDO<
+  Env = unknown,
+  Message extends TurnQueueMessage = TurnQueueMessage,
+> {
+  private tail: Promise<void> = Promise.resolve();
+
+  protected constructor(
+    protected readonly state: DurableObjectState,
+    protected readonly env: Env,
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+
+    const payload = await request.json() as TurnExecutorDORequest<Message>;
+    await this.enqueue(payload.message);
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    });
+  }
+
+  async runSerialized(message: Message): Promise<void> {
+    await this.enqueue(message);
+  }
+
+  protected abstract runTurn(
+    message: Message,
+    ctx: ExecutionContext,
+  ): Promise<void> | void;
+
+  private async enqueue(message: Message): Promise<void> {
+    const run = this.tail.then(async () => {
+      const fake = createFakeExecutionContext();
+      await this.runTurn(message, fake.ctx);
+      await fake.settleAll();
+    });
+
+    this.tail = run.catch(() => undefined);
+    await run;
+  }
+}

--- a/packages/cloudflare-runtime/src/executor/cf-turn-executor.test.ts
+++ b/packages/cloudflare-runtime/src/executor/cf-turn-executor.test.ts
@@ -1,0 +1,59 @@
+import type { ExecutionContext } from '@cloudflare/workers-types';
+import { describe, expect, it } from 'vitest';
+
+import { handleCfQueue, type CfQueueBatch } from './cf-turn-executor.js';
+import type { TurnQueueMessage } from '../types.js';
+
+function makeCtx(): ExecutionContext {
+  return {
+    waitUntil() {},
+    passThroughOnException() {},
+    props: undefined,
+  };
+}
+
+function makeMessage(): TurnQueueMessage {
+  return {
+    type: 'webhook',
+    provider: 'slack',
+    descriptor: { channel: 'C123', text: 'hello' },
+    receivedAt: '2026-04-24T00:00:00.000Z',
+  };
+}
+
+describe('handleCfQueue', () => {
+  it('awaits promises registered with waitUntil before acking', async () => {
+    const events: string[] = [];
+    let acked = false;
+    const batch: CfQueueBatch<TurnQueueMessage> = {
+      messages: [{ body: makeMessage(), ack: () => { acked = true; } }],
+    };
+
+    await handleCfQueue(batch, {}, makeCtx(), {
+      runTurn(_message, _env, ctx) {
+        ctx.waitUntil(Promise.resolve().then(() => events.push('waitUntil')));
+        events.push('runTurn');
+      },
+    });
+
+    expect(events).toEqual(['runTurn', 'waitUntil']);
+    expect(acked).toBe(true);
+  });
+
+  it('propagates waitUntil rejections so the queue retries', async () => {
+    let retried = false;
+    const batch: CfQueueBatch<TurnQueueMessage> = {
+      messages: [{ body: makeMessage(), retry: () => { retried = true; } }],
+    };
+
+    await expect(
+      handleCfQueue(batch, {}, makeCtx(), {
+        runTurn(_message, _env, ctx) {
+          ctx.waitUntil(Promise.reject(new Error('failed async turn work')));
+        },
+      }),
+    ).rejects.toThrow('failed async turn work');
+
+    expect(retried).toBe(true);
+  });
+});

--- a/packages/cloudflare-runtime/src/executor/cf-turn-executor.ts
+++ b/packages/cloudflare-runtime/src/executor/cf-turn-executor.ts
@@ -1,6 +1,7 @@
 import type { ExecutionContext } from '@cloudflare/workers-types';
 
 import type { TurnQueueMessage } from '../types.js';
+import { consoleJsonLogger, type CfLogger } from '../observability/index.js';
 import { createFakeExecutionContext } from './fake-execution-context.js';
 
 export interface CfQueueMessage<Body> {
@@ -24,6 +25,12 @@ export interface CfTurnExecutorOptions<
     env: Env,
     ctx: ExecutionContext,
   ): Promise<void> | void;
+  // Persona-injectable logger. Defaults to consoleJsonLogger.
+  logger?: CfLogger;
+  // Optional correlation-id extractor. If provided, every log line for a
+  // message includes the result as `turnId`. Useful for greppable per-turn
+  // tracing across ingress, executor, and delivery.
+  resolveTurnId?(message: Message): string | undefined;
 }
 
 export async function handleCfQueue<
@@ -35,14 +42,35 @@ export async function handleCfQueue<
   ctx: ExecutionContext,
   options: CfTurnExecutorOptions<Env, Message>,
 ): Promise<void> {
+  const baseLogger = (options.logger ?? consoleJsonLogger).child({
+    component: "cf-turn-executor",
+  });
+  baseLogger.debug("batch received", { count: batch.messages.length });
+
   for (const message of batch.messages) {
+    const turnId = options.resolveTurnId?.(message.body);
+    const log = baseLogger.child({
+      messageType: (message.body as { type?: string })?.type,
+      ...(turnId ? { turnId } : {}),
+    });
     const fake = createFakeExecutionContext();
+    const startedAt = Date.now();
 
     try {
+      log.debug("dispatch start");
       await options.runTurn(message.body, env, fake.ctx);
+      const pendingBeforeSettle = fake.pendingCount?.() ?? 0;
       await fake.settleAll();
       message.ack?.();
+      log.info("dispatch complete", {
+        durationMs: Date.now() - startedAt,
+        waitUntilCount: pendingBeforeSettle,
+      });
     } catch (error) {
+      log.error("dispatch failed", {
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+      });
       await options.onMessageError?.(error, message, env, ctx);
       message.retry?.();
       throw error;

--- a/packages/cloudflare-runtime/src/executor/cf-turn-executor.ts
+++ b/packages/cloudflare-runtime/src/executor/cf-turn-executor.ts
@@ -1,0 +1,64 @@
+import type { ExecutionContext } from '@cloudflare/workers-types';
+
+import type { TurnQueueMessage } from '../types.js';
+import { createFakeExecutionContext } from './fake-execution-context.js';
+
+export interface CfQueueMessage<Body> {
+  body: Body;
+  ack?(): void;
+  retry?(options?: { delaySeconds?: number }): void;
+}
+
+export interface CfQueueBatch<Body> {
+  messages: CfQueueMessage<Body>[];
+}
+
+export interface CfTurnExecutorOptions<
+  Env,
+  Message extends TurnQueueMessage = TurnQueueMessage,
+> {
+  runTurn(message: Message, env: Env, ctx: ExecutionContext): Promise<void> | void;
+  onMessageError?(
+    error: unknown,
+    message: CfQueueMessage<Message>,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> | void;
+}
+
+export async function handleCfQueue<
+  Env,
+  Message extends TurnQueueMessage = TurnQueueMessage,
+>(
+  batch: CfQueueBatch<Message>,
+  env: Env,
+  ctx: ExecutionContext,
+  options: CfTurnExecutorOptions<Env, Message>,
+): Promise<void> {
+  for (const message of batch.messages) {
+    const fake = createFakeExecutionContext();
+
+    try {
+      await options.runTurn(message.body, env, fake.ctx);
+      await fake.settleAll();
+      message.ack?.();
+    } catch (error) {
+      await options.onMessageError?.(error, message, env, ctx);
+      message.retry?.();
+      throw error;
+    }
+  }
+}
+
+export function createCfTurnExecutor<
+  Env,
+  Message extends TurnQueueMessage = TurnQueueMessage,
+>(
+  options: CfTurnExecutorOptions<Env, Message>,
+): (
+  batch: CfQueueBatch<Message>,
+  env: Env,
+  ctx: ExecutionContext,
+) => Promise<void> {
+  return (batch, env, ctx) => handleCfQueue(batch, env, ctx, options);
+}

--- a/packages/cloudflare-runtime/src/executor/fake-execution-context.test.ts
+++ b/packages/cloudflare-runtime/src/executor/fake-execution-context.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFakeExecutionContext } from './fake-execution-context.js';
+
+describe('createFakeExecutionContext', () => {
+  it('resolves pushed promises in order', async () => {
+    const fake = createFakeExecutionContext();
+    const resolved: number[] = [];
+
+    fake.ctx.waitUntil(Promise.resolve().then(() => resolved.push(1)));
+    fake.ctx.waitUntil(Promise.resolve().then(() => resolved.push(2)));
+
+    await fake.settleAll();
+
+    expect(resolved).toEqual([1, 2]);
+    expect(fake.pendingCount()).toBe(0);
+    expect(fake.settledCount()).toBe(2);
+  });
+
+  it('awaits promises registered during settling', async () => {
+    const fake = createFakeExecutionContext();
+    const resolved: string[] = [];
+
+    fake.ctx.waitUntil(
+      Promise.resolve().then(() => {
+        resolved.push('first');
+        fake.ctx.waitUntil(Promise.resolve().then(() => resolved.push('second')));
+      }),
+    );
+
+    await fake.settleAll();
+
+    expect(resolved).toEqual(['first', 'second']);
+    expect(fake.pendingCount()).toBe(0);
+    expect(fake.settledCount()).toBe(2);
+  });
+
+  it('surfaces waitUntil promise rejections', async () => {
+    const fake = createFakeExecutionContext();
+    const error = new Error('boom');
+
+    fake.ctx.waitUntil(Promise.reject(error));
+
+    await expect(fake.settleAll()).rejects.toThrow(error);
+  });
+});

--- a/packages/cloudflare-runtime/src/executor/fake-execution-context.ts
+++ b/packages/cloudflare-runtime/src/executor/fake-execution-context.ts
@@ -1,0 +1,43 @@
+import type { ExecutionContext } from '@cloudflare/workers-types';
+
+export interface FakeExecutionContextController {
+  ctx: ExecutionContext;
+  settleAll(): Promise<void>;
+  pendingCount(): number;
+  settledCount(): number;
+}
+
+export function createFakeExecutionContext(): FakeExecutionContextController {
+  const pending: Promise<unknown>[] = [];
+  let settled = 0;
+
+  const ctx: ExecutionContext = {
+    waitUntil(promise) {
+      pending.push(Promise.resolve(promise));
+    },
+    passThroughOnException() {
+      // Queue consumers do not need Cloudflare's exception passthrough hook.
+    },
+    props: undefined,
+  };
+
+  return {
+    ctx,
+    async settleAll() {
+      while (pending.length > 0) {
+        const next = pending.shift();
+        if (!next) {
+          continue;
+        }
+        await next;
+        settled += 1;
+      }
+    },
+    pendingCount() {
+      return pending.length;
+    },
+    settledCount() {
+      return settled;
+    },
+  };
+}

--- a/packages/cloudflare-runtime/src/index.test.ts
+++ b/packages/cloudflare-runtime/src/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { handleCfQueue, handleCfTurnQueue } from './index.js';
+import { handleCfQueue as executorHandleCfQueue } from './executor/cf-turn-executor.js';
+
+describe('package entrypoints', () => {
+  it('exports the real queue executor as handleCfQueue', () => {
+    expect(handleCfQueue).toBe(executorHandleCfQueue);
+  });
+
+  it('keeps handleCfTurnQueue as an alias of the same executor', () => {
+    expect(handleCfTurnQueue).toBe(executorHandleCfQueue);
+  });
+});

--- a/packages/cloudflare-runtime/src/index.ts
+++ b/packages/cloudflare-runtime/src/index.ts
@@ -80,3 +80,14 @@ export type {
   WebhookQueueMessage,
   ResumeQueueMessage,
 } from './types.js';
+export {
+  consoleJsonLogger,
+  createConsoleJsonLogger,
+  nullLogger,
+  createCapturingLogger,
+} from './observability/index.js';
+export type {
+  CfLogger,
+  LogLevel,
+  CapturedLogRecord,
+} from './observability/index.js';

--- a/packages/cloudflare-runtime/src/index.ts
+++ b/packages/cloudflare-runtime/src/index.ts
@@ -1,0 +1,82 @@
+export {
+  CfIngressConfigurationError,
+  handleCfQueue,
+  wrapCloudflareWorker,
+} from './ingress/cf-ingress.js';
+export type {
+  CfIngressOptions,
+  ParseResult,
+  WebhookRouteConfig,
+} from './ingress/cf-ingress.js';
+export {
+  verifySlackSignature,
+} from './ingress/signature/slack.js';
+export type {
+  VerifyResult as SlackVerifyResult,
+} from './ingress/signature/slack.js';
+export {
+  verifyGitHubSignature,
+} from './ingress/signature/github.js';
+export type {
+  VerifyResult as GitHubVerifyResult,
+} from './ingress/signature/github.js';
+export {
+  createFakeExecutionContext,
+} from './executor/fake-execution-context.js';
+export type {
+  FakeExecutionContextController,
+} from './executor/fake-execution-context.js';
+export {
+  createCfTurnExecutor,
+  handleCfQueue as handleCfTurnQueue,
+} from './executor/cf-turn-executor.js';
+export type {
+  CfQueueBatch,
+  CfQueueMessage,
+  CfTurnExecutorOptions,
+} from './executor/cf-turn-executor.js';
+export {
+  TurnExecutorDO,
+} from './do/turn-executor-do.js';
+export type {
+  TurnExecutorDORequest,
+} from './do/turn-executor-do.js';
+export {
+  CfContinuationStore,
+  continuationTriggerIndexKey,
+  resumeTriggerIndexKey,
+} from './adapters/cf-continuation-store.js';
+export type {
+  CfContinuationStoreOptions,
+  DurableObjectStorageLike,
+} from './adapters/cf-continuation-store.js';
+export {
+  CfContinuationScheduler,
+} from './adapters/cf-continuation-scheduler.js';
+export type {
+  AlarmStorageLike,
+  CfContinuationSchedulerOptions,
+} from './adapters/cf-continuation-scheduler.js';
+export {
+  CfDeliveryAdapter,
+} from './adapters/cf-delivery-adapter.js';
+export type {
+  CfDeliveryAdapterOptions,
+  CfDeliveryTarget,
+} from './adapters/cf-delivery-adapter.js';
+export {
+  CfSpecialistClient,
+} from './adapters/cf-specialist-client.js';
+export type {
+  SpecialistCallInput,
+  SpecialistResultInput,
+} from './adapters/cf-specialist-client.js';
+export type {
+  CfBindingsShape,
+  SpecialistCallQueueMessage,
+  SpecialistResultQueueMessage,
+  TurnQueueMessage,
+  TurnQueueProvider,
+  WebhookQueueMessage,
+  ResumeQueueMessage,
+} from './types.js';

--- a/packages/cloudflare-runtime/src/index.ts
+++ b/packages/cloudflare-runtime/src/index.ts
@@ -1,6 +1,5 @@
 export {
   CfIngressConfigurationError,
-  handleCfQueue,
   wrapCloudflareWorker,
 } from './ingress/cf-ingress.js';
 export type {
@@ -28,6 +27,7 @@ export type {
 } from './executor/fake-execution-context.js';
 export {
   createCfTurnExecutor,
+  handleCfQueue,
   handleCfQueue as handleCfTurnQueue,
 } from './executor/cf-turn-executor.js';
 export type {

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.test.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CfIngressConfigurationError,
+  wrapCloudflareWorker,
+  type ParseResult,
+} from "./cf-ingress.js";
+
+type TestEnv = {
+  TURN_QUEUE: { send: ReturnType<typeof vi.fn> };
+  DEDUP: InMemoryKv;
+};
+
+class InMemoryKv {
+  readonly values = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+}
+
+function createEnv(): TestEnv {
+  return {
+    TURN_QUEUE: { send: vi.fn(async () => undefined) },
+    DEDUP: new InMemoryKv(),
+  };
+}
+
+function request(path = "/api/webhooks/slack", init?: RequestInit): Request {
+  return new Request(`https://example.test${path}`, init);
+}
+
+function dispatchResult(): ParseResult {
+  return {
+    kind: "dispatch",
+    response: new Response("accepted", { status: 200 }),
+    turn: { id: "turn_123", text: "hello" },
+    dedupKey: { eventId: "Ev123", ts: "1700000000.000100" },
+  };
+}
+
+function verifiedSlackRoute(parse = vi.fn(async () => dispatchResult())) {
+  return {
+    provider: "slack" as const,
+    verify: vi.fn(async () => ({ ok: true as const })),
+    parse,
+  };
+}
+
+describe("wrapCloudflareWorker", () => {
+  it("verifies, parses, dedups, enqueues, and returns the persona response", async () => {
+    const env = createEnv();
+    const verify = vi.fn(async () => ({ ok: true as const }));
+    const parse = vi.fn(async () => dispatchResult());
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/slack": { provider: "slack", verify, parse },
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    const response = await worker.fetch?.(request(), env, {} as ExecutionContext);
+
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("accepted");
+    expect(verify).toHaveBeenCalledTimes(1);
+    expect(parse).toHaveBeenCalledTimes(1);
+    expect(env.TURN_QUEUE.send).toHaveBeenCalledTimes(1);
+    expect(env.TURN_QUEUE.send).toHaveBeenCalledWith({
+      type: "webhook",
+      provider: "slack",
+      descriptor: { id: "turn_123", text: "hello" },
+      receivedAt: expect.any(String),
+    });
+    expect(env.DEDUP.values.get("Ev123")).toBe("1");
+  });
+
+  it("returns 401 without parsing, deduping, or enqueueing when verification fails", async () => {
+    const env = createEnv();
+    const verify = vi.fn(async () => ({ ok: false as const, reason: "bad_signature" }));
+    const parse = vi.fn(async () => dispatchResult());
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/slack": { provider: "slack", verify, parse },
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    const response = await worker.fetch?.(request(), env, {} as ExecutionContext);
+
+    expect(response?.status).toBe(401);
+    expect(parse).not.toHaveBeenCalled();
+    expect(env.TURN_QUEUE.send).not.toHaveBeenCalled();
+    expect(env.DEDUP.values.size).toBe(0);
+  });
+
+  it("returns ack responses without deduping or enqueueing", async () => {
+    const env = createEnv();
+    const parse = vi.fn(async (): Promise<ParseResult> => ({
+      kind: "ack",
+      response: new Response("challenge", { status: 200 }),
+    }));
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/slack": verifiedSlackRoute(parse),
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    const response = await worker.fetch?.(request(), env, {} as ExecutionContext);
+
+    expect(response?.status).toBe(200);
+    expect(await response?.text()).toBe("challenge");
+    expect(env.TURN_QUEUE.send).not.toHaveBeenCalled();
+    expect(env.DEDUP.values.size).toBe(0);
+  });
+
+  it("dedups repeated Slack event ids at ingress and enqueues once", async () => {
+    const env = createEnv();
+    const parse = vi.fn(async () => dispatchResult());
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/slack": verifiedSlackRoute(parse),
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    const first = await worker.fetch?.(request(), env, {} as ExecutionContext);
+    const second = await worker.fetch?.(request(), env, {} as ExecutionContext);
+
+    expect(first?.status).toBe(200);
+    expect(second?.status).toBe(200);
+    expect(parse).toHaveBeenCalledTimes(2);
+    expect(env.TURN_QUEUE.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates queue send failures so the platform can retry", async () => {
+    const env = createEnv();
+    env.TURN_QUEUE.send.mockRejectedValueOnce(new Error("queue unavailable"));
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/slack": verifiedSlackRoute(vi.fn(async () => dispatchResult())),
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    await expect(worker.fetch?.(request(), env, {} as ExecutionContext)).rejects.toThrow(
+      "queue unavailable",
+    );
+  });
+
+  it("falls back to the inner worker for non-webhook routes", async () => {
+    const env = createEnv();
+    const innerFetch = vi.fn(async () => new Response("inner", { status: 200 }));
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {},
+      inner: { fetch: innerFetch },
+      queueBinding: "TURN_QUEUE",
+    });
+
+    const response = await worker.fetch?.(request("/health"), env, {} as ExecutionContext);
+
+    expect(response?.status).toBe(200);
+    expect(innerFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails loud when a Slack route is missing signature verification", () => {
+    expect(() =>
+      wrapCloudflareWorker<TestEnv>({
+        webhookRoutes: {
+          "/api/webhooks/slack": { provider: "slack", parse: vi.fn(async () => dispatchResult()) },
+        },
+        queueBinding: "TURN_QUEUE",
+        dedupBinding: "DEDUP",
+      }),
+    ).toThrow(CfIngressConfigurationError);
+  });
+
+  it("fails loud when ingress dedup storage is not configured", () => {
+    expect(() =>
+      wrapCloudflareWorker<TestEnv>({
+        webhookRoutes: {
+          "/api/webhooks/slack": {
+            provider: "slack",
+            verify: vi.fn(async () => ({ ok: true as const })),
+            parse: vi.fn(async () => dispatchResult()),
+          },
+        },
+        queueBinding: "TURN_QUEUE",
+      }),
+    ).toThrow(CfIngressConfigurationError);
+  });
+});

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.test.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.test.ts
@@ -198,4 +198,51 @@ describe("wrapCloudflareWorker", () => {
       }),
     ).toThrow(CfIngressConfigurationError);
   });
+
+  it("dedups nango webhooks via the persona-supplied dedupKey (no Slack fall-through)", async () => {
+    const env = createEnv();
+    const parse = vi.fn(async (): Promise<ParseResult> => ({
+      kind: "dispatch",
+      response: new Response("accepted", { status: 200 }),
+      turn: { id: "n-1" },
+      dedupKey: { eventId: "nango-delivery-abc" },
+    }));
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/nango": { provider: "nango", parse },
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    await worker.fetch?.(request("/api/webhooks/nango"), env, {} as ExecutionContext);
+    await worker.fetch?.(request("/api/webhooks/nango"), env, {} as ExecutionContext);
+
+    // Second delivery with the same persona-supplied dedup key is skipped —
+    // proves dedup runs for nango (regression: previously fell through to
+    // Slack-shaped extraction which silently returned undefined and skipped).
+    expect(env.TURN_QUEUE.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dedup nango when the persona supplies no dedupKey", async () => {
+    const env = createEnv();
+    const parse = vi.fn(async (): Promise<ParseResult> => ({
+      kind: "dispatch",
+      response: new Response("accepted", { status: 200 }),
+      turn: { id: "n-1" },
+      // No dedupKey — persona explicitly opts out.
+    }));
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {
+        "/api/webhooks/nango": { provider: "nango", parse },
+      },
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+    });
+
+    await worker.fetch?.(request("/api/webhooks/nango"), env, {} as ExecutionContext);
+    await worker.fetch?.(request("/api/webhooks/nango"), env, {} as ExecutionContext);
+
+    expect(env.TURN_QUEUE.send).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.test.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.test.ts
@@ -172,6 +172,15 @@ describe("wrapCloudflareWorker", () => {
     expect(innerFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("does not attach a stub queue handler", () => {
+    const worker = wrapCloudflareWorker<TestEnv>({
+      webhookRoutes: {},
+      queueBinding: "TURN_QUEUE",
+    });
+
+    expect(worker.queue).toBeUndefined();
+  });
+
   it("fails loud when a Slack route is missing signature verification", () => {
     expect(() =>
       wrapCloudflareWorker<TestEnv>({

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
@@ -1,0 +1,169 @@
+import {
+  SlackEventDedupGate,
+  getSlackDeduplicationKey,
+  type SlackEventDedupStore,
+} from "@agent-assistant/surfaces";
+import type {
+  ExecutionContext,
+  KVNamespace,
+  Queue,
+} from "@cloudflare/workers-types";
+
+type MaybePromise<T> = T | Promise<T>;
+
+export interface CfIngressRequest {
+  readonly url: string;
+  readonly headers: Headers;
+  clone(): CfIngressRequest;
+}
+
+export type CfFetchHandler<Env> = (
+  req: CfIngressRequest,
+  env: Env,
+  ctx: ExecutionContext,
+) => MaybePromise<Response>;
+
+export interface CfWorkerHandler<Env> {
+  fetch?: CfFetchHandler<Env>;
+  queue?: (batch: unknown, env: Env, ctx: ExecutionContext) => MaybePromise<void>;
+}
+
+export interface ParseResult {
+  kind: "ack" | "dispatch";
+  response: Response;
+  turn?: unknown;
+  dedupKey?: { eventId?: string; ts?: string };
+}
+
+export interface WebhookRouteConfig<Env> {
+  provider: "slack" | "github" | "nango";
+  verify?: (
+    req: CfIngressRequest,
+    env: Env,
+  ) => Promise<{ ok: true } | { ok: false; reason?: string }>;
+  parse: (req: CfIngressRequest, env: Env) => Promise<ParseResult>;
+}
+
+export interface CfIngressOptions<Env> {
+  webhookRoutes: Record<string, WebhookRouteConfig<Env>>;
+  inner?: { fetch?: CfFetchHandler<Env> };
+  queueBinding: keyof Env & string;
+  dedupBinding?: keyof Env & string;
+  dedupTtlSeconds?: number;
+  continuationBinding?: keyof Env & string;
+  turnExecutorDoBinding?: keyof Env & string;
+}
+
+export class CfIngressConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CfIngressConfigurationError";
+  }
+}
+
+class KvSlackEventDedupStore implements SlackEventDedupStore {
+  constructor(private readonly kv: KVNamespace) {}
+
+  async hasBeenProcessed(key: string): Promise<boolean> {
+    return (await this.kv.get(key)) !== null;
+  }
+
+  async markProcessed(key: string, ttlSeconds: number): Promise<void> {
+    await this.kv.put(key, "1", { expirationTtl: ttlSeconds });
+  }
+}
+
+export function wrapCloudflareWorker<Env>(
+  opts: CfIngressOptions<Env>,
+): CfWorkerHandler<Env> {
+  validateOptions(opts);
+
+  return {
+    async fetch(req, env, ctx) {
+      const route = opts.webhookRoutes[new URL(req.url).pathname];
+      if (!route) {
+        return opts.inner?.fetch?.(req, env, ctx) ?? new Response("Not Found", { status: 404 });
+      }
+
+      const verification = await route.verify?.(req.clone(), env);
+      if (verification && !verification.ok) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      const result = await route.parse(req, env);
+      if (result.kind === "ack") return result.response;
+
+      const shouldDispatch = await shouldDispatchWebhook(req, env, route, result, opts);
+      if (!shouldDispatch) return new Response("OK", { status: 200 });
+
+      const queue = env[opts.queueBinding] as Queue;
+      await queue.send({
+        type: "webhook",
+        provider: route.provider,
+        descriptor: result.turn,
+        receivedAt: new Date().toISOString(),
+      });
+
+      return result.response;
+    },
+
+    queue: handleCfQueue,
+  };
+}
+
+export async function handleCfQueue(): Promise<void> {
+  throw new Error("executor not wired — see W3");
+}
+
+async function shouldDispatchWebhook<Env>(
+  req: CfIngressRequest,
+  env: Env,
+  route: WebhookRouteConfig<Env>,
+  result: ParseResult,
+  opts: CfIngressOptions<Env>,
+): Promise<boolean> {
+  const key = getProviderDedupKey(req, route.provider, result);
+  if (!key) return true;
+
+  if (!opts.dedupBinding) {
+    throw new CfIngressConfigurationError("dedupBinding is required for webhook ingress");
+  }
+  const kv = env[opts.dedupBinding] as KVNamespace;
+  const gate = new SlackEventDedupGate({
+    store: new KvSlackEventDedupStore(kv),
+    ttlSeconds: opts.dedupTtlSeconds,
+  });
+  const decision = await gate.claim({ eventId: key });
+  return decision.proceed;
+}
+
+function getProviderDedupKey<Env>(
+  req: CfIngressRequest,
+  provider: WebhookRouteConfig<Env>["provider"],
+  result: ParseResult,
+): string | undefined {
+  if (provider === "github") {
+    const deliveryId = req.headers.get("x-github-delivery");
+    return deliveryId && deliveryId.length > 0 ? deliveryId : undefined;
+  }
+
+  if (provider === "slack") {
+    return getSlackDeduplicationKey(result.dedupKey ?? {});
+  }
+
+  return getSlackDeduplicationKey(result.dedupKey ?? {});
+}
+
+function validateOptions<Env>(opts: CfIngressOptions<Env>): void {
+  if (Object.keys(opts.webhookRoutes).length > 0 && !opts.dedupBinding) {
+    throw new CfIngressConfigurationError("dedupBinding is required for webhook ingress");
+  }
+
+  for (const [path, route] of Object.entries(opts.webhookRoutes)) {
+    if ((route.provider === "slack" || route.provider === "github") && !route.verify) {
+      throw new CfIngressConfigurationError(
+        `webhook route ${path} requires verify for provider ${route.provider}`,
+      );
+    }
+  }
+}

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
@@ -180,7 +180,13 @@ function getProviderDedupKey<Env>(
     return getSlackDeduplicationKey(result.dedupKey ?? {});
   }
 
-  return getSlackDeduplicationKey(result.dedupKey ?? {});
+  // For nango (and any future provider), the persona's parse() supplies the
+  // dedup key explicitly via result.dedupKey. We do NOT fall back to Slack-
+  // shaped extraction — nango envelopes don't have Slack's eventId/ts fields,
+  // and silently returning undefined would mean dedup is skipped entirely.
+  // Personas wire result.dedupKey from whatever stable header / payload field
+  // their provider exposes (e.g. nango delivery_id).
+  return result.dedupKey?.eventId ?? result.dedupKey?.ts ?? undefined;
 }
 
 function validateOptions<Env>(opts: CfIngressOptions<Env>): void {

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
@@ -130,13 +130,7 @@ export function wrapCloudflareWorker<Env>(
 
       return result.response;
     },
-
-    queue: handleCfQueue,
   };
-}
-
-export async function handleCfQueue(): Promise<void> {
-  throw new Error("executor not wired — see W3");
 }
 
 async function shouldDispatchWebhook<Env>(

--- a/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
+++ b/packages/cloudflare-runtime/src/ingress/cf-ingress.ts
@@ -8,6 +8,7 @@ import type {
   KVNamespace,
   Queue,
 } from "@cloudflare/workers-types";
+import { consoleJsonLogger, type CfLogger } from "../observability/index.js";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -52,6 +53,11 @@ export interface CfIngressOptions<Env> {
   dedupTtlSeconds?: number;
   continuationBinding?: keyof Env & string;
   turnExecutorDoBinding?: keyof Env & string;
+  // Persona-injectable logger. Defaults to consoleJsonLogger (JSON to stdout,
+  // surfaces in `wrangler tail --format json`). Pass a custom logger to ship
+  // events to Workers Analytics Engine, Datadog, etc., or `nullLogger` to
+  // silence in tests.
+  logger?: CfLogger;
 }
 
 export class CfIngressConfigurationError extends Error {
@@ -77,32 +83,50 @@ export function wrapCloudflareWorker<Env>(
   opts: CfIngressOptions<Env>,
 ): CfWorkerHandler<Env> {
   validateOptions(opts);
+  const baseLogger = opts.logger ?? consoleJsonLogger;
 
   return {
     async fetch(req, env, ctx) {
-      const route = opts.webhookRoutes[new URL(req.url).pathname];
+      const url = new URL(req.url);
+      const route = opts.webhookRoutes[url.pathname];
+      const log = baseLogger.child({ component: "cf-ingress", path: url.pathname });
+
       if (!route) {
+        log.debug("non-webhook request — delegating to inner");
         return opts.inner?.fetch?.(req, env, ctx) ?? new Response("Not Found", { status: 404 });
       }
 
+      const routeLog = log.child({ provider: route.provider });
+      routeLog.info("webhook received");
+
       const verification = await route.verify?.(req.clone(), env);
       if (verification && !verification.ok) {
+        routeLog.warn("signature verification failed", { reason: verification.reason });
         return new Response("Unauthorized", { status: 401 });
       }
 
       const result = await route.parse(req, env);
-      if (result.kind === "ack") return result.response;
+      routeLog.debug("parse complete", { kind: result.kind, hasDedupKey: Boolean(result.dedupKey) });
+      if (result.kind === "ack") {
+        routeLog.info("ack-only response", { status: result.response.status });
+        return result.response;
+      }
 
-      const shouldDispatch = await shouldDispatchWebhook(req, env, route, result, opts);
-      if (!shouldDispatch) return new Response("OK", { status: 200 });
+      const shouldDispatch = await shouldDispatchWebhook(req, env, route, result, opts, routeLog);
+      if (!shouldDispatch) {
+        routeLog.info("duplicate event — skipping enqueue");
+        return new Response("OK", { status: 200 });
+      }
 
       const queue = env[opts.queueBinding] as Queue;
+      const receivedAt = new Date().toISOString();
       await queue.send({
         type: "webhook",
         provider: route.provider,
         descriptor: result.turn,
-        receivedAt: new Date().toISOString(),
+        receivedAt,
       });
+      routeLog.info("turn enqueued", { receivedAt });
 
       return result.response;
     },
@@ -121,9 +145,13 @@ async function shouldDispatchWebhook<Env>(
   route: WebhookRouteConfig<Env>,
   result: ParseResult,
   opts: CfIngressOptions<Env>,
+  log: CfLogger,
 ): Promise<boolean> {
   const key = getProviderDedupKey(req, route.provider, result);
-  if (!key) return true;
+  if (!key) {
+    log.debug("no dedup key — letting through");
+    return true;
+  }
 
   if (!opts.dedupBinding) {
     throw new CfIngressConfigurationError("dedupBinding is required for webhook ingress");
@@ -134,6 +162,7 @@ async function shouldDispatchWebhook<Env>(
     ttlSeconds: opts.dedupTtlSeconds,
   });
   const decision = await gate.claim({ eventId: key });
+  log.debug("dedup decision", { dedupKey: key, proceed: decision.proceed, reason: decision.reason });
   return decision.proceed;
 }
 

--- a/packages/cloudflare-runtime/src/ingress/signature/github.test.ts
+++ b/packages/cloudflare-runtime/src/ingress/signature/github.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { verifyGitHubSignature } from "./github.js";
+
+const WEBHOOK_SECRET = "github-test-secret";
+
+describe("verifyGitHubSignature", () => {
+  it("accepts a valid GitHub signature", async () => {
+    const rawBody = JSON.stringify({ action: "opened", issue: { number: 1 } });
+    const headers = await signedHeaders(rawBody);
+
+    await expect(
+      verifyGitHubSignature(rawBody, headers, WEBHOOK_SECRET),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects an equal-length bad signature without malformed short-circuit", async () => {
+    const rawBody = "github=payload";
+    const headers = await signedHeaders(rawBody);
+    const original = headers.get("X-Hub-Signature-256");
+    expect(original).toBeTruthy();
+    headers.set("X-Hub-Signature-256", tamperLastHexDigit(original!));
+
+    const signSpy = vi.spyOn(crypto.subtle, "sign");
+
+    await expect(
+      verifyGitHubSignature(rawBody, headers, WEBHOOK_SECRET),
+    ).resolves.toEqual({ ok: false, reason: "bad_signature" });
+    expect(signSpy).toHaveBeenCalled();
+
+    signSpy.mockRestore();
+  });
+
+  it("rejects a tampered body", async () => {
+    const rawBody = "github=original";
+    const headers = await signedHeaders(rawBody);
+
+    await expect(
+      verifyGitHubSignature("github=tampered", headers, WEBHOOK_SECRET),
+    ).resolves.toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects missing headers", async () => {
+    await expect(
+      verifyGitHubSignature("github=missing", new Headers(), WEBHOOK_SECRET),
+    ).resolves.toEqual({ ok: false, reason: "missing_headers" });
+  });
+
+  it("rejects malformed signature headers", async () => {
+    const headers = new Headers({
+      "X-Hub-Signature-256": "sha256=not-hex",
+    });
+
+    await expect(
+      verifyGitHubSignature("github=bad", headers, WEBHOOK_SECRET),
+    ).resolves.toEqual({ ok: false, reason: "malformed" });
+  });
+
+  it("rejects length-mismatched hex signatures after computing the expected HMAC", async () => {
+    const rawBody = "github=short";
+    const headers = await signedHeaders(rawBody);
+    const original = headers.get("X-Hub-Signature-256");
+    expect(original).toBeTruthy();
+    headers.set("X-Hub-Signature-256", original!.slice(0, -2));
+
+    const signSpy = vi.spyOn(crypto.subtle, "sign");
+
+    await expect(
+      verifyGitHubSignature(rawBody, headers, WEBHOOK_SECRET),
+    ).resolves.toEqual({ ok: false, reason: "bad_signature" });
+    expect(signSpy).toHaveBeenCalled();
+
+    signSpy.mockRestore();
+  });
+
+  it("throws when called with an empty webhook secret", async () => {
+    const headers = await signedHeaders("github=config");
+
+    await expect(
+      verifyGitHubSignature("github=config", headers, ""),
+    ).rejects.toThrow("GitHub webhook secret is required");
+  });
+});
+
+async function signedHeaders(rawBody: string): Promise<Headers> {
+  const digest = await hmacSha256(WEBHOOK_SECRET, rawBody);
+  return new Headers({
+    "X-Hub-Signature-256": `sha256=${bytesToHex(digest)}`,
+  });
+}
+
+async function hmacSha256(secret: string, data: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encodeUtf8(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encodeUtf8(data));
+  return new Uint8Array(signature);
+}
+
+function encodeUtf8(value: string): ArrayBuffer {
+  const encoded = new TextEncoder().encode(value);
+  const copy = new Uint8Array(encoded.byteLength);
+  copy.set(encoded);
+  return copy.buffer;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function tamperLastHexDigit(value: string): string {
+  const replacement = value.endsWith("0") ? "1" : "0";
+  return `${value.slice(0, -1)}${replacement}`;
+}

--- a/packages/cloudflare-runtime/src/ingress/signature/github.ts
+++ b/packages/cloudflare-runtime/src/ingress/signature/github.ts
@@ -1,0 +1,138 @@
+export type GitHubVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: "missing_headers" | "malformed" | "bad_signature" };
+
+export type VerifyResult = GitHubVerifyResult;
+
+const SIGNATURE_PREFIX = "sha256=";
+const HMAC_ALGORITHM = { name: "HMAC", hash: "SHA-256" };
+
+/**
+ * Verifies a GitHub webhook signature against the exact raw request body bytes.
+ *
+ * Contract: callers must pass the raw body exactly as received, before parsing
+ * or re-serializing. If the caller gets the body from a Request, that read
+ * consumes the body stream; clone the Request first when downstream code still
+ * needs to read it.
+ */
+export async function verifyGitHubSignature(
+  rawBody: string,
+  headers: Headers,
+  signingSecret: string,
+): Promise<GitHubVerifyResult> {
+  if (signingSecret.length === 0) {
+    throw new Error("GitHub webhook secret is required");
+  }
+
+  try {
+    const signatureHeader = headers.get("X-Hub-Signature-256");
+    if (!signatureHeader) {
+      return { ok: false, reason: "missing_headers" };
+    }
+
+    if (!isSignatureHeaderWellFormed(signatureHeader, SIGNATURE_PREFIX)) {
+      return { ok: false, reason: "malformed" };
+    }
+
+    const expectedDigest = await hmacSha256(signingSecret, encodeUtf8(rawBody));
+    const expectedSignature = `${SIGNATURE_PREFIX}${bytesToHex(expectedDigest)}`;
+
+    return constantTimeEqual(encodeView(signatureHeader), encodeView(expectedSignature))
+      ? { ok: true }
+      : { ok: false, reason: "bad_signature" };
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+}
+
+async function hmacSha256(
+  secret: string,
+  data: BufferSource,
+): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encodeUtf8(secret),
+    HMAC_ALGORITHM,
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(HMAC_ALGORITHM.name, key, data);
+  return new Uint8Array(signature);
+}
+
+function isSignatureHeaderWellFormed(value: string, prefix: string): boolean {
+  const encodedValue = encodeView(value);
+  const encodedPrefix = encodeView(prefix);
+  const digest = encodedValue.subarray(encodedPrefix.byteLength);
+
+  return (
+    constantTimeEqual(
+      encodedValue.subarray(0, encodedPrefix.byteLength),
+      encodedPrefix,
+    ) && isNonEmptyHex(digest)
+  );
+}
+
+function isNonEmptyHex(bytes: Uint8Array): boolean {
+  if (bytes.byteLength === 0) {
+    return false;
+  }
+
+  for (let index = 0; index < bytes.byteLength; index += 1) {
+    if (hexNibble(bytes[index]) < 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function hexNibble(code: number | undefined): number {
+  if (code === undefined) {
+    return -1;
+  }
+  if (code >= 48 && code <= 57) {
+    return code - 48;
+  }
+  if (code >= 65 && code <= 70) {
+    return code - 55;
+  }
+  if (code >= 97 && code <= 102) {
+    return code - 87;
+  }
+  return -1;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let index = 0; index < bytes.byteLength; index += 1) {
+    const byte = bytes[index] ?? 0;
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function encodeUtf8(value: string): ArrayBuffer {
+  return copyToArrayBuffer(encodeView(value));
+}
+
+function encodeView(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function constantTimeEqual(left: Uint8Array, right: Uint8Array): boolean {
+  let diff = left.length ^ right.length;
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    diff |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+
+  return diff === 0;
+}

--- a/packages/cloudflare-runtime/src/ingress/signature/slack.test.ts
+++ b/packages/cloudflare-runtime/src/ingress/signature/slack.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { verifySlackSignature } from "./slack.js";
+
+const SIGNING_SECRET = "slack-test-secret";
+const NOW = 1_700_000_000_000;
+const TIMESTAMP = String(Math.floor(NOW / 1000));
+
+describe("verifySlackSignature", () => {
+  it("accepts a valid Slack signature", async () => {
+    const rawBody = JSON.stringify({ type: "event_callback", event_id: "Ev1" });
+    const headers = await signedHeaders(rawBody, TIMESTAMP);
+
+    await expect(
+      verifySlackSignature(rawBody, headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects an equal-length bad signature without malformed short-circuit", async () => {
+    const rawBody = "payload=hello";
+    const headers = await signedHeaders(rawBody, TIMESTAMP);
+    const original = headers.get("X-Slack-Signature");
+    expect(original).toBeTruthy();
+    headers.set("X-Slack-Signature", tamperLastHexDigit(original!));
+
+    const signSpy = vi.spyOn(crypto.subtle, "sign");
+
+    await expect(
+      verifySlackSignature(rawBody, headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "bad_signature" });
+    expect(signSpy).toHaveBeenCalled();
+
+    signSpy.mockRestore();
+  });
+
+  it("rejects an old timestamp", async () => {
+    const rawBody = "old=true";
+    const oldTimestamp = String(Math.floor((NOW - 301_000) / 1000));
+    const headers = await signedHeaders(rawBody, oldTimestamp);
+
+    await expect(
+      verifySlackSignature(rawBody, headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "timestamp_skew" });
+  });
+
+  it("rejects a timestamp too far in the future", async () => {
+    const rawBody = "future=true";
+    const futureTimestamp = String(Math.floor((NOW + 301_000) / 1000));
+    const headers = await signedHeaders(rawBody, futureTimestamp);
+
+    await expect(
+      verifySlackSignature(rawBody, headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "timestamp_skew" });
+  });
+
+  it("rejects a tampered body", async () => {
+    const rawBody = "payload=original";
+    const headers = await signedHeaders(rawBody, TIMESTAMP);
+
+    await expect(
+      verifySlackSignature("payload=tampered", headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects missing headers", async () => {
+    await expect(
+      verifySlackSignature("payload=missing", new Headers(), SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "missing_headers" });
+  });
+
+  it("rejects malformed signature headers", async () => {
+    const headers = new Headers({
+      "X-Slack-Request-Timestamp": TIMESTAMP,
+      "X-Slack-Signature": "v0=not-hex",
+    });
+
+    await expect(
+      verifySlackSignature("payload=bad", headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "malformed" });
+  });
+
+  it("rejects length-mismatched hex signatures after computing the expected HMAC", async () => {
+    const rawBody = "payload=short";
+    const headers = await signedHeaders(rawBody, TIMESTAMP);
+    const original = headers.get("X-Slack-Signature");
+    expect(original).toBeTruthy();
+    headers.set("X-Slack-Signature", original!.slice(0, -2));
+
+    const signSpy = vi.spyOn(crypto.subtle, "sign");
+
+    await expect(
+      verifySlackSignature(rawBody, headers, SIGNING_SECRET, () => NOW),
+    ).resolves.toEqual({ ok: false, reason: "bad_signature" });
+    expect(signSpy).toHaveBeenCalled();
+
+    signSpy.mockRestore();
+  });
+
+  it("throws when called with an empty signing secret", async () => {
+    const headers = await signedHeaders("payload=config", TIMESTAMP);
+
+    await expect(
+      verifySlackSignature("payload=config", headers, "", () => NOW),
+    ).rejects.toThrow("Slack signing secret is required");
+  });
+});
+
+async function signedHeaders(rawBody: string, timestamp: string): Promise<Headers> {
+  const baseString = `v0:${timestamp}:${rawBody}`;
+  const digest = await hmacSha256(SIGNING_SECRET, baseString);
+  return new Headers({
+    "X-Slack-Request-Timestamp": timestamp,
+    "X-Slack-Signature": `v0=${bytesToHex(digest)}`,
+  });
+}
+
+async function hmacSha256(secret: string, data: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encodeUtf8(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encodeUtf8(data));
+  return new Uint8Array(signature);
+}
+
+function encodeUtf8(value: string): ArrayBuffer {
+  const encoded = new TextEncoder().encode(value);
+  const copy = new Uint8Array(encoded.byteLength);
+  copy.set(encoded);
+  return copy.buffer;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function tamperLastHexDigit(value: string): string {
+  const replacement = value.endsWith("0") ? "1" : "0";
+  return `${value.slice(0, -1)}${replacement}`;
+}

--- a/packages/cloudflare-runtime/src/ingress/signature/slack.ts
+++ b/packages/cloudflare-runtime/src/ingress/signature/slack.ts
@@ -1,0 +1,176 @@
+export type SlackVerifyResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | "missing_headers"
+        | "malformed"
+        | "timestamp_skew"
+        | "bad_signature";
+    };
+
+export type VerifyResult = SlackVerifyResult;
+
+const SLACK_VERSION = "v0";
+const SIGNATURE_PREFIX = "v0=";
+const MAX_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+const HMAC_ALGORITHM = { name: "HMAC", hash: "SHA-256" };
+
+/**
+ * Verifies a Slack request signature against the exact raw request body bytes.
+ *
+ * Contract: callers must pass the raw body exactly as received, before parsing
+ * or re-serializing. If the caller gets the body from a Request, that read
+ * consumes the body stream; clone the Request first when downstream code still
+ * needs to read it.
+ */
+export async function verifySlackSignature(
+  rawBody: string,
+  headers: Headers,
+  signingSecret: string,
+  now: () => number = () => Date.now(),
+): Promise<SlackVerifyResult> {
+  if (signingSecret.length === 0) {
+    throw new Error("Slack signing secret is required");
+  }
+
+  try {
+    const timestampHeader = headers.get("X-Slack-Request-Timestamp");
+    const signatureHeader = headers.get("X-Slack-Signature");
+    if (!timestampHeader || !signatureHeader) {
+      return { ok: false, reason: "missing_headers" };
+    }
+
+    const timestamp = parseTimestampSeconds(timestampHeader);
+    if (timestamp === null) {
+      return { ok: false, reason: "malformed" };
+    }
+
+    if (!isSignatureHeaderWellFormed(signatureHeader, SIGNATURE_PREFIX)) {
+      return { ok: false, reason: "malformed" };
+    }
+
+    if (Math.abs(now() - timestamp * 1000) > MAX_REPLAY_WINDOW_MS) {
+      return { ok: false, reason: "timestamp_skew" };
+    }
+
+    const baseString = `${SLACK_VERSION}:${timestampHeader}:${rawBody}`;
+    const expectedDigest = await hmacSha256(signingSecret, encodeUtf8(baseString));
+    const expectedSignature = `${SIGNATURE_PREFIX}${bytesToHex(expectedDigest)}`;
+
+    return constantTimeEqual(encodeView(signatureHeader), encodeView(expectedSignature))
+      ? { ok: true }
+      : { ok: false, reason: "bad_signature" };
+  } catch {
+    return { ok: false, reason: "malformed" };
+  }
+}
+
+function parseTimestampSeconds(value: string): number | null {
+  let timestamp = 0;
+  if (value.length === 0) {
+    return null;
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 48 || code > 57) {
+      return null;
+    }
+    timestamp = timestamp * 10 + (code - 48);
+  }
+
+  return Number.isSafeInteger(timestamp) ? timestamp : null;
+}
+
+async function hmacSha256(
+  secret: string,
+  data: BufferSource,
+): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encodeUtf8(secret),
+    HMAC_ALGORITHM,
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(HMAC_ALGORITHM.name, key, data);
+  return new Uint8Array(signature);
+}
+
+function isSignatureHeaderWellFormed(value: string, prefix: string): boolean {
+  const encodedValue = encodeView(value);
+  const encodedPrefix = encodeView(prefix);
+  const digest = encodedValue.subarray(encodedPrefix.byteLength);
+
+  return (
+    constantTimeEqual(
+      encodedValue.subarray(0, encodedPrefix.byteLength),
+      encodedPrefix,
+    ) && isNonEmptyHex(digest)
+  );
+}
+
+function isNonEmptyHex(bytes: Uint8Array): boolean {
+  if (bytes.byteLength === 0) {
+    return false;
+  }
+
+  for (let index = 0; index < bytes.byteLength; index += 1) {
+    if (hexNibble(bytes[index]) < 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function hexNibble(code: number | undefined): number {
+  if (code === undefined) {
+    return -1;
+  }
+  if (code >= 48 && code <= 57) {
+    return code - 48;
+  }
+  if (code >= 65 && code <= 70) {
+    return code - 55;
+  }
+  if (code >= 97 && code <= 102) {
+    return code - 87;
+  }
+  return -1;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let index = 0; index < bytes.byteLength; index += 1) {
+    const byte = bytes[index] ?? 0;
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+function encodeUtf8(value: string): ArrayBuffer {
+  return copyToArrayBuffer(encodeView(value));
+}
+
+function encodeView(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function copyToArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function constantTimeEqual(left: Uint8Array, right: Uint8Array): boolean {
+  let diff = left.length ^ right.length;
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    diff |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+
+  return diff === 0;
+}

--- a/packages/cloudflare-runtime/src/observability/index.ts
+++ b/packages/cloudflare-runtime/src/observability/index.ts
@@ -1,0 +1,9 @@
+export {
+  type CfLogger,
+  type LogLevel,
+  type CapturedLogRecord,
+  consoleJsonLogger,
+  createConsoleJsonLogger,
+  nullLogger,
+  createCapturingLogger,
+} from "./logger.js";

--- a/packages/cloudflare-runtime/src/observability/logger.ts
+++ b/packages/cloudflare-runtime/src/observability/logger.ts
@@ -1,0 +1,137 @@
+// Logger interface for cf-runtime. Persona-injectable; default implementation
+// emits structured JSON to console (renders well in `wrangler tail --format
+// json` and any log-collection pipeline that ingests CF Workers stdout).
+//
+// All cf-runtime entry points accept an optional `logger`; if omitted, they
+// fall back to `consoleJsonLogger`. Pass `nullLogger` in tests to silence.
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface CfLogger {
+  debug(event: string, data?: Record<string, unknown>): void;
+  info(event: string, data?: Record<string, unknown>): void;
+  warn(event: string, data?: Record<string, unknown>): void;
+  error(event: string, data?: Record<string, unknown>): void;
+  // Returns a new logger that merges `bindings` into every subsequent log line.
+  // Use this to correlate by turnId / continuationId / conversationId.
+  child(bindings: Record<string, unknown>): CfLogger;
+}
+
+interface ConsoleJsonLoggerOptions {
+  // Minimum level to emit. Default "info".
+  level?: LogLevel;
+  // Static bindings merged into every log line (e.g. { service: "sage" }).
+  bindings?: Record<string, unknown>;
+  // Sink override — defaults to globalThis.console.
+  sink?: Pick<Console, "debug" | "info" | "warn" | "error">;
+}
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+class ConsoleJsonLogger implements CfLogger {
+  private readonly level: LogLevel;
+  private readonly bindings: Record<string, unknown>;
+  private readonly sink: NonNullable<ConsoleJsonLoggerOptions["sink"]>;
+
+  constructor(opts: ConsoleJsonLoggerOptions = {}) {
+    this.level = opts.level ?? "info";
+    this.bindings = opts.bindings ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.sink = opts.sink ?? (globalThis.console as any);
+  }
+
+  debug(event: string, data?: Record<string, unknown>): void {
+    this.emit("debug", event, data);
+  }
+  info(event: string, data?: Record<string, unknown>): void {
+    this.emit("info", event, data);
+  }
+  warn(event: string, data?: Record<string, unknown>): void {
+    this.emit("warn", event, data);
+  }
+  error(event: string, data?: Record<string, unknown>): void {
+    this.emit("error", event, data);
+  }
+
+  child(bindings: Record<string, unknown>): CfLogger {
+    return new ConsoleJsonLogger({
+      level: this.level,
+      bindings: { ...this.bindings, ...bindings },
+      sink: this.sink,
+    });
+  }
+
+  private emit(level: LogLevel, event: string, data?: Record<string, unknown>): void {
+    if (LEVEL_RANK[level] < LEVEL_RANK[this.level]) return;
+    const payload = {
+      level,
+      event,
+      time: new Date().toISOString(),
+      ...this.bindings,
+      ...(data ?? {}),
+    };
+    // CF Workers stdout sees the JSON object; wrangler tail --format json
+    // surfaces it as a structured event.
+    const line = JSON.stringify(payload);
+    if (level === "error") this.sink.error(line);
+    else if (level === "warn") this.sink.warn(line);
+    else if (level === "debug") this.sink.debug(line);
+    else this.sink.info(line);
+  }
+}
+
+export function createConsoleJsonLogger(opts?: ConsoleJsonLoggerOptions): CfLogger {
+  return new ConsoleJsonLogger(opts);
+}
+
+// Convenience default — info level, console sink, no bindings.
+export const consoleJsonLogger: CfLogger = createConsoleJsonLogger();
+
+// Use in tests to silence output without losing the type.
+export const nullLogger: CfLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  child() {
+    return nullLogger;
+  },
+};
+
+// Capturing logger for tests that want to assert on emitted events.
+// Returns the logger plus an array that collects every emitted record.
+export interface CapturedLogRecord {
+  level: LogLevel;
+  event: string;
+  data: Record<string, unknown>;
+}
+
+export function createCapturingLogger(): {
+  logger: CfLogger;
+  records: CapturedLogRecord[];
+} {
+  const records: CapturedLogRecord[] = [];
+  const make = (bindings: Record<string, unknown>): CfLogger => ({
+    debug(event, data) {
+      records.push({ level: "debug", event, data: { ...bindings, ...(data ?? {}) } });
+    },
+    info(event, data) {
+      records.push({ level: "info", event, data: { ...bindings, ...(data ?? {}) } });
+    },
+    warn(event, data) {
+      records.push({ level: "warn", event, data: { ...bindings, ...(data ?? {}) } });
+    },
+    error(event, data) {
+      records.push({ level: "error", event, data: { ...bindings, ...(data ?? {}) } });
+    },
+    child(extra) {
+      return make({ ...bindings, ...extra });
+    },
+  });
+  return { logger: make({}), records };
+}

--- a/packages/cloudflare-runtime/src/observability/logger.ts
+++ b/packages/cloudflare-runtime/src/observability/logger.ts
@@ -41,8 +41,7 @@ class ConsoleJsonLogger implements CfLogger {
   constructor(opts: ConsoleJsonLoggerOptions = {}) {
     this.level = opts.level ?? "info";
     this.bindings = opts.bindings ?? {};
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.sink = opts.sink ?? (globalThis.console as any);
+    this.sink = opts.sink ?? globalThis.console;
   }
 
   debug(event: string, data?: Record<string, unknown>): void {

--- a/packages/cloudflare-runtime/src/observability/observability.test.ts
+++ b/packages/cloudflare-runtime/src/observability/observability.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { wrapCloudflareWorker } from "../ingress/cf-ingress.js";
+import { handleCfQueue } from "../executor/cf-turn-executor.js";
+import {
+  createCapturingLogger,
+  createConsoleJsonLogger,
+  nullLogger,
+} from "./logger.js";
+
+describe("CfLogger", () => {
+  it("emits structured JSON to the configured sink", () => {
+    const sink = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const logger = createConsoleJsonLogger({ sink, level: "debug", bindings: { service: "x" } });
+    logger.info("hello", { k: 1 });
+    expect(sink.info).toHaveBeenCalledTimes(1);
+    const line = sink.info.mock.calls[0][0] as string;
+    const parsed = JSON.parse(line);
+    expect(parsed.level).toBe("info");
+    expect(parsed.event).toBe("hello");
+    expect(parsed.service).toBe("x");
+    expect(parsed.k).toBe(1);
+    expect(typeof parsed.time).toBe("string");
+  });
+
+  it("respects level threshold (debug suppressed at info)", () => {
+    const sink = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const logger = createConsoleJsonLogger({ sink, level: "info" });
+    logger.debug("nope");
+    logger.info("yep");
+    expect(sink.debug).not.toHaveBeenCalled();
+    expect(sink.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("child() merges bindings", () => {
+    const { logger, records } = createCapturingLogger();
+    const turnLog = logger.child({ turnId: "T1" });
+    turnLog.info("hello");
+    turnLog.child({ step: "parse" }).info("nested");
+    expect(records).toHaveLength(2);
+    expect(records[0].data).toMatchObject({ turnId: "T1" });
+    expect(records[1].data).toMatchObject({ turnId: "T1", step: "parse" });
+  });
+});
+
+describe("ingress logger wiring", () => {
+  it("emits webhook lifecycle events with the injected logger", async () => {
+    const { logger, records } = createCapturingLogger();
+
+    const sentMessages: unknown[] = [];
+    const fakeQueue = { send: async (m: unknown) => { sentMessages.push(m); } };
+    const dedupStore = new Map<string, string>();
+    const fakeKv = {
+      async get(k: string) { return dedupStore.get(k) ?? null; },
+      async put(k: string, v: string) { dedupStore.set(k, v); },
+    };
+
+    const env = { TURN_QUEUE: fakeQueue, DEDUP: fakeKv } as unknown as { TURN_QUEUE: unknown; DEDUP: unknown };
+
+    const handler = wrapCloudflareWorker<typeof env>({
+      logger,
+      queueBinding: "TURN_QUEUE",
+      dedupBinding: "DEDUP",
+      webhookRoutes: {
+        "/api/webhooks/slack": {
+          provider: "slack",
+          verify: async () => ({ ok: true as const }),
+          parse: async () => ({
+            kind: "dispatch",
+            response: new Response("OK", { status: 200 }),
+            turn: { id: "evt-1" },
+            dedupKey: { eventId: "evt-1" },
+          }),
+        },
+      },
+    });
+
+    const req = {
+      url: "https://sage.test/api/webhooks/slack",
+      headers: new Headers(),
+      clone() { return this; },
+    } as unknown as Request;
+
+    // Cast ctx to any — we only care that it's passed through.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler.fetch!(req as any, env, {} as any);
+
+    const events = records.map((r) => r.event);
+    expect(events).toContain("webhook received");
+    expect(events).toContain("turn enqueued");
+    // Signature verification did NOT fail; we should NOT see the warn event.
+    expect(events).not.toContain("signature verification failed");
+
+    // Second delivery of the same event-id is deduped.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler.fetch!(req as any, env, {} as any);
+    expect(events.filter((e) => e === "turn enqueued")).toHaveLength(1);
+    expect(records.some((r) => r.event === "duplicate event — skipping enqueue")).toBe(true);
+  });
+});
+
+describe("executor logger wiring", () => {
+  it("logs dispatch start + complete with waitUntilCount", async () => {
+    const { logger, records } = createCapturingLogger();
+
+    let acked = 0;
+    const message = {
+      body: { type: "webhook", provider: "slack", descriptor: { id: "T1" }, receivedAt: "now" },
+      ack: () => { acked++; },
+    };
+
+    await handleCfQueue<{}, typeof message.body>(
+      { messages: [message as unknown as { body: typeof message.body }] },
+      {} as {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      {
+        logger,
+        runTurn: async (_msg, _env, ctx) => {
+          // Schedule a waitUntil so we can verify the count is captured.
+          ctx.waitUntil(Promise.resolve());
+          ctx.waitUntil(Promise.resolve());
+        },
+        resolveTurnId: (m) => (m as { descriptor?: { id?: string } }).descriptor?.id,
+      },
+    );
+
+    expect(acked).toBe(1);
+    const events = records.map((r) => r.event);
+    expect(events).toContain("dispatch start");
+    expect(events).toContain("dispatch complete");
+
+    const completeRec = records.find((r) => r.event === "dispatch complete")!;
+    expect(completeRec.data.turnId).toBe("T1");
+    expect(completeRec.data.waitUntilCount).toBe(2);
+  });
+
+  it("logs dispatch failed with error message + still calls retry", async () => {
+    const { logger, records } = createCapturingLogger();
+
+    let retried = 0;
+    const message = {
+      body: { type: "webhook", provider: "slack", descriptor: {}, receivedAt: "now" },
+      retry: () => { retried++; },
+    };
+
+    await expect(
+      handleCfQueue<{}, typeof message.body>(
+        { messages: [message as unknown as { body: typeof message.body }] },
+        {} as {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        {
+          logger,
+          runTurn: () => {
+            throw new Error("boom");
+          },
+        },
+      ),
+    ).rejects.toThrow("boom");
+
+    expect(retried).toBe(1);
+    const failed = records.find((r) => r.event === "dispatch failed");
+    expect(failed?.data.error).toBe("boom");
+    expect(failed?.level).toBe("error");
+  });
+});
+
+describe("nullLogger", () => {
+  it("is a no-op and supports child()", () => {
+    expect(() => nullLogger.info("nope")).not.toThrow();
+    expect(nullLogger.child({ x: 1 })).toBe(nullLogger);
+  });
+});

--- a/packages/cloudflare-runtime/src/types.ts
+++ b/packages/cloudflare-runtime/src/types.ts
@@ -1,0 +1,54 @@
+import type { ContinuationResumeTrigger } from '@agent-assistant/continuation';
+import type {
+  DurableObjectNamespace,
+  KVNamespace,
+  Queue,
+} from '@cloudflare/workers-types';
+
+export type TurnQueueProvider = 'slack' | 'github' | 'nango';
+
+export interface WebhookQueueMessage {
+  type: 'webhook';
+  provider: TurnQueueProvider;
+  descriptor: unknown;
+  receivedAt: string;
+}
+
+export interface ResumeQueueMessage {
+  type: 'resume';
+  continuationId: string;
+  trigger: ContinuationResumeTrigger;
+}
+
+export interface SpecialistCallQueueMessage {
+  type: 'specialist_call';
+  turnId: string;
+  capability: string;
+  input: unknown;
+  callbackTrigger: ContinuationResumeTrigger;
+}
+
+export interface SpecialistResultQueueMessage {
+  type: 'specialist_result';
+  callbackTrigger: ContinuationResumeTrigger;
+  result: unknown;
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+export type TurnQueueMessage =
+  | WebhookQueueMessage
+  | ResumeQueueMessage
+  | SpecialistCallQueueMessage
+  | SpecialistResultQueueMessage;
+
+export interface CfBindingsShape<TMessage extends TurnQueueMessage = TurnQueueMessage> {
+  TURN_QUEUE: Queue<TMessage>;
+  DEAD_LETTER_QUEUE?: Queue<TMessage>;
+  DEDUP?: KVNamespace;
+  CONTINUATIONS?: KVNamespace;
+  TURN_EXECUTOR_DO?: DurableObjectNamespace;
+  [binding: string]: unknown;
+}

--- a/packages/cloudflare-runtime/tsconfig.json
+++ b/packages/cloudflare-runtime/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": [
+      "@cloudflare/workers-types"
+    ],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/packages/cloudflare-runtime/vitest.config.ts
+++ b/packages/cloudflare-runtime/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
Adds `@agent-assistant/cloudflare-runtime` — the CF-Workers runtime adapter for personas built on `@agent-assistant/continuation`.

**This single PR consolidates W1+W2+W3** of the cf-runtime workflow bundle (originally planned as three sequential PRs). The implementer agents built the full surface in one pass and all 35 tests pass cleanly, so splitting after the fact would just add review overhead.

## Public surface
- `wrapCloudflareWorker` — webhook ingress + dedup (via @agent-assistant/surfaces SlackEventDedupGate) + enqueue
- `handleCfQueue` + `TurnExecutorDO` — queue consumer + per-conversation Durable Object
- `createFakeExecutionContext` — collects `waitUntil` and awaits before ack — **this is the direct fix for the production Slack-silence bug**
- `createCfContinuationStore` — DO storage primary + KV trigger index
- `createCfContinuationScheduler` — DO alarm + queue delayed delivery
- `createCfDeliveryAdapter` — Slack / GitHub / a2a-callback post-back
- `createCfSpecialistClient` — async sage to specialist bridge
- `verifySlackSignature` / `verifyGitHubSignature` helpers

## Production fix this enables
Sage currently dispatches Slack turn work via `ctx.waitUntil(...)`, which CF cancels ~30s after HTTP 200. Long turns (Notion lookups, multi-tool specialist routing) are silently dropped — Slack metrics show 100% success while users get no reply.

Once cloud's sage-worker migrates onto this package (cloud W6, blocked on this + sage 1.5.0 publish), turns run inside a queue consumer with the full 15-min wall budget, and the fake-ctx pattern catches anything internal that still uses `waitUntil`.

## SPEC invariants enforced
- #1 fake ctx never orphans
- #2 continuation writes synchronous on suspend
- #3 personas own signature verification
- #4 cf-runtime owns ingress dedup, exactly once
- #5 DO is single writer per conversation
- #6 dedup primitive is the upstream @agent-assistant/surfaces `SlackEventDedupGate`
- #7 personas expose parse<Surface>Webhook + run<Persona>Turn

## Test evidence
- `npx tsc --noEmit` clean
- `npx vitest run`: **35 tests across 10 files, all passing**

## Order
Independent of W4 (`@agent-assistant/webhook-runtime` patch, PR #55). Both should land before publishing the runtime to npm. Sage repo PR (https://github.com/AgentWorkforce/sage/pull/122) lands independently and publishes 1.5.0 separately.

## Reference
Architecture and SPEC: `workflows/cf-runtime/SPEC.md` and `workflows/cf-runtime/ARCHITECTURE.md` in AgentWorkforce/cloud.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
