### PR TITLE
Fix webhook-runtime surfaces test dependency

### DIFF
--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "prepack": "npm run build",
     "build": "tsc",
-    "pretest": "npm --prefix ../harness run build && npm --prefix ../specialists run build",
+    "pretest": "npm --prefix ../harness run build && npm --prefix ../specialists run build && npm --prefix ../surfaces run build",
     "test": "vitest run",
     "cli": "tsx examples/cli.ts",
     "worker": "tsx examples/byoh-worker.ts",


### PR DESCRIPTION
## Summary
- build @agent-assistant/surfaces in webhook-runtime pretest before Vitest resolves package exports
- fixes clean-checkout failures where @agent-assistant/surfaces exports point at missing dist/index.js

## Verification
- npm test -w @agent-assistant/webhook-runtime
- npm --prefix packages/webhook-runtime test (rerun with localhost permission; 8 files, 31 tests passed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
