### PR TITLE
feat(memory): add turn memory helpers

### DIFF
--- a/.trajectories/completed/2026-04/traj_nhoot50i38bn.json
+++ b/.trajectories/completed/2026-04/traj_nhoot50i38bn.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_nhoot50i38bn",
+  "version": 1,
+  "task": {
+    "title": "Add memory turn-context helpers"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-27T15:37:38.560Z",
+  "completedAt": "2026-04-27T15:42:47.931Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-27T15:42:42.246Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_jztv54oj7yku",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-27T15:42:42.246Z",
+      "endedAt": "2026-04-27T15:42:47.931Z",
+      "events": [
+        {
+          "ts": 1777304562247,
+          "type": "decision",
+          "content": "Added raw memory helpers in @agent-assistant/memory: Added raw memory helpers in @agent-assistant/memory",
+          "raw": {
+            "question": "Added raw memory helpers in @agent-assistant/memory",
+            "chosen": "Added raw memory helpers in @agent-assistant/memory",
+            "alternatives": [],
+            "reasoning": "Sage needs reusable scoped retrieval, relay-backed store construction, and latest-session promotion while keeping Slack-specific promotion policy and prompt formatting product-local."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added @agent-assistant/memory helpers for relay-backed store construction, scoped turn memory retrieval, latest session promotion, docs, and tests.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant-issue-134-memory-adoption",
+  "tags": [],
+  "_trace": {
+    "startRef": "3091a5284b123c0e310b1283aff105c0b963def2",
+    "endRef": "3091a5284b123c0e310b1283aff105c0b963def2"
+  }
+}

--- a/.trajectories/completed/2026-04/traj_nhoot50i38bn.md
+++ b/.trajectories/completed/2026-04/traj_nhoot50i38bn.md
@@ -1,0 +1,31 @@
+# Trajectory: Add memory turn-context helpers
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** April 27, 2026 at 08:37 AM
+> **Completed:** April 27, 2026 at 08:42 AM
+
+---
+
+## Summary
+
+Added @agent-assistant/memory helpers for relay-backed store construction, scoped turn memory retrieval, latest session promotion, docs, and tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Added raw memory helpers in @agent-assistant/memory
+- **Chose:** Added raw memory helpers in @agent-assistant/memory
+- **Reasoning:** Sage needs reusable scoped retrieval, relay-backed store construction, and latest-session promotion while keeping Slack-specific promotion policy and prompt formatting product-local.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Added raw memory helpers in @agent-assistant/memory: Added raw memory helpers in @agent-assistant/memory

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-26T00:42:05.580Z",
+  "lastUpdated": "2026-04-27T15:42:48.047Z",
   "trajectories": {
     "traj_34202idd4b5w": {
       "title": "aa-proactive-signals-03-slack-presence-workflow",
@@ -328,6 +328,13 @@
       "status": "active",
       "startedAt": "2026-04-26T00:41:52.014Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/active/traj_znshefbf3jtn.json"
+    },
+    "traj_nhoot50i38bn": {
+      "title": "Add memory turn-context helpers",
+      "status": "completed",
+      "startedAt": "2026-04-27T15:37:38.560Z",
+      "completedAt": "2026-04-27T15:42:47.931Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant-issue-134-memory-adoption/.trajectories/completed/2026-04/traj_nhoot50i38bn.json"
     }
   }
 }

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -22,9 +22,12 @@ npm install @agent-assistant/memory
 
 ```typescript
 import {
+  createRelayBackedMemoryStore,
   createMemoryStore,
   InMemoryMemoryStoreAdapter,
   RelayMemoryStoreAdapter,
+  retrieveTurnMemoryContext,
+  promoteLatestSessionMemory,
 } from '@agent-assistant/memory';
 ```
 
@@ -152,6 +155,47 @@ const memory = createMemoryStore({
 ```
 
 The wrapped relay adapter must implement `list()` and `update()`. The constructor rejects adapters that do not provide both methods.
+
+## Turn Memory Helpers
+
+Consumers that build their own prompt formatting can use the raw turn helpers instead of reimplementing scoped retrieval and promotion:
+
+```typescript
+import {
+  createRelayBackedMemoryStore,
+  retrieveTurnMemoryContext,
+  promoteLatestSessionMemory,
+} from '@agent-assistant/memory';
+
+const { store, close } = await createRelayBackedMemoryStore({
+  config: {
+    type: 'supermemory',
+    apiKey: process.env.SUPERMEMORY_API_KEY,
+    defaultAgentId: 'sage',
+    defaultProjectId: 'workspace-123',
+  },
+});
+
+const context = await retrieveTurnMemoryContext({
+  store,
+  sessionId: 'thread-1',
+  userId: 'user-1',
+  workspaceId: 'workspace-123',
+  tags: ['conversation'],
+  limit: 5,
+});
+
+await promoteLatestSessionMemory({
+  store,
+  sessionId: 'thread-1',
+  userId: 'user-1',
+  tags: ['promotable'],
+});
+
+await close();
+```
+
+`retrieveTurnMemoryContext()` returns entries in session, user, then workspace order by default, deduped by entry id. `promoteLatestSessionMemory()` promotes the newest matching session entry to a user or caller-supplied target scope.
 
 ## Isolation
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -5,6 +5,12 @@ export {
 } from './memory.js';
 
 export {
+  createRelayBackedMemoryStore,
+  promoteLatestSessionMemory,
+  retrieveTurnMemoryContext,
+} from './turn-memory.js';
+
+export {
   CompactionError,
   InvalidScopePromotionError,
   MemoryEntryNotFoundError,
@@ -24,3 +30,12 @@ export type {
   UpdateMemoryPatch,
   WriteMemoryInput,
 } from './types.js';
+
+export type {
+  CreateRelayBackedMemoryStoreOptions,
+  PromoteLatestSessionMemoryInput,
+  RelayBackedMemoryStore,
+  RetrieveTurnMemoryContextInput,
+  TurnMemoryContext,
+  TurnMemoryScopeKind,
+} from './turn-memory.js';

--- a/packages/memory/src/turn-memory.test.ts
+++ b/packages/memory/src/turn-memory.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createMemoryStore,
+  InMemoryMemoryStoreAdapter,
+} from './memory.js';
+import {
+  createRelayBackedMemoryStore,
+  promoteLatestSessionMemory,
+  retrieveTurnMemoryContext,
+} from './turn-memory.js';
+import type { MemoryStore } from './types.js';
+
+function makeStore(): MemoryStore {
+  return createMemoryStore({ adapter: new InMemoryMemoryStoreAdapter() });
+}
+
+describe('turn memory helpers', () => {
+  it('creates a relay-backed memory store with a close handle', async () => {
+    const handle = await createRelayBackedMemoryStore({ config: { type: 'inmemory' } });
+
+    const entry = await handle.store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'hello',
+    });
+
+    expect(entry.id).toBeTruthy();
+    await expect(handle.close()).resolves.toBeUndefined();
+  });
+
+  it('retrieves turn memory in session, user, then workspace order by default', async () => {
+    const store = makeStore();
+
+    await store.write({
+      scope: { kind: 'workspace', workspaceId: 'w1' },
+      content: 'workspace convention',
+    });
+    await store.write({
+      scope: { kind: 'user', userId: 'u1' },
+      content: 'user preference',
+    });
+    await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'current thread',
+    });
+
+    const context = await retrieveTurnMemoryContext({
+      store,
+      sessionId: 's1',
+      userId: 'u1',
+      workspaceId: 'w1',
+    });
+
+    expect(context.entries.map((entry) => entry.content)).toEqual([
+      'current thread',
+      'user preference',
+      'workspace convention',
+    ]);
+    expect(context.byScope.session?.map((entry) => entry.content)).toEqual(['current thread']);
+    expect(context.byScope.user?.map((entry) => entry.content)).toEqual(['user preference']);
+    expect(context.byScope.workspace?.map((entry) => entry.content)).toEqual(['workspace convention']);
+  });
+
+  it('honors tags, per-scope limits, and global limits', async () => {
+    const store = makeStore();
+
+    await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'session keep',
+      tags: ['turn'],
+    });
+    await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'session skip',
+      tags: ['other'],
+    });
+    await store.write({
+      scope: { kind: 'user', userId: 'u1' },
+      content: 'user keep',
+      tags: ['turn'],
+    });
+    await store.write({
+      scope: { kind: 'workspace', workspaceId: 'w1' },
+      content: 'workspace keep',
+      tags: ['turn'],
+    });
+
+    const context = await retrieveTurnMemoryContext({
+      store,
+      sessionId: 's1',
+      userId: 'u1',
+      workspaceId: 'w1',
+      tags: ['turn'],
+      perScopeLimit: 1,
+      limit: 2,
+    });
+
+    expect(context.entries.map((entry) => entry.content)).toEqual(['session keep', 'user keep']);
+    expect(context.entries).toHaveLength(2);
+  });
+
+  it('supports custom scope order', async () => {
+    const store = makeStore();
+    await store.write({
+      scope: { kind: 'workspace', workspaceId: 'w1' },
+      content: 'workspace first',
+    });
+    await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'session second',
+    });
+
+    const context = await retrieveTurnMemoryContext({
+      store,
+      sessionId: 's1',
+      workspaceId: 'w1',
+      scopeOrder: ['workspace', 'session'],
+    });
+
+    expect(context.entries.map((entry) => entry.content)).toEqual([
+      'workspace first',
+      'session second',
+    ]);
+  });
+
+  it('promotes the latest session memory to user scope', async () => {
+    const store = makeStore();
+    await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'older',
+    });
+    const latest = await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'latest',
+      tags: ['promotable'],
+    });
+
+    const promoted = await promoteLatestSessionMemory({
+      store,
+      sessionId: 's1',
+      userId: 'u1',
+      tags: ['promotable'],
+    });
+
+    expect(promoted?.content).toBe('latest');
+    expect(promoted?.promotedFromId).toBe(latest.id);
+    expect(promoted?.scope).toEqual({ kind: 'user', userId: 'u1' });
+    expect(promoted?.metadata.createdInSessionId).toBe('s1');
+  });
+
+  it('returns null when no session memory can be promoted', async () => {
+    const store = makeStore();
+
+    await expect(
+      promoteLatestSessionMemory({
+        store,
+        sessionId: 'missing',
+        userId: 'u1',
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('requires a target scope or userId for latest-session promotion', async () => {
+    const store = makeStore();
+    await store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'promote me',
+    });
+
+    await expect(
+      promoteLatestSessionMemory({
+        store,
+        sessionId: 's1',
+      }),
+    ).rejects.toThrow(/targetScope or userId/);
+  });
+});

--- a/packages/memory/src/turn-memory.ts
+++ b/packages/memory/src/turn-memory.ts
@@ -1,0 +1,174 @@
+import { createMemoryAdapter } from '@agent-relay/memory';
+import type {
+  MemoryAdapter as RelayMemoryAdapter,
+  MemoryConfig as RelayMemoryConfig,
+} from '@agent-relay/memory';
+
+import {
+  createMemoryStore,
+  RelayMemoryStoreAdapter,
+} from './memory.js';
+import type {
+  MemoryEntry,
+  MemoryQuery,
+  MemoryScope,
+  MemoryStore,
+  PromoteMemoryInput,
+} from './types.js';
+
+export interface RelayBackedMemoryStore {
+  store: MemoryStore;
+  relayAdapter: RelayMemoryAdapter;
+  close(): Promise<void>;
+}
+
+export interface CreateRelayBackedMemoryStoreOptions {
+  config?: RelayMemoryConfig;
+  relayAdapter?: RelayMemoryAdapter;
+}
+
+export type TurnMemoryScopeKind = Extract<MemoryScope['kind'], 'session' | 'user' | 'workspace'>;
+
+export interface RetrieveTurnMemoryContextInput {
+  store: MemoryStore;
+  sessionId?: string;
+  userId?: string;
+  workspaceId?: string;
+  tags?: string[];
+  since?: string;
+  limit?: number;
+  perScopeLimit?: number;
+  order?: MemoryQuery['order'];
+  scopeOrder?: TurnMemoryScopeKind[];
+}
+
+export interface TurnMemoryContext {
+  entries: MemoryEntry[];
+  byScope: Partial<Record<TurnMemoryScopeKind, MemoryEntry[]>>;
+}
+
+export interface PromoteLatestSessionMemoryInput {
+  store: MemoryStore;
+  sessionId: string;
+  targetScope?: MemoryScope;
+  userId?: string;
+  tags?: string[];
+  since?: string;
+  deleteOriginal?: boolean;
+  content?: string;
+  promotedTags?: string[];
+}
+
+const DEFAULT_SCOPE_ORDER: TurnMemoryScopeKind[] = ['session', 'user', 'workspace'];
+const DEFAULT_TURN_MEMORY_LIMIT = 20;
+
+export async function createRelayBackedMemoryStore(
+  options: CreateRelayBackedMemoryStoreOptions,
+): Promise<RelayBackedMemoryStore> {
+  const relayAdapter =
+    options.relayAdapter ?? await createMemoryAdapter(options.config ?? { type: 'inmemory' });
+  const store = createMemoryStore({
+    adapter: new RelayMemoryStoreAdapter(relayAdapter),
+  });
+
+  return {
+    store,
+    relayAdapter,
+    async close(): Promise<void> {
+      await relayAdapter.close?.();
+    },
+  };
+}
+
+export async function retrieveTurnMemoryContext(
+  input: RetrieveTurnMemoryContextInput,
+): Promise<TurnMemoryContext> {
+  const scopeOrder = input.scopeOrder ?? DEFAULT_SCOPE_ORDER;
+  const perScopeLimit = normalizeLimit(input.perScopeLimit ?? input.limit);
+  const globalLimit = normalizeLimit(input.limit);
+  const byScope: Partial<Record<TurnMemoryScopeKind, MemoryEntry[]>> = {};
+  const deduped = new Map<string, MemoryEntry>();
+
+  for (const scopeKind of scopeOrder) {
+    const scope = resolveTurnScope(scopeKind, input);
+    if (!scope) {
+      continue;
+    }
+
+    const entries = await input.store.retrieve({
+      scope,
+      tags: input.tags,
+      since: input.since,
+      limit: perScopeLimit,
+      order: input.order ?? 'newest',
+      includeNarrower: false,
+    });
+
+    byScope[scopeKind] = entries;
+
+    for (const entry of entries) {
+      if (!deduped.has(entry.id)) {
+        deduped.set(entry.id, entry);
+      }
+    }
+  }
+
+  return {
+    entries: [...deduped.values()].slice(0, globalLimit),
+    byScope,
+  };
+}
+
+export async function promoteLatestSessionMemory(
+  input: PromoteLatestSessionMemoryInput,
+): Promise<MemoryEntry | null> {
+  const [source] = await input.store.retrieve({
+    scope: { kind: 'session', sessionId: input.sessionId },
+    tags: input.tags,
+    since: input.since,
+    limit: 1,
+    order: 'newest',
+  });
+
+  if (!source) {
+    return null;
+  }
+
+  const targetScope =
+    input.targetScope ?? (input.userId ? { kind: 'user', userId: input.userId } : undefined);
+  if (!targetScope) {
+    throw new Error('promoteLatestSessionMemory requires targetScope or userId.');
+  }
+
+  const promotion: PromoteMemoryInput = {
+    sourceEntryId: source.id,
+    targetScope,
+    deleteOriginal: input.deleteOriginal,
+    content: input.content,
+    tags: input.promotedTags,
+  };
+
+  return input.store.promote(promotion);
+}
+
+function resolveTurnScope(
+  scopeKind: TurnMemoryScopeKind,
+  input: RetrieveTurnMemoryContextInput,
+): MemoryScope | null {
+  switch (scopeKind) {
+    case 'session':
+      return input.sessionId ? { kind: 'session', sessionId: input.sessionId } : null;
+    case 'user':
+      return input.userId ? { kind: 'user', userId: input.userId } : null;
+    case 'workspace':
+      return input.workspaceId ? { kind: 'workspace', workspaceId: input.workspaceId } : null;
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (!limit || limit < 1) {
+    return DEFAULT_TURN_MEMORY_LIMIT;
+  }
+
+  return Math.floor(limit);
+}


### PR DESCRIPTION
## Summary

- Adds createRelayBackedMemoryStore() so consumers can build a MemoryStore from a relay adapter/config without repeating createMemoryAdapter + RelayMemoryStoreAdapter ceremony.
- Adds retrieveTurnMemoryContext() for raw session/user/workspace scoped retrieval in deterministic scope order, with tag, since, per-scope, and global limit support.
- Adds promoteLatestSessionMemory() for the common Sage-style flow of promoting the newest matching session entry to user or another target scope.
- Documents the helper APIs in packages/memory/README.md and adds focused tests.

## Why

Sage PR AgentWorkforce/sage#137 needed this reusable shape while adopting @agent-assistant/memory: relay-backed store construction, scoped turn retrieval, and latest-session promotion are general assistant memory concerns. Slack-specific promotion heuristics and prompt formatting remain product-local in Sage.

## Test plan

npm test -w @agent-assistant/memory
npm run typecheck -w @agent-assistant/memory
npm run build -w @agent-assistant/memory

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
