### PR TITLE
feat(memory,harness): scope-attributed render, structured logs, memory tool registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3512,6 +3512,59 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/continuation/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/continuation/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/continuation/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/continuation/node_modules/@agent-assistant/harness": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
+      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.3.4",
+        "@agent-assistant/vfs": "^0.2.23",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
+    "packages/continuation/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/continuation/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
       "version": "0.3.10",
@@ -3570,11 +3623,12 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.6.12",
+      "version": "0.7.0",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/memory": "^0.4.0",
         "@agent-assistant/traits": "^0.2.0",
         "@agent-assistant/turn-context": "^0.3.4",
         "@agent-assistant/vfs": "^0.2.23",
@@ -4415,7 +4469,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.3.10",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4543,6 +4597,59 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/telemetry/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/telemetry/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/telemetry/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/telemetry/node_modules/@agent-assistant/harness": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
+      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.3.4",
+        "@agent-assistant/vfs": "^0.2.23",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
+    "packages/telemetry/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/telemetry/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
     "packages/traits": {
       "name": "@agent-assistant/traits",
       "version": "0.3.10",
@@ -4566,6 +4673,47 @@
         "vitest": "^3.2.4"
       }
     },
+    "packages/turn-context/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/harness": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
+      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.3.4",
+        "@agent-assistant/vfs": "^0.2.23",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/turn-context/node_modules/@agent-assistant/memory": {
       "version": "0.2.24",
       "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
@@ -4579,6 +4727,12 @@
       "version": "0.2.24",
       "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
       "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/turn-context/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
       "license": "MIT"
     },
     "packages/vfs": {
@@ -4652,6 +4806,30 @@
         "nanoid": "^5.1.6"
       }
     },
+    "packages/webhook-runtime/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "dev": true,
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/harness": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
+      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
+      "dev": true,
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.3.4",
+        "@agent-assistant/vfs": "^0.2.23",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
     "packages/webhook-runtime/node_modules/@agent-assistant/specialists": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@agent-assistant/specialists/-/specialists-0.3.12.tgz",
@@ -4662,6 +4840,13 @@
         "@relayfile/adapter-github": "^0.1.6",
         "@relayfile/adapter-linear": "^0.1.7"
       }
+    },
+    "packages/webhook-runtime/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/webhook-runtime/node_modules/@agent-assistant/vfs": {
       "version": "0.2.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3476,7 +3476,7 @@
     },
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
-      "version": "0.1.5",
+      "version": "0.1.9",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -3491,7 +3491,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3503,7 +3503,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.3.7",
+      "version": "0.3.11",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
       },
@@ -3514,7 +3514,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3537,7 +3537,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3570,7 +3570,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.6.7",
+      "version": "0.6.12",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3627,7 +3627,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4415,7 +4415,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^4.0.23"
@@ -4427,7 +4427,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4439,7 +4439,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4461,7 +4461,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4478,7 +4478,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4486,7 +4486,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.4.6",
+      "version": "0.4.10",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4525,7 +4525,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4533,7 +4533,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.2.7",
+      "version": "0.2.11",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
       },
@@ -4545,7 +4545,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4554,7 +4554,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.3.7",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
@@ -4583,7 +4583,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.3.6",
+      "version": "0.3.10",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4610,7 +4610,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.2.8",
+      "version": "0.2.12",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@agent-assistant/surfaces": "^0.3.0",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.6.12",
+  "version": "0.7.0",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -38,6 +38,7 @@
     "@agent-assistant/connectivity": "^0.2.6",
     "@agent-assistant/core": "^0.2.0",
     "@agent-assistant/coordination": "^0.2.6",
+    "@agent-assistant/memory": "^0.4.0",
     "@agent-assistant/traits": "^0.2.0",
     "@agent-assistant/turn-context": "^0.3.4",
     "@agent-assistant/vfs": "^0.2.23",

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -25,6 +25,14 @@ export {
 } from './tools/workspace-tool-registry.js';
 export type { WorkspaceToolRegistryOptions } from './tools/workspace-tool-registry.js';
 export {
+  createMemoryToolRegistry,
+  MEMORY_FORGET_TOOL_NAME,
+  MEMORY_RECALL_TOOL_NAME,
+  MEMORY_REMEMBER_TOOL_NAME,
+  MEMORY_TOOL_NAMES,
+} from './tools/memory-tool-registry.js';
+export type { MemoryToolRegistryOptions } from './tools/memory-tool-registry.js';
+export {
   createToolEvidenceClarificationHook,
   detectToolEvidenceClarification,
 } from './tool-evidence-clarification.js';

--- a/packages/harness/src/tools/memory-tool-registry.test.ts
+++ b/packages/harness/src/tools/memory-tool-registry.test.ts
@@ -1,0 +1,436 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as memoryModule from '@agent-assistant/memory';
+import { MemoryEntryNotFoundError } from '@agent-assistant/memory';
+import type { MemoryEntry, MemoryStore } from '@agent-assistant/memory';
+
+import type {
+  HarnessToolAvailabilityInput,
+  HarnessToolCall,
+  HarnessToolExecutionContext,
+  HarnessToolResult,
+} from '../types.js';
+import { createMemoryToolRegistry } from './memory-tool-registry.js';
+
+const AVAILABILITY_INPUT: HarnessToolAvailabilityInput = {
+  assistantId: 'assistant-1',
+  turnId: 'turn-1',
+  workspaceId: 'ws1',
+  sessionId: 's1',
+  userId: 'u1',
+};
+
+const EXECUTION_CONTEXT: HarnessToolExecutionContext = {
+  assistantId: 'assistant-1',
+  turnId: 'turn-1',
+  workspaceId: 'ws1',
+  sessionId: 's1',
+  userId: 'u1',
+  threadId: 'thread-1',
+  iteration: 0,
+  toolCallIndex: 0,
+};
+
+function makeEntry(
+  id: string,
+  scope: MemoryEntry['scope'],
+  content: string,
+  overrides: Partial<MemoryEntry> = {},
+): MemoryEntry {
+  return {
+    id,
+    scope,
+    content,
+    tags: [],
+    createdAt: '2026-04-27T12:00:00.000Z',
+    updatedAt: '2026-04-27T12:00:00.000Z',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeStore(overrides: Partial<MemoryStore> = {}): MemoryStore {
+  return {
+    write: vi.fn(),
+    retrieve: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    update: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+    deleteByScope: vi.fn(),
+    promote: vi.fn(),
+    compact: vi.fn(),
+    ...overrides,
+  } as MemoryStore;
+}
+
+function makeCall(name: string, input: Record<string, unknown>): HarnessToolCall {
+  return {
+    id: `${name}-call-1`,
+    name,
+    input,
+  };
+}
+
+function createRegistry(
+  store: MemoryStore | null,
+  scopeContext: { workspaceId?: string; userId?: string; sessionId?: string } = {
+    workspaceId: 'ws1',
+    userId: 'u1',
+    sessionId: 's1',
+  },
+) {
+  return createMemoryToolRegistry({
+    store,
+    resolveScopeContext: () => scopeContext,
+  });
+}
+
+function parseJsonOutput(result: HarnessToolResult): Record<string, unknown> {
+  expect(result.output).toEqual(expect.any(String));
+  return JSON.parse(result.output ?? 'null') as Record<string, unknown>;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('createMemoryToolRegistry listAvailable', () => {
+  it('returns all three tools when the store is provided', async () => {
+    const registry = createRegistry(makeStore());
+
+    const tools = await registry.listAvailable(AVAILABILITY_INPUT);
+
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'memory_remember',
+      'memory_recall',
+      'memory_forget',
+    ]);
+  });
+
+  it('returns [] when the store is null', async () => {
+    const registry = createRegistry(null);
+
+    const tools = await registry.listAvailable(AVAILABILITY_INPUT);
+
+    expect(tools).toEqual([]);
+  });
+
+  it('filters to allowedToolNames when set', async () => {
+    const registry = createRegistry(makeStore());
+
+    const tools = await registry.listAvailable({
+      ...AVAILABILITY_INPUT,
+      allowedToolNames: ['memory_recall'],
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(['memory_recall']);
+  });
+});
+
+describe('createMemoryToolRegistry execute memory_remember', () => {
+  it('writes a session-scoped memory entry and returns id, scope, and expiresAt JSON', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-27T12:00:00.000Z'));
+
+    const storedEntry = makeEntry(
+      'mem-1',
+      { kind: 'session', sessionId: 's1' },
+      'Remember this for the current thread.',
+      { expiresAt: '2026-05-04T12:00:00.000Z' },
+    );
+    const store = makeStore({
+      write: vi.fn().mockResolvedValue(storedEntry),
+    });
+    const registry = createRegistry(store, {
+      userId: 'u1',
+      workspaceId: 'ws1',
+      sessionId: 's1',
+    });
+    const call = makeCall('memory_remember', {
+      content: 'Remember this for the current thread.',
+      scope: 'session',
+      tags: ['project', 'handoff'],
+      expiresInDays: 7,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(store.write).toHaveBeenCalledWith({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'Remember this for the current thread.',
+      tags: ['project', 'handoff'],
+      expiresAt: '2026-05-04T12:00:00.000Z',
+    });
+    expect(result.status).toBe('success');
+    expect(parseJsonOutput(result)).toEqual({
+      id: 'mem-1',
+      scope: { kind: 'session', sessionId: 's1' },
+      expiresAt: '2026-05-04T12:00:00.000Z',
+    });
+  });
+
+  it.each([
+    [
+      'user',
+      { workspaceId: 'ws1', sessionId: 's1' },
+      "memory_remember scope='user' requires user identity in execution context",
+    ],
+    [
+      'session',
+      { workspaceId: 'ws1', userId: 'u1' },
+      "memory_remember scope='session' requires session identity in execution context",
+    ],
+    [
+      'workspace',
+      { userId: 'u1', sessionId: 's1' },
+      "memory_remember scope='workspace' requires workspace identity in execution context",
+    ],
+  ])(
+    'returns invalid_input when scope=%s cannot be resolved from execution context',
+    async (scope, scopeContext, message) => {
+      const store = makeStore();
+      const registry = createRegistry(store, scopeContext);
+      const call = makeCall('memory_remember', {
+        content: 'Scoped fact',
+        scope,
+      });
+
+      const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+      expect(result.status).toBe('error');
+      expect(result.error).toMatchObject({
+        code: 'invalid_input',
+        message,
+        retryable: false,
+      });
+      expect(store.write).not.toHaveBeenCalled();
+    },
+  );
+
+  it('returns invalid_input when content exceeds 2000 characters', async () => {
+    const store = makeStore();
+    const registry = createRegistry(store);
+    const call = makeCall('memory_remember', {
+      content: 'x'.repeat(2001),
+      scope: 'session',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'invalid_input',
+      message: 'input.content must be between 1 and 2000 characters',
+      retryable: false,
+    });
+    expect(store.write).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid_input when scope is missing', async () => {
+    const store = makeStore();
+    const registry = createRegistry(store);
+    const call = makeCall('memory_remember', {
+      content: 'Scoped fact',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'invalid_input',
+      message: 'input.scope must be one of: session, user, workspace',
+      retryable: false,
+    });
+    expect(store.write).not.toHaveBeenCalled();
+  });
+});
+
+describe('createMemoryToolRegistry execute memory_recall', () => {
+  it('calls retrieveTurnMemoryContext when scope is omitted and renders the turn-memory context', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-27T12:00:00.000Z'));
+
+    const sessionEntry = makeEntry(
+      'mem-session',
+      { kind: 'session', sessionId: 's1' },
+      'Remembered for this thread.',
+    );
+    const userEntry = makeEntry(
+      'mem-user',
+      { kind: 'user', userId: 'u1' },
+      'Remembered for this user.',
+    );
+    const contextResult = {
+      entries: [sessionEntry, userEntry],
+      byScope: {
+        session: [sessionEntry],
+        user: [userEntry],
+      },
+    };
+    const retrieveSpy = vi
+      .spyOn(memoryModule, 'retrieveTurnMemoryContext')
+      .mockResolvedValue(contextResult);
+    const store = makeStore();
+    const registry = createRegistry(store);
+    const call = makeCall('memory_recall', {
+      query: 'remembered',
+      limit: 3,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(retrieveSpy).toHaveBeenCalledWith({
+      store,
+      sessionId: 's1',
+      userId: 'u1',
+      workspaceId: 'ws1',
+      query: 'remembered',
+      limit: 3,
+      perScopeLimit: 3,
+      order: 'newest',
+    });
+    expect(result.status).toBe('success');
+    expect(result.output).toBe(memoryModule.renderTurnMemoryContext(contextResult));
+  });
+
+  it('calls store.retrieve directly when a concrete scope is provided', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-27T12:00:00.000Z'));
+
+    const userEntry = makeEntry(
+      'mem-user',
+      { kind: 'user', userId: 'u1' },
+      'Remembered for this user.',
+    );
+    const store = makeStore({
+      retrieve: vi.fn().mockResolvedValue([userEntry]),
+    });
+    const registry = createRegistry(store);
+    const call = makeCall('memory_recall', {
+      query: 'user memory',
+      scope: 'user',
+      limit: 2,
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(store.retrieve).toHaveBeenCalledWith({
+      scope: { kind: 'user', userId: 'u1' },
+      query: 'user memory',
+      limit: 2,
+      order: 'newest',
+    });
+    expect(result.status).toBe('success');
+    expect(result.output).toBe('[user, just now] Remembered for this user.');
+  });
+
+  it('returns status=success with an empty string output when no entries are found', async () => {
+    const store = makeStore({
+      retrieve: vi.fn().mockResolvedValue([]),
+    });
+    const registry = createRegistry(store);
+    const call = makeCall('memory_recall', {
+      query: 'missing',
+      scope: 'user',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('success');
+    expect(result.output).toBe('');
+  });
+});
+
+describe('createMemoryToolRegistry execute memory_forget', () => {
+  it("returns 'forgotten' on the happy path", async () => {
+    const store = makeStore({
+      delete: vi.fn().mockResolvedValue(undefined),
+    });
+    const registry = createRegistry(store);
+    const call = makeCall('memory_forget', {
+      entryId: 'mem-1',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(store.delete).toHaveBeenCalledWith('mem-1');
+    expect(result).toMatchObject({
+      status: 'success',
+      output: 'forgotten',
+    });
+  });
+
+  it('maps MemoryEntryNotFoundError to a not_found tool error', async () => {
+    const store = makeStore({
+      delete: vi.fn().mockRejectedValue(new MemoryEntryNotFoundError('mem-missing')),
+    });
+    const registry = createRegistry(store);
+    const call = makeCall('memory_forget', {
+      entryId: 'mem-missing',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'not_found',
+      message: 'Memory entry not found: mem-missing',
+      retryable: false,
+    });
+  });
+});
+
+describe('createMemoryToolRegistry observability', () => {
+  it("logs one success event JSON line via console.info when a memory write succeeds", async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const store = makeStore({
+      write: vi.fn().mockResolvedValue(
+        makeEntry('mem-1', { kind: 'session', sessionId: 's1' }, 'Observable success.'),
+      ),
+    });
+    const registry = createRegistry(store);
+    const call = makeCall('memory_remember', {
+      content: 'Observable success.',
+      scope: 'session',
+    });
+
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
+
+    expect(result.status).toBe('success');
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(infoSpy.mock.calls[0]?.[0]))).toMatchObject({
+      event: 'memory_op',
+      op: 'save',
+      scope: 'session',
+      sessionId: 's1',
+      status: 'ok',
+      entryCount: 1,
+      contentChars: 'Observable success.'.length,
+    });
+  });
+
+  it("rethrows store.write failures and logs a status='failed' memory_op event", async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const store = makeStore({
+      write: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    const registry = createRegistry(store);
+    const call = makeCall('memory_remember', {
+      content: 'This write fails.',
+      scope: 'session',
+    });
+
+    await expect(registry.execute(call, EXECUTION_CONTEXT)).rejects.toThrow('boom');
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(infoSpy.mock.calls[0]?.[0]))).toMatchObject({
+      event: 'memory_op',
+      op: 'save',
+      scope: 'session',
+      sessionId: 's1',
+      status: 'failed',
+      error: 'boom',
+    });
+  });
+});

--- a/packages/harness/src/tools/memory-tool-registry.test.ts
+++ b/packages/harness/src/tools/memory-tool-registry.test.ts
@@ -410,7 +410,7 @@ describe('createMemoryToolRegistry observability', () => {
     });
   });
 
-  it("rethrows store.write failures and logs a status='failed' memory_op event", async () => {
+  it("returns a retryable tool_error on store.write failures and logs a status='failed' memory_op event", async () => {
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
     const store = makeStore({
       write: vi.fn().mockRejectedValue(new Error('boom')),
@@ -421,8 +421,14 @@ describe('createMemoryToolRegistry observability', () => {
       scope: 'session',
     });
 
-    await expect(registry.execute(call, EXECUTION_CONTEXT)).rejects.toThrow('boom');
+    const result = await registry.execute(call, EXECUTION_CONTEXT);
 
+    expect(result.status).toBe('error');
+    expect(result.error).toMatchObject({
+      code: 'tool_error',
+      message: 'boom',
+      retryable: true,
+    });
     expect(infoSpy).toHaveBeenCalledTimes(1);
     expect(JSON.parse(String(infoSpy.mock.calls[0]?.[0]))).toMatchObject({
       event: 'memory_op',

--- a/packages/harness/src/tools/memory-tool-registry.ts
+++ b/packages/harness/src/tools/memory-tool-registry.ts
@@ -1,0 +1,627 @@
+import {
+  MemoryEntryNotFoundError,
+  measureMemoryOp,
+  renderTurnMemoryContext,
+  retrieveTurnMemoryContext,
+} from '@agent-assistant/memory';
+import type {
+  MemoryEntry,
+  MemoryScope,
+  MemoryStore,
+  WriteMemoryInput,
+} from '@agent-assistant/memory';
+import type {
+  HarnessToolAvailabilityInput,
+  HarnessToolCall,
+  HarnessToolDefinition,
+  HarnessToolExecutionContext,
+  HarnessToolRegistry,
+  HarnessToolResult,
+} from '../types.js';
+
+export interface MemoryToolRegistryOptions {
+  store: MemoryStore | null;
+  resolveScopeContext: (input: HarnessToolExecutionContext) => {
+    workspaceId?: string;
+    userId?: string;
+    sessionId?: string;
+  };
+}
+
+type MemoryToolScope = 'session' | 'user' | 'workspace';
+type MemoryRecallScope = MemoryToolScope | 'any';
+
+interface ValidationSuccess<T> {
+  ok: true;
+  value: T;
+}
+
+interface ValidationFailure {
+  ok: false;
+  message: string;
+}
+
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+const MAX_CONTENT_CHARS = 2000;
+const MAX_QUERY_CHARS = 500;
+const MAX_ENTRY_ID_CHARS = 200;
+const MAX_TAGS = 10;
+const DEFAULT_RECALL_LIMIT = 5;
+const MAX_RECALL_LIMIT = 20;
+const MAX_EXPIRES_IN_DAYS = 365;
+
+const MEMORY_SCOPES = ['session', 'user', 'workspace'] as const;
+const MEMORY_RECALL_SCOPES = [...MEMORY_SCOPES, 'any'] as const;
+
+export const MEMORY_REMEMBER_TOOL_NAME = 'memory_remember';
+export const MEMORY_RECALL_TOOL_NAME = 'memory_recall';
+export const MEMORY_FORGET_TOOL_NAME = 'memory_forget';
+export const MEMORY_TOOL_NAMES = [
+  MEMORY_REMEMBER_TOOL_NAME,
+  MEMORY_RECALL_TOOL_NAME,
+  MEMORY_FORGET_TOOL_NAME,
+] as const;
+
+const MEMORY_REMEMBER_TOOL: HarnessToolDefinition = {
+  name: MEMORY_REMEMBER_TOOL_NAME,
+  description:
+    "Save a durable fact to memory. Use when the user shares a preference, project context, ownership info, deadline, or any fact you should recall in future turns. Pick the narrowest scope that's still useful: 'session' for thread-only context, 'user' for per-person facts, 'workspace' for org-wide context shared by everyone in this Slack workspace.",
+  inputSchema: {
+    type: 'object',
+    required: ['content', 'scope'],
+    properties: {
+      content: { type: 'string', minLength: 1, maxLength: MAX_CONTENT_CHARS },
+      scope: { type: 'string', enum: MEMORY_SCOPES },
+      tags: {
+        type: 'array',
+        maxItems: MAX_TAGS,
+        items: { type: 'string' },
+      },
+      expiresInDays: { type: 'number', minimum: 1, maximum: MAX_EXPIRES_IN_DAYS },
+    },
+  },
+};
+
+const MEMORY_RECALL_TOOL: HarnessToolDefinition = {
+  name: MEMORY_RECALL_TOOL_NAME,
+  description:
+    'Search memory for relevant facts. Use when the user asks about prior context, when you need to verify a preference before acting, or before answering questions where you suspect prior context exists. Returns up to limit entries ranked by recency and (when supported) semantic relevance.',
+  inputSchema: {
+    type: 'object',
+    required: ['query'],
+    properties: {
+      query: { type: 'string', minLength: 1, maxLength: MAX_QUERY_CHARS },
+      scope: { type: 'string', enum: MEMORY_RECALL_SCOPES },
+      limit: { type: 'number', minimum: 1, maximum: MAX_RECALL_LIMIT },
+    },
+  },
+};
+
+const MEMORY_FORGET_TOOL: HarnessToolDefinition = {
+  name: MEMORY_FORGET_TOOL_NAME,
+  description:
+    'Delete a specific memory entry by id. Use when the user explicitly asks you to forget something, or when you discover a stored fact is wrong / superseded. Pass the id from a memory_recall result.',
+  inputSchema: {
+    type: 'object',
+    required: ['entryId'],
+    properties: {
+      entryId: { type: 'string', minLength: 1, maxLength: MAX_ENTRY_ID_CHARS },
+    },
+  },
+};
+
+const MEMORY_TOOLS = [
+  MEMORY_REMEMBER_TOOL,
+  MEMORY_RECALL_TOOL,
+  MEMORY_FORGET_TOOL,
+] satisfies HarnessToolDefinition[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isMemoryToolScope(value: unknown): value is MemoryToolScope {
+  return (
+    typeof value === 'string' &&
+    (MEMORY_SCOPES as readonly string[]).includes(value)
+  );
+}
+
+function isMemoryRecallScope(value: unknown): value is MemoryRecallScope {
+  return (
+    typeof value === 'string' &&
+    (MEMORY_RECALL_SCOPES as readonly string[]).includes(value)
+  );
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+function successResult(
+  call: HarnessToolCall,
+  output: string,
+  structuredOutput?: Record<string, unknown>,
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'success',
+    output,
+    ...(structuredOutput ? { structuredOutput } : {}),
+  };
+}
+
+function errorResult(
+  call: HarnessToolCall,
+  code: string,
+  message: string,
+  retryable: boolean,
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'error',
+    error: {
+      code,
+      message,
+      retryable,
+    },
+  };
+}
+
+function memoryUnavailableResult(call: HarnessToolCall): HarnessToolResult {
+  return errorResult(
+    call,
+    'memory_unavailable',
+    'Memory store not configured',
+    false,
+  );
+}
+
+function unknownToolResult(call: HarnessToolCall): HarnessToolResult {
+  return errorResult(call, 'unknown_tool', `Unknown tool: ${call.name}`, false);
+}
+
+function invalidInputResult(call: HarnessToolCall, message: string): HarnessToolResult {
+  return errorResult(call, 'invalid_input', message, false);
+}
+
+function thrownErrorResult(call: HarnessToolCall, error: unknown): HarnessToolResult {
+  return errorResult(call, 'tool_error', toErrorMessage(error), true);
+}
+
+function notFoundResult(call: HarnessToolCall, message: string): HarnessToolResult {
+  return errorResult(call, 'not_found', message, false);
+}
+
+function readRequiredString(
+  input: Record<string, unknown>,
+  key: string,
+): ValidationResult<string> {
+  const value = input[key];
+  if (typeof value !== 'string' || value.trim().length < 1) {
+    return { ok: false, message: `input.${key} must be a non-empty string` };
+  }
+  return { ok: true, value };
+}
+
+function readOptionalInteger(
+  input: Record<string, unknown>,
+  key: string,
+  fallback: number | undefined,
+  min: number,
+  max: number,
+): ValidationResult<number | undefined> {
+  const value = input[key];
+  if (value === undefined) {
+    return { ok: true, value: fallback };
+  }
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < min ||
+    value > max
+  ) {
+    return {
+      ok: false,
+      message: `input.${key} must be an integer between ${min} and ${max}`,
+    };
+  }
+  return { ok: true, value };
+}
+
+function readOptionalTags(
+  input: Record<string, unknown>,
+  key: string,
+): ValidationResult<string[] | undefined> {
+  const value = input[key];
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+  if (!Array.isArray(value)) {
+    return { ok: false, message: `input.${key} must be an array of strings` };
+  }
+  if (value.length > MAX_TAGS) {
+    return { ok: false, message: `input.${key} must contain at most ${MAX_TAGS} items` };
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || item.trim().length < 1) {
+      return { ok: false, message: `input.${key} must be an array of non-empty strings` };
+    }
+  }
+  return { ok: true, value: [...value] };
+}
+
+function validateRememberInput(
+  input: unknown,
+): ValidationResult<{
+  content: string;
+  scope: MemoryToolScope;
+  tags?: string[];
+  expiresInDays?: number;
+}> {
+  if (!isRecord(input)) {
+    return { ok: false, message: 'input must be an object' };
+  }
+
+  const content = readRequiredString(input, 'content');
+  if (!content.ok) {
+    return content;
+  }
+  if (content.value.length > MAX_CONTENT_CHARS) {
+    return {
+      ok: false,
+      message: `input.content must be between 1 and ${MAX_CONTENT_CHARS} characters`,
+    };
+  }
+
+  if (!isMemoryToolScope(input.scope)) {
+    return {
+      ok: false,
+      message: 'input.scope must be one of: session, user, workspace',
+    };
+  }
+
+  const tags = readOptionalTags(input, 'tags');
+  if (!tags.ok) {
+    return tags;
+  }
+
+  const expiresInDays = readOptionalInteger(
+    input,
+    'expiresInDays',
+    undefined,
+    1,
+    MAX_EXPIRES_IN_DAYS,
+  );
+  if (!expiresInDays.ok) {
+    return expiresInDays;
+  }
+
+  return {
+    ok: true,
+    value: {
+      content: content.value,
+      scope: input.scope,
+      ...(tags.value ? { tags: tags.value } : {}),
+      ...(expiresInDays.value !== undefined ? { expiresInDays: expiresInDays.value } : {}),
+    },
+  };
+}
+
+function validateRecallInput(
+  input: unknown,
+): ValidationResult<{
+  query: string;
+  scope?: MemoryRecallScope;
+  limit: number;
+}> {
+  if (!isRecord(input)) {
+    return { ok: false, message: 'input must be an object' };
+  }
+
+  const query = readRequiredString(input, 'query');
+  if (!query.ok) {
+    return query;
+  }
+  if (query.value.length > MAX_QUERY_CHARS) {
+    return {
+      ok: false,
+      message: `input.query must be between 1 and ${MAX_QUERY_CHARS} characters`,
+    };
+  }
+
+  if (input.scope !== undefined && !isMemoryRecallScope(input.scope)) {
+    return {
+      ok: false,
+      message: 'input.scope must be one of: session, user, workspace, any',
+    };
+  }
+
+  const limit = readOptionalInteger(
+    input,
+    'limit',
+    DEFAULT_RECALL_LIMIT,
+    1,
+    MAX_RECALL_LIMIT,
+  );
+  if (!limit.ok || limit.value === undefined) {
+    return limit.ok
+      ? { ok: false, message: `input.limit must be an integer between 1 and ${MAX_RECALL_LIMIT}` }
+      : limit;
+  }
+
+  return {
+    ok: true,
+    value: {
+      query: query.value,
+      ...(input.scope ? { scope: input.scope } : {}),
+      limit: limit.value,
+    },
+  };
+}
+
+function validateForgetInput(input: unknown): ValidationResult<{ entryId: string }> {
+  if (!isRecord(input)) {
+    return { ok: false, message: 'input must be an object' };
+  }
+
+  const entryId = readRequiredString(input, 'entryId');
+  if (!entryId.ok) {
+    return entryId;
+  }
+  if (entryId.value.length > MAX_ENTRY_ID_CHARS) {
+    return {
+      ok: false,
+      message: `input.entryId must be between 1 and ${MAX_ENTRY_ID_CHARS} characters`,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      entryId: entryId.value,
+    },
+  };
+}
+
+function scopeEventMeta(
+  scope: MemoryScope,
+): {
+  scope: MemoryToolScope;
+  sessionId?: string;
+  userId?: string;
+  workspaceId?: string;
+} {
+  switch (scope.kind) {
+    case 'session':
+      return { scope: 'session', sessionId: scope.sessionId };
+    case 'user':
+      return { scope: 'user', userId: scope.userId };
+    case 'workspace':
+      return { scope: 'workspace', workspaceId: scope.workspaceId };
+    default:
+      throw new Error(`Unsupported memory scope: ${(scope as MemoryScope).kind}`);
+  }
+}
+
+function resolveScope(
+  toolName: string,
+  scope: MemoryToolScope,
+  resolved: ReturnType<MemoryToolRegistryOptions['resolveScopeContext']>,
+): ValidationResult<MemoryScope> {
+  switch (scope) {
+    case 'session':
+      if (!resolved.sessionId) {
+        return {
+          ok: false,
+          message: `${toolName} scope='session' requires session identity in execution context`,
+        };
+      }
+      return { ok: true, value: { kind: 'session', sessionId: resolved.sessionId } };
+    case 'user':
+      if (!resolved.userId) {
+        return {
+          ok: false,
+          message: `${toolName} scope='user' requires user identity in execution context`,
+        };
+      }
+      return { ok: true, value: { kind: 'user', userId: resolved.userId } };
+    case 'workspace':
+      if (!resolved.workspaceId) {
+        return {
+          ok: false,
+          message: `${toolName} scope='workspace' requires workspace identity in execution context`,
+        };
+      }
+      return {
+        ok: true,
+        value: { kind: 'workspace', workspaceId: resolved.workspaceId },
+      };
+  }
+}
+
+function knownToolName(name: string): boolean {
+  return MEMORY_TOOLS.some((tool) => tool.name === name);
+}
+
+function expiresAtFromDays(expiresInDays: number | undefined): string | undefined {
+  if (expiresInDays === undefined) {
+    return undefined;
+  }
+
+  return new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function renderScopedEntries(scope: MemoryToolScope, entries: MemoryEntry[]): string {
+  return renderTurnMemoryContext({
+    entries,
+    byScope: {
+      [scope]: entries,
+    },
+  });
+}
+
+export function createMemoryToolRegistry(
+  options: MemoryToolRegistryOptions,
+): HarnessToolRegistry {
+  return {
+    async listAvailable(input: HarnessToolAvailabilityInput) {
+      if (!options.store) {
+        return [];
+      }
+
+      if (!input.allowedToolNames || input.allowedToolNames.length === 0) {
+        return [...MEMORY_TOOLS];
+      }
+
+      const allowedToolNames = new Set(input.allowedToolNames);
+      return MEMORY_TOOLS.filter((tool) => allowedToolNames.has(tool.name));
+    },
+
+    async execute(call: HarnessToolCall, context: HarnessToolExecutionContext) {
+      if (!knownToolName(call.name)) {
+        return unknownToolResult(call);
+      }
+
+      const store = options.store;
+      if (!store) {
+        return memoryUnavailableResult(call);
+      }
+
+      const resolvedScopeContext = options.resolveScopeContext(context);
+
+      try {
+        if (call.name === MEMORY_REMEMBER_TOOL_NAME) {
+          const validation = validateRememberInput(call.input);
+          if (!validation.ok) {
+            return invalidInputResult(call, validation.message);
+          }
+
+          const scope = resolveScope(call.name, validation.value.scope, resolvedScopeContext);
+          if (!scope.ok) {
+            return invalidInputResult(call, scope.message);
+          }
+
+          const expiresAt = expiresAtFromDays(validation.value.expiresInDays);
+          const writeInput: WriteMemoryInput = {
+            scope: scope.value,
+            content: validation.value.content,
+            ...(validation.value.tags ? { tags: validation.value.tags } : {}),
+            ...(expiresAt ? { expiresAt } : {}),
+          };
+
+          const written = await measureMemoryOp(
+            {
+              op: 'save',
+              ...scopeEventMeta(scope.value),
+              contentChars: validation.value.content.length,
+              entryCount: 1,
+            },
+            async () => store.write(writeInput),
+          );
+
+          return successResult(
+            call,
+            JSON.stringify({
+              id: written.id,
+              scope: written.scope,
+              expiresAt: written.expiresAt ?? null,
+            }),
+            { entry: written },
+          );
+        }
+
+        if (call.name === MEMORY_RECALL_TOOL_NAME) {
+          const validation = validateRecallInput(call.input);
+          if (!validation.ok) {
+            return invalidInputResult(call, validation.message);
+          }
+
+          if (validation.value.scope === undefined || validation.value.scope === 'any') {
+            const contextResult = await measureMemoryOp(
+              {
+                op: 'load',
+                ...(resolvedScopeContext.sessionId
+                  ? { sessionId: resolvedScopeContext.sessionId }
+                  : {}),
+                ...(resolvedScopeContext.userId ? { userId: resolvedScopeContext.userId } : {}),
+                ...(resolvedScopeContext.workspaceId
+                  ? { workspaceId: resolvedScopeContext.workspaceId }
+                  : {}),
+              },
+              async () =>
+                retrieveTurnMemoryContext({
+                  store,
+                  sessionId: resolvedScopeContext.sessionId,
+                  userId: resolvedScopeContext.userId,
+                  workspaceId: resolvedScopeContext.workspaceId,
+                  query: validation.value.query,
+                  limit: validation.value.limit,
+                  perScopeLimit: validation.value.limit,
+                  order: 'newest',
+                }),
+            );
+
+            return successResult(
+              call,
+              renderTurnMemoryContext(contextResult),
+              { entries: contextResult.entries },
+            );
+          }
+
+          const scope = resolveScope(call.name, validation.value.scope, resolvedScopeContext);
+          if (!scope.ok) {
+            return invalidInputResult(call, scope.message);
+          }
+
+          const entries = await measureMemoryOp(
+            {
+              op: 'load',
+              ...scopeEventMeta(scope.value),
+            },
+            async () =>
+              store.retrieve({
+                scope: scope.value,
+                query: validation.value.query,
+                limit: validation.value.limit,
+                order: 'newest',
+              }),
+          );
+
+          return successResult(
+            call,
+            renderScopedEntries(validation.value.scope, entries),
+            { entries },
+          );
+        }
+
+        const validation = validateForgetInput(call.input);
+        if (!validation.ok) {
+          return invalidInputResult(call, validation.message);
+        }
+
+        await measureMemoryOp(
+          {
+            op: 'forget',
+            entryCount: 1,
+          },
+          async () => store.delete(validation.value.entryId),
+        );
+
+        return successResult(call, 'forgotten');
+      } catch (error) {
+        if (call.name === MEMORY_REMEMBER_TOOL_NAME) {
+          throw error;
+        }
+        if (call.name === MEMORY_FORGET_TOOL_NAME && error instanceof MemoryEntryNotFoundError) {
+          return notFoundResult(call, error.message);
+        }
+        return thrownErrorResult(call, error);
+      }
+    },
+  };
+}

--- a/packages/harness/src/tools/memory-tool-registry.ts
+++ b/packages/harness/src/tools/memory-tool-registry.ts
@@ -614,9 +614,6 @@ export function createMemoryToolRegistry(
 
         return successResult(call, 'forgotten');
       } catch (error) {
-        if (call.name === MEMORY_REMEMBER_TOOL_NAME) {
-          throw error;
-        }
         if (call.name === MEMORY_FORGET_TOOL_NAME && error instanceof MemoryEntryNotFoundError) {
           return notFoundResult(call, error.message);
         }

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/memory",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "description": "Assistant-scoped memory composition layer over @agent-relay/memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -5,9 +5,23 @@ export {
 } from './memory.js';
 
 export {
+  hashMemoryContent,
+  logMemoryOp,
+  measureMemoryOp,
+} from './observability.js';
+
+export {
+  formatRelativeAge,
+} from './relative-age.js';
+
+export {
   createRelayBackedMemoryStore,
   promoteLatestSessionMemory,
+  renderTurnMemoryContext,
   retrieveTurnMemoryContext,
+  SESSION_LOAD_LIMIT,
+  USER_LOAD_LIMIT,
+  WORKSPACE_LOAD_LIMIT,
 } from './turn-memory.js';
 
 export {
@@ -32,9 +46,15 @@ export type {
 } from './types.js';
 
 export type {
+  MemoryOpEvent,
+  MemoryOpName,
+} from './observability.js';
+
+export type {
   CreateRelayBackedMemoryStoreOptions,
   PromoteLatestSessionMemoryInput,
   RelayBackedMemoryStore,
+  RenderTurnMemoryContextOptions,
   RetrieveTurnMemoryContextInput,
   TurnMemoryContext,
   TurnMemoryScopeKind,

--- a/packages/memory/src/observability.test.ts
+++ b/packages/memory/src/observability.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  hashMemoryContent,
+  logMemoryOp,
+  measureMemoryOp,
+} from './observability.js';
+
+describe('observability helpers', () => {
+  it('logMemoryOp emits one JSON line via console.info', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    logMemoryOp({
+      event: 'memory_op',
+      op: 'load',
+      scope: 'session',
+      sessionId: 's1',
+      status: 'ok',
+      durationMs: 12,
+    });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      JSON.stringify({
+        event: 'memory_op',
+        op: 'load',
+        scope: 'session',
+        sessionId: 's1',
+        status: 'ok',
+        durationMs: 12,
+      }),
+    );
+  });
+
+  it('measureMemoryOp returns the inner value and logs an ok status', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const inner = vi.fn(async () => 'result');
+
+    await expect(measureMemoryOp({ op: 'save', scope: 'user', userId: 'u1' }, inner)).resolves.toBe(
+      'result',
+    );
+
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(infoSpy.mock.calls[0]?.[0]))).toMatchObject({
+      event: 'memory_op',
+      op: 'save',
+      scope: 'user',
+      userId: 'u1',
+      status: 'ok',
+    });
+    expect(JSON.parse(String(infoSpy.mock.calls[0]?.[0])).durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('hashes memory content to a deterministic 22-character digest', () => {
+    const first = hashMemoryContent('hello world');
+    const second = hashMemoryContent('hello world');
+    const third = hashMemoryContent('different');
+
+    expect(first).toHaveLength(22);
+    expect(first).toBe(second);
+    expect(first).not.toBe(third);
+  });
+
+  it('logs failed measured operations and rethrows the original error', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const failure = new Error('boom');
+
+    await expect(
+      measureMemoryOp({ op: 'load', scope: 'session', sessionId: 's1' }, async () => {
+        throw failure;
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(infoSpy.mock.calls[0]?.[0]))).toMatchObject({
+      event: 'memory_op',
+      op: 'load',
+      status: 'failed',
+      error: 'boom',
+      scope: 'session',
+      sessionId: 's1',
+    });
+  });
+});

--- a/packages/memory/src/observability.ts
+++ b/packages/memory/src/observability.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto';
+
+export type MemoryOpName =
+  | 'load'
+  | 'save'
+  | 'promote'
+  | 'compact'
+  | 'close'
+  | 'init'
+  | 'forget';
+
+export interface MemoryOpEvent {
+  event: 'memory_op';
+  op: MemoryOpName;
+  scope?: 'session' | 'user' | 'workspace';
+  workspaceId?: string;
+  sessionId?: string;
+  userId?: string;
+  entryCount?: number;
+  contentChars?: number;
+  status: 'ok' | 'failed';
+  error?: string;
+  durationMs: number;
+}
+
+export function logMemoryOp(event: MemoryOpEvent): void {
+  console.info(JSON.stringify(event));
+}
+
+export async function measureMemoryOp<T>(
+  meta: Omit<MemoryOpEvent, 'event' | 'status' | 'durationMs'>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const startedAt = performance.now();
+
+  try {
+    const result = await fn();
+    logMemoryOp({
+      ...meta,
+      event: 'memory_op',
+      status: 'ok',
+      durationMs: performance.now() - startedAt,
+    });
+    return result;
+  } catch (error) {
+    logMemoryOp({
+      ...meta,
+      event: 'memory_op',
+      status: 'failed',
+      error: error instanceof Error ? error.message : String(error),
+      durationMs: performance.now() - startedAt,
+    });
+    throw error;
+  }
+}
+
+export function hashMemoryContent(content: string): string {
+  return createHash('sha256').update(content).digest().subarray(0, 16).toString('base64url');
+}

--- a/packages/memory/src/relative-age.test.ts
+++ b/packages/memory/src/relative-age.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRelativeAge } from './relative-age.js';
+
+describe('formatRelativeAge', () => {
+  const now = new Date('2026-04-27T12:00:00.000Z');
+
+  it('returns just now for entries less than 60 seconds old', () => {
+    expect(formatRelativeAge({ createdAt: '2026-04-27T11:59:01.000Z' }, now)).toBe('just now');
+  });
+
+  it('formats minute and hour boundaries correctly', () => {
+    expect(formatRelativeAge({ createdAt: '2026-04-27T11:59:00.000Z' }, now)).toBe('1 minute ago');
+    expect(formatRelativeAge({ createdAt: '2026-04-27T11:01:00.000Z' }, now)).toBe('59 minutes ago');
+    expect(formatRelativeAge({ createdAt: '2026-04-27T11:00:00.000Z' }, now)).toBe('1 hour ago');
+  });
+
+  it('formats singular and plural units correctly', () => {
+    expect(formatRelativeAge({ createdAt: '2026-04-27T10:00:00.000Z' }, now)).toBe('2 hours ago');
+    expect(formatRelativeAge({ createdAt: '2026-04-26T12:00:00.000Z' }, now)).toBe('1 day ago');
+    expect(formatRelativeAge({ createdAt: '2026-04-25T12:00:00.000Z' }, now)).toBe('2 days ago');
+    expect(formatRelativeAge({ createdAt: '2026-04-20T12:00:00.000Z' }, now)).toBe('1 week ago');
+    expect(formatRelativeAge({ createdAt: '2026-03-28T12:00:00.000Z' }, now)).toBe('1 month ago');
+    expect(formatRelativeAge({ createdAt: '2025-04-27T12:00:00.000Z' }, now)).toBe('1 year ago');
+  });
+
+  it('accepts string, Date, and epoch-millisecond createdAt values', () => {
+    expect(formatRelativeAge({ createdAt: '2026-04-27T11:59:00.000Z' }, now)).toBe('1 minute ago');
+    expect(formatRelativeAge({ createdAt: new Date('2026-04-20T12:00:00.000Z') }, now)).toBe(
+      '1 week ago',
+    );
+    expect(formatRelativeAge({ createdAt: Date.parse('2026-04-27T10:00:00.000Z') }, now)).toBe(
+      '2 hours ago',
+    );
+  });
+
+  it('returns unknown age for missing or unparseable timestamps', () => {
+    expect(formatRelativeAge({}, now)).toBe('unknown age');
+    expect(formatRelativeAge({ createdAt: 'not-a-date' }, now)).toBe('unknown age');
+  });
+});

--- a/packages/memory/src/relative-age.ts
+++ b/packages/memory/src/relative-age.ts
@@ -1,0 +1,56 @@
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+const MONTH_MS = 30 * DAY_MS;
+const YEAR_MS = 365 * DAY_MS;
+
+function pluralize(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? '' : 's'} ago`;
+}
+
+function toDate(value: string | Date | number | undefined): Date | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatRelativeAge(
+  entry: { createdAt?: string | Date | number },
+  now = new Date(),
+): string {
+  const createdAt = toDate(entry.createdAt);
+  if (!createdAt) {
+    return 'unknown age';
+  }
+
+  const ageMs = Math.max(0, now.getTime() - createdAt.getTime());
+  if (ageMs < MINUTE_MS) {
+    return 'just now';
+  }
+
+  if (ageMs < HOUR_MS) {
+    return pluralize(Math.floor(ageMs / MINUTE_MS), 'minute');
+  }
+
+  if (ageMs < DAY_MS) {
+    return pluralize(Math.floor(ageMs / HOUR_MS), 'hour');
+  }
+
+  if (ageMs < WEEK_MS) {
+    return pluralize(Math.floor(ageMs / DAY_MS), 'day');
+  }
+
+  if (ageMs < MONTH_MS) {
+    return pluralize(Math.floor(ageMs / WEEK_MS), 'week');
+  }
+
+  if (ageMs < YEAR_MS) {
+    return pluralize(Math.floor(ageMs / MONTH_MS), 'month');
+  }
+
+  return pluralize(Math.floor(ageMs / YEAR_MS), 'year');
+}

--- a/packages/memory/src/turn-memory.test.ts
+++ b/packages/memory/src/turn-memory.test.ts
@@ -161,7 +161,13 @@ describe('turn memory helpers', () => {
     ]);
   });
 
-  it('uses scope-specific default load limits', async () => {
+  it('preserves backwards-compat: uses DEFAULT_TURN_MEMORY_LIMIT when no explicit limit is provided', async () => {
+    // Per Devin review on PR #68: callers that provide neither limit,
+    // perScopeLimit, nor perScopeLimits previously got DEFAULT_TURN_MEMORY_LIMIT
+    // (20) per scope. Falling through to scope-specific constants
+    // (SESSION_LOAD_LIMIT=6, USER_LOAD_LIMIT=8, WORKSPACE_LOAD_LIMIT=4) would
+    // silently shrink existing callers' results. Constants remain available
+    // for opt-in via perScopeLimits.
     const entry = fixedEntry({ kind: 'session', sessionId: 's1' });
     const retrieve = vi.fn(async (query: MemoryQuery) => [entry]);
     const store = stubStore(entry, retrieve);
@@ -171,6 +177,27 @@ describe('turn memory helpers', () => {
       sessionId: 's1',
       userId: 'u1',
       workspaceId: 'w1',
+    });
+
+    const queries = retrieve.mock.calls.map(([query]) => query);
+    expect(queries.map((query) => query.limit)).toEqual([20, 20, 20]);
+  });
+
+  it('honors SESSION/USER/WORKSPACE_LOAD_LIMIT constants when caller opts in via perScopeLimits', async () => {
+    const entry = fixedEntry({ kind: 'session', sessionId: 's1' });
+    const retrieve = vi.fn(async (query: MemoryQuery) => [entry]);
+    const store = stubStore(entry, retrieve);
+
+    await retrieveTurnMemoryContext({
+      store,
+      sessionId: 's1',
+      userId: 'u1',
+      workspaceId: 'w1',
+      perScopeLimits: {
+        session: SESSION_LOAD_LIMIT,
+        user: USER_LOAD_LIMIT,
+        workspace: WORKSPACE_LOAD_LIMIT,
+      },
     });
 
     const queries = retrieve.mock.calls.map(([query]) => query);

--- a/packages/memory/src/turn-memory.test.ts
+++ b/packages/memory/src/turn-memory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createMemoryStore,
@@ -7,13 +7,36 @@ import {
 import {
   createRelayBackedMemoryStore,
   promoteLatestSessionMemory,
+  renderTurnMemoryContext,
   retrieveTurnMemoryContext,
+  SESSION_LOAD_LIMIT,
+  USER_LOAD_LIMIT,
+  WORKSPACE_LOAD_LIMIT,
 } from './turn-memory.js';
-import type { MemoryStore } from './types.js';
+import type { MemoryEntry, MemoryQuery, MemoryStore } from './types.js';
 
 function makeStore(): MemoryStore {
   return createMemoryStore({ adapter: new InMemoryMemoryStoreAdapter() });
 }
+
+function fixedEntry(
+  scope: MemoryEntry['scope'],
+  overrides: Partial<MemoryEntry> = {},
+): MemoryEntry {
+  return {
+    id: overrides.id ?? 'entry-1',
+    scope,
+    content: overrides.content ?? 'memory',
+    tags: overrides.tags ?? [],
+    createdAt: overrides.createdAt ?? '2026-04-27T12:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-04-27T12:00:00.000Z',
+    metadata: overrides.metadata ?? {},
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('turn memory helpers', () => {
   it('creates a relay-backed memory store with a close handle', async () => {
@@ -58,45 +81,104 @@ describe('turn memory helpers', () => {
     ]);
     expect(context.byScope.session?.map((entry) => entry.content)).toEqual(['current thread']);
     expect(context.byScope.user?.map((entry) => entry.content)).toEqual(['user preference']);
-    expect(context.byScope.workspace?.map((entry) => entry.content)).toEqual(['workspace convention']);
+    expect(context.byScope.workspace?.map((entry) => entry.content)).toEqual([
+      'workspace convention',
+    ]);
   });
 
   it('honors tags, per-scope limits, and global limits', async () => {
     const store = makeStore();
+    vi.useFakeTimers();
 
-    await store.write({
-      scope: { kind: 'session', sessionId: 's1' },
-      content: 'session keep',
-      tags: ['turn'],
-    });
-    await store.write({
-      scope: { kind: 'session', sessionId: 's1' },
-      content: 'session skip',
-      tags: ['other'],
-    });
-    await store.write({
-      scope: { kind: 'user', userId: 'u1' },
-      content: 'user keep',
-      tags: ['turn'],
-    });
-    await store.write({
-      scope: { kind: 'workspace', workspaceId: 'w1' },
-      content: 'workspace keep',
-      tags: ['turn'],
-    });
+    try {
+      vi.setSystemTime(new Date('2026-04-27T12:00:00.000Z'));
+      await store.write({
+        scope: { kind: 'session', sessionId: 's1' },
+        content: 'session skip',
+        tags: ['other'],
+      });
+      vi.setSystemTime(new Date('2026-04-27T12:00:02.000Z'));
+      await store.write({
+        scope: { kind: 'user', userId: 'u1' },
+        content: 'user keep',
+        tags: ['turn'],
+      });
+      vi.setSystemTime(new Date('2026-04-27T12:00:03.000Z'));
+      await store.write({
+        scope: { kind: 'workspace', workspaceId: 'w1' },
+        content: 'workspace keep',
+        tags: ['turn'],
+      });
+      vi.setSystemTime(new Date('2026-04-27T12:00:04.000Z'));
+      await store.write({
+        scope: { kind: 'session', sessionId: 's1' },
+        content: 'session keep',
+        tags: ['turn'],
+      });
 
-    const context = await retrieveTurnMemoryContext({
+      const context = await retrieveTurnMemoryContext({
+        store,
+        sessionId: 's1',
+        userId: 'u1',
+        workspaceId: 'w1',
+        tags: ['turn'],
+        perScopeLimit: 1,
+        limit: 2,
+      });
+
+      expect(context.entries.map((entry) => entry.content)).toEqual(['session keep', 'user keep']);
+      expect(context.entries).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('supports per-scope limit overrides and query passthrough', async () => {
+    const entry = fixedEntry({ kind: 'session', sessionId: 's1' });
+    const retrieve = vi.fn(async (query: MemoryQuery) => [entry]);
+    const store = stubStore(entry, retrieve);
+
+    await retrieveTurnMemoryContext({
       store,
       sessionId: 's1',
       userId: 'u1',
       workspaceId: 'w1',
-      tags: ['turn'],
-      perScopeLimit: 1,
-      limit: 2,
+      query: 'project alpha',
+      perScopeLimits: {
+        session: 2,
+        user: 3,
+        workspace: 1,
+      },
     });
 
-    expect(context.entries.map((entry) => entry.content)).toEqual(['session keep', 'user keep']);
-    expect(context.entries).toHaveLength(2);
+    expect(retrieve).toHaveBeenCalledTimes(3);
+    const queries = retrieve.mock.calls.map(([query]) => query);
+    expect(queries.map((query) => query.limit)).toEqual([2, 3, 1]);
+    expect(queries.map((query) => query.query)).toEqual([
+      'project alpha',
+      'project alpha',
+      'project alpha',
+    ]);
+  });
+
+  it('uses scope-specific default load limits', async () => {
+    const entry = fixedEntry({ kind: 'session', sessionId: 's1' });
+    const retrieve = vi.fn(async (query: MemoryQuery) => [entry]);
+    const store = stubStore(entry, retrieve);
+
+    await retrieveTurnMemoryContext({
+      store,
+      sessionId: 's1',
+      userId: 'u1',
+      workspaceId: 'w1',
+    });
+
+    const queries = retrieve.mock.calls.map(([query]) => query);
+    expect(queries.map((query) => query.limit)).toEqual([
+      SESSION_LOAD_LIMIT,
+      USER_LOAD_LIMIT,
+      WORKSPACE_LOAD_LIMIT,
+    ]);
   });
 
   it('supports custom scope order', async () => {
@@ -121,6 +203,83 @@ describe('turn memory helpers', () => {
       'workspace first',
       'session second',
     ]);
+  });
+
+  it('renders session, user, then workspace lines in the expected format', () => {
+    const context = {
+      entries: [
+        fixedEntry(
+          { kind: 'session', sessionId: 's1' },
+          { id: 'session-1', content: 'current thread', createdAt: '2026-04-27T11:59:00.000Z' },
+        ),
+        fixedEntry(
+          { kind: 'user', userId: 'u1' },
+          { id: 'user-1', content: 'user preference', createdAt: '2026-04-27T10:00:00.000Z' },
+        ),
+        fixedEntry(
+          { kind: 'workspace', workspaceId: 'w1' },
+          { id: 'workspace-1', content: 'workspace convention', createdAt: '2026-04-20T12:00:00.000Z' },
+        ),
+      ],
+      byScope: {
+        session: [
+          fixedEntry(
+            { kind: 'session', sessionId: 's1' },
+            { id: 'session-1', content: 'current thread', createdAt: '2026-04-27T11:59:00.000Z' },
+          ),
+        ],
+        user: [
+          fixedEntry(
+            { kind: 'user', userId: 'u1' },
+            { id: 'user-1', content: 'user preference', createdAt: '2026-04-27T10:00:00.000Z' },
+          ),
+        ],
+        workspace: [
+          fixedEntry(
+            { kind: 'workspace', workspaceId: 'w1' },
+            {
+              id: 'workspace-1',
+              content: 'workspace convention',
+              createdAt: '2026-04-20T12:00:00.000Z',
+            },
+          ),
+        ],
+      },
+    };
+
+    expect(renderTurnMemoryContext(context, { now: new Date('2026-04-27T12:00:00.000Z') })).toBe(
+      '[thread, 1 minute ago] current thread\n[user, 2 hours ago] user preference\n[workspace, 1 week ago] workspace convention',
+    );
+  });
+
+  it('respects scope label overrides when rendering turn memory context', () => {
+    const context = {
+      entries: [
+        fixedEntry(
+          { kind: 'user', userId: 'u1' },
+          { id: 'user-1', content: 'user preference', createdAt: '2026-04-27T10:00:00.000Z' },
+        ),
+      ],
+      byScope: {
+        user: [
+          fixedEntry(
+            { kind: 'user', userId: 'u1' },
+            { id: 'user-1', content: 'user preference', createdAt: '2026-04-27T10:00:00.000Z' },
+          ),
+        ],
+      },
+    };
+
+    expect(
+      renderTurnMemoryContext(context, {
+        now: new Date('2026-04-27T12:00:00.000Z'),
+        scopeLabels: { user: 'profile' },
+      }),
+    ).toBe('[profile, 2 hours ago] user preference');
+  });
+
+  it('returns an empty string for empty turn memory context', () => {
+    expect(renderTurnMemoryContext({ entries: [], byScope: {} })).toBe('');
   });
 
   it('promotes the latest session memory to user scope', async () => {
@@ -174,4 +333,61 @@ describe('turn memory helpers', () => {
       }),
     ).rejects.toThrow(/targetScope or userId/);
   });
+
+  it('emits memory operation logs for relay-backed store calls', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const handle = await createRelayBackedMemoryStore({ config: { type: 'inmemory' } });
+
+    const stored = await handle.store.write({
+      scope: { kind: 'session', sessionId: 's1' },
+      content: 'hello',
+    });
+    await handle.store.retrieve({
+      scope: { kind: 'session', sessionId: 's1' },
+      limit: 1,
+    });
+    await handle.store.promote({
+      sourceEntryId: stored.id,
+      targetScope: { kind: 'user', userId: 'u1' },
+    });
+    await handle.close();
+
+    const events = infoSpy.mock.calls.map(([payload]) => JSON.parse(String(payload)));
+
+    expect(events.map((event) => event.op)).toEqual(['init', 'save', 'load', 'promote', 'close']);
+    expect(events.every((event) => event.event === 'memory_op')).toBe(true);
+    expect(events.every((event) => event.status === 'ok')).toBe(true);
+  });
 });
+
+function stubStore(
+  entry: MemoryEntry,
+  retrieveImpl: (query: MemoryQuery) => Promise<MemoryEntry[]>,
+): MemoryStore {
+  return {
+    async write() {
+      return entry;
+    },
+    async retrieve(query) {
+      return retrieveImpl(query);
+    },
+    async get() {
+      return entry;
+    },
+    async update() {
+      return entry;
+    },
+    async delete() {
+      return undefined;
+    },
+    async deleteByScope() {
+      return 0;
+    },
+    async promote() {
+      return entry;
+    },
+    async compact() {
+      return entry;
+    },
+  };
+}

--- a/packages/memory/src/turn-memory.test.ts
+++ b/packages/memory/src/turn-memory.test.ts
@@ -252,6 +252,35 @@ describe('turn memory helpers', () => {
     );
   });
 
+  it('renders only entries that survived the global limit', () => {
+    const context = {
+      entries: [
+        fixedEntry(
+          { kind: 'session', sessionId: 's1' },
+          { id: 'session-1', content: 'kept', createdAt: '2026-04-27T11:59:00.000Z' },
+        ),
+      ],
+      byScope: {
+        session: [
+          fixedEntry(
+            { kind: 'session', sessionId: 's1' },
+            { id: 'session-1', content: 'kept', createdAt: '2026-04-27T11:59:00.000Z' },
+          ),
+        ],
+        user: [
+          fixedEntry(
+            { kind: 'user', userId: 'u1' },
+            { id: 'user-dropped', content: 'dropped', createdAt: '2026-04-27T10:00:00.000Z' },
+          ),
+        ],
+      },
+    };
+
+    expect(renderTurnMemoryContext(context, { now: new Date('2026-04-27T12:00:00.000Z') })).toBe(
+      '[thread, 1 minute ago] kept',
+    );
+  });
+
   it('respects scope label overrides when rendering turn memory context', () => {
     const context = {
       entries: [

--- a/packages/memory/src/turn-memory.ts
+++ b/packages/memory/src/turn-memory.ts
@@ -233,19 +233,18 @@ function resolvePerScopeLimit(
   scopeKind: TurnMemoryScopeKind,
   input: RetrieveTurnMemoryContextInput,
 ): number {
+  // Backwards-compat (per Devin review on PR #68): when caller provides
+  // none of `perScopeLimits[scopeKind]`, `perScopeLimit`, or `limit`,
+  // preserve the previous behavior of returning DEFAULT_TURN_MEMORY_LIMIT
+  // (20). Falling through to the smaller scope-specific constants
+  // (SESSION_LOAD_LIMIT=6, USER_LOAD_LIMIT=8, WORKSPACE_LOAD_LIMIT=4)
+  // would silently shrink existing callers' results by up to 80% — a
+  // breaking change at odds with the PR's "fully backwards compatible"
+  // promise. The constants remain exported so callers can opt in
+  // explicitly via `perScopeLimits: { session: SESSION_LOAD_LIMIT, ... }`.
+  void scopeKind;
   const explicitLimit = input.perScopeLimits?.[scopeKind] ?? input.perScopeLimit ?? input.limit;
-  if (explicitLimit) {
-    return normalizeLimit(explicitLimit);
-  }
-
-  switch (scopeKind) {
-    case 'session':
-      return SESSION_LOAD_LIMIT;
-    case 'user':
-      return USER_LOAD_LIMIT;
-    case 'workspace':
-      return WORKSPACE_LOAD_LIMIT;
-  }
+  return normalizeLimit(explicitLimit);
 }
 
 function scopeEventMeta(scope: MemoryScope): Pick<

--- a/packages/memory/src/turn-memory.ts
+++ b/packages/memory/src/turn-memory.ts
@@ -118,24 +118,15 @@ export async function retrieveTurnMemoryContext(
       continue;
     }
 
-    const entries = await measureMemoryOp(
-      {
-        op: 'load',
-        ...scopeEventMeta(scope),
-      },
-      async () => {
-        const retrieved = await input.store.retrieve({
-          scope,
-          tags: input.tags,
-          since: input.since,
-          query: input.query,
-          limit: resolvePerScopeLimit(scopeKind, input),
-          order: input.order ?? 'newest',
-          includeNarrower: false,
-        });
-        return retrieved;
-      },
-    );
+    const entries = await input.store.retrieve({
+      scope,
+      tags: input.tags,
+      since: input.since,
+      query: input.query,
+      limit: resolvePerScopeLimit(scopeKind, input),
+      order: input.order ?? 'newest',
+      includeNarrower: false,
+    });
 
     byScope[scopeKind] = entries;
 
@@ -165,11 +156,12 @@ export function renderTurnMemoryContext(
     ...DEFAULT_SCOPE_LABELS,
     ...options.scopeLabels,
   };
+  const allowedIds = new Set(context.entries.map((entry) => entry.id));
   const lines: string[] = [];
 
   for (const scopeKind of DEFAULT_SCOPE_ORDER) {
     for (const entry of context.byScope[scopeKind] ?? []) {
-      if (entry.content.trim().length === 0) {
+      if (!allowedIds.has(entry.id) || entry.content.trim().length === 0) {
         continue;
       }
 
@@ -186,20 +178,13 @@ export async function promoteLatestSessionMemory(
   input: PromoteLatestSessionMemoryInput,
 ): Promise<MemoryEntry | null> {
   const sessionScope: MemoryScope = { kind: 'session', sessionId: input.sessionId };
-  const [source] = await measureMemoryOp(
-    {
-      op: 'load',
-      ...scopeEventMeta(sessionScope),
-    },
-    async () =>
-      input.store.retrieve({
-        scope: sessionScope,
-        tags: input.tags,
-        since: input.since,
-        limit: 1,
-        order: 'newest',
-      }),
-  );
+  const [source] = await input.store.retrieve({
+    scope: sessionScope,
+    tags: input.tags,
+    since: input.since,
+    limit: 1,
+    order: 'newest',
+  });
 
   if (!source) {
     return null;
@@ -211,25 +196,15 @@ export async function promoteLatestSessionMemory(
     throw new Error('promoteLatestSessionMemory requires targetScope or userId.');
   }
 
-  return measureMemoryOp(
-    {
-      op: 'promote',
-      ...scopeEventMeta(targetScope),
-      contentChars: (input.content ?? source.content).length,
-      entryCount: 1,
-    },
-    async () => {
-      const promotion: PromoteMemoryInput = {
-        sourceEntryId: source.id,
-        targetScope,
-        deleteOriginal: input.deleteOriginal,
-        content: input.content,
-        tags: input.promotedTags,
-      };
+  const promotion: PromoteMemoryInput = {
+    sourceEntryId: source.id,
+    targetScope,
+    deleteOriginal: input.deleteOriginal,
+    content: input.content,
+    tags: input.promotedTags,
+  };
 
-      return input.store.promote(promotion);
-    },
-  );
+  return input.store.promote(promotion);
 }
 
 function resolveTurnScope(

--- a/packages/memory/src/turn-memory.ts
+++ b/packages/memory/src/turn-memory.ts
@@ -8,6 +8,8 @@ import {
   createMemoryStore,
   RelayMemoryStoreAdapter,
 } from './memory.js';
+import { formatRelativeAge } from './relative-age.js';
+import { measureMemoryOp } from './observability.js';
 import type {
   MemoryEntry,
   MemoryQuery,
@@ -28,6 +30,7 @@ export interface CreateRelayBackedMemoryStoreOptions {
 }
 
 export type TurnMemoryScopeKind = Extract<MemoryScope['kind'], 'session' | 'user' | 'workspace'>;
+type TurnMemoryScopeLabels = Partial<Record<TurnMemoryScopeKind, string>>;
 
 export interface RetrieveTurnMemoryContextInput {
   store: MemoryStore;
@@ -36,8 +39,10 @@ export interface RetrieveTurnMemoryContextInput {
   workspaceId?: string;
   tags?: string[];
   since?: string;
+  query?: string;
   limit?: number;
   perScopeLimit?: number;
+  perScopeLimits?: Partial<Record<TurnMemoryScopeKind, number>>;
   order?: MemoryQuery['order'];
   scopeOrder?: TurnMemoryScopeKind[];
 }
@@ -45,6 +50,11 @@ export interface RetrieveTurnMemoryContextInput {
 export interface TurnMemoryContext {
   entries: MemoryEntry[];
   byScope: Partial<Record<TurnMemoryScopeKind, MemoryEntry[]>>;
+}
+
+export interface RenderTurnMemoryContextOptions {
+  now?: Date;
+  scopeLabels?: TurnMemoryScopeLabels;
 }
 
 export interface PromoteLatestSessionMemoryInput {
@@ -61,21 +71,35 @@ export interface PromoteLatestSessionMemoryInput {
 
 const DEFAULT_SCOPE_ORDER: TurnMemoryScopeKind[] = ['session', 'user', 'workspace'];
 const DEFAULT_TURN_MEMORY_LIMIT = 20;
+export const SESSION_LOAD_LIMIT = 6;
+export const USER_LOAD_LIMIT = 8;
+export const WORKSPACE_LOAD_LIMIT = 4;
+const DEFAULT_SCOPE_LABELS: Record<TurnMemoryScopeKind, string> = {
+  session: 'thread',
+  user: 'user',
+  workspace: 'workspace',
+};
 
 export async function createRelayBackedMemoryStore(
   options: CreateRelayBackedMemoryStoreOptions,
 ): Promise<RelayBackedMemoryStore> {
-  const relayAdapter =
-    options.relayAdapter ?? await createMemoryAdapter(options.config ?? { type: 'inmemory' });
+  const relayAdapter = await measureMemoryOp(
+    { op: 'init' },
+    async () =>
+      options.relayAdapter ?? await createMemoryAdapter(options.config ?? { type: 'inmemory' }),
+  );
   const store = createMemoryStore({
     adapter: new RelayMemoryStoreAdapter(relayAdapter),
   });
+  const observedStore = observeMemoryStore(store);
 
   return {
-    store,
+    store: observedStore,
     relayAdapter,
     async close(): Promise<void> {
-      await relayAdapter.close?.();
+      await measureMemoryOp({ op: 'close' }, async () => {
+        await relayAdapter.close?.();
+      });
     },
   };
 }
@@ -84,7 +108,6 @@ export async function retrieveTurnMemoryContext(
   input: RetrieveTurnMemoryContextInput,
 ): Promise<TurnMemoryContext> {
   const scopeOrder = input.scopeOrder ?? DEFAULT_SCOPE_ORDER;
-  const perScopeLimit = normalizeLimit(input.perScopeLimit ?? input.limit);
   const globalLimit = normalizeLimit(input.limit);
   const byScope: Partial<Record<TurnMemoryScopeKind, MemoryEntry[]>> = {};
   const deduped = new Map<string, MemoryEntry>();
@@ -95,14 +118,24 @@ export async function retrieveTurnMemoryContext(
       continue;
     }
 
-    const entries = await input.store.retrieve({
-      scope,
-      tags: input.tags,
-      since: input.since,
-      limit: perScopeLimit,
-      order: input.order ?? 'newest',
-      includeNarrower: false,
-    });
+    const entries = await measureMemoryOp(
+      {
+        op: 'load',
+        ...scopeEventMeta(scope),
+      },
+      async () => {
+        const retrieved = await input.store.retrieve({
+          scope,
+          tags: input.tags,
+          since: input.since,
+          query: input.query,
+          limit: resolvePerScopeLimit(scopeKind, input),
+          order: input.order ?? 'newest',
+          includeNarrower: false,
+        });
+        return retrieved;
+      },
+    );
 
     byScope[scopeKind] = entries;
 
@@ -119,16 +152,54 @@ export async function retrieveTurnMemoryContext(
   };
 }
 
+export function renderTurnMemoryContext(
+  context: TurnMemoryContext,
+  options: RenderTurnMemoryContextOptions = {},
+): string {
+  if (context.entries.length === 0) {
+    return '';
+  }
+
+  const now = options.now ?? new Date();
+  const scopeLabels = {
+    ...DEFAULT_SCOPE_LABELS,
+    ...options.scopeLabels,
+  };
+  const lines: string[] = [];
+
+  for (const scopeKind of DEFAULT_SCOPE_ORDER) {
+    for (const entry of context.byScope[scopeKind] ?? []) {
+      if (entry.content.trim().length === 0) {
+        continue;
+      }
+
+      lines.push(
+        `[${scopeLabels[scopeKind]}, ${formatRelativeAge(entry, now)}] ${entry.content}`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
 export async function promoteLatestSessionMemory(
   input: PromoteLatestSessionMemoryInput,
 ): Promise<MemoryEntry | null> {
-  const [source] = await input.store.retrieve({
-    scope: { kind: 'session', sessionId: input.sessionId },
-    tags: input.tags,
-    since: input.since,
-    limit: 1,
-    order: 'newest',
-  });
+  const sessionScope: MemoryScope = { kind: 'session', sessionId: input.sessionId };
+  const [source] = await measureMemoryOp(
+    {
+      op: 'load',
+      ...scopeEventMeta(sessionScope),
+    },
+    async () =>
+      input.store.retrieve({
+        scope: sessionScope,
+        tags: input.tags,
+        since: input.since,
+        limit: 1,
+        order: 'newest',
+      }),
+  );
 
   if (!source) {
     return null;
@@ -140,15 +211,25 @@ export async function promoteLatestSessionMemory(
     throw new Error('promoteLatestSessionMemory requires targetScope or userId.');
   }
 
-  const promotion: PromoteMemoryInput = {
-    sourceEntryId: source.id,
-    targetScope,
-    deleteOriginal: input.deleteOriginal,
-    content: input.content,
-    tags: input.promotedTags,
-  };
+  return measureMemoryOp(
+    {
+      op: 'promote',
+      ...scopeEventMeta(targetScope),
+      contentChars: (input.content ?? source.content).length,
+      entryCount: 1,
+    },
+    async () => {
+      const promotion: PromoteMemoryInput = {
+        sourceEntryId: source.id,
+        targetScope,
+        deleteOriginal: input.deleteOriginal,
+        content: input.content,
+        tags: input.promotedTags,
+      };
 
-  return input.store.promote(promotion);
+      return input.store.promote(promotion);
+    },
+  );
 }
 
 function resolveTurnScope(
@@ -171,4 +252,106 @@ function normalizeLimit(limit: number | undefined): number {
   }
 
   return Math.floor(limit);
+}
+
+function resolvePerScopeLimit(
+  scopeKind: TurnMemoryScopeKind,
+  input: RetrieveTurnMemoryContextInput,
+): number {
+  const explicitLimit = input.perScopeLimits?.[scopeKind] ?? input.perScopeLimit ?? input.limit;
+  if (explicitLimit) {
+    return normalizeLimit(explicitLimit);
+  }
+
+  switch (scopeKind) {
+    case 'session':
+      return SESSION_LOAD_LIMIT;
+    case 'user':
+      return USER_LOAD_LIMIT;
+    case 'workspace':
+      return WORKSPACE_LOAD_LIMIT;
+  }
+}
+
+function scopeEventMeta(scope: MemoryScope): Pick<
+  MemoryQuery,
+  never
+> &
+  Partial<{
+    scope: 'session' | 'user' | 'workspace';
+    sessionId: string;
+    userId: string;
+    workspaceId: string;
+  }> {
+  switch (scope.kind) {
+    case 'session':
+      return { scope: 'session', sessionId: scope.sessionId };
+    case 'user':
+      return { scope: 'user', userId: scope.userId };
+    case 'workspace':
+      return { scope: 'workspace', workspaceId: scope.workspaceId };
+    default:
+      return {};
+  }
+}
+
+function observeMemoryStore(store: MemoryStore): MemoryStore {
+  return {
+    ...store,
+    async write(input) {
+      return measureMemoryOp(
+        {
+          op: 'save',
+          ...scopeEventMeta(input.scope),
+          contentChars: input.content.length,
+          entryCount: 1,
+        },
+        async () => store.write(input),
+      );
+    },
+    async retrieve(query) {
+      return measureMemoryOp(
+        {
+          op: 'load',
+          ...scopeEventMeta(query.scope),
+        },
+        async () => store.retrieve(query),
+      );
+    },
+    async promote(input) {
+      return measureMemoryOp(
+        {
+          op: 'promote',
+          ...scopeEventMeta(input.targetScope),
+          contentChars: input.content?.length,
+          entryCount: 1,
+        },
+        async () => store.promote(input),
+      );
+    },
+    async compact(input) {
+      return measureMemoryOp(
+        {
+          op: 'compact',
+          ...scopeEventMeta(input.targetScope),
+          entryCount: input.sourceEntryIds.length,
+        },
+        async () => store.compact(input),
+      );
+    },
+    async delete(entryId) {
+      return measureMemoryOp({ op: 'forget', entryCount: 1 }, async () => {
+        await store.delete(entryId);
+      });
+    },
+    async deleteByScope(scope) {
+      return measureMemoryOp(
+        {
+          op: 'forget',
+          ...scopeEventMeta(scope),
+        },
+        async () => store.deleteByScope(scope),
+      );
+    },
+  };
 }

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -42,6 +42,7 @@ export interface MemoryQuery {
   includeNarrower?: boolean;
   tags?: string[];
   since?: string;
+  query?: string;
   limit?: number;
   order?: 'newest' | 'oldest';
   context?: {

--- a/workflows/improve-memory-primitives/00-execute.ts
+++ b/workflows/improve-memory-primitives/00-execute.ts
@@ -1,0 +1,132 @@
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+
+/**
+ * Master executor for improve-memory-primitives.
+ *
+ * Sets up a feature branch on agent-assistant, runs subs sequentially,
+ * fails fast. Final sub commits + opens PR. Sage adoption is a separate
+ * workflow in the sage repo (improve-sage-memory) that runs AFTER this PR
+ * merges and the new package versions publish.
+ *
+ * Subs:
+ *   01 — @agent-assistant/memory primitives (formatRelativeAge,
+ *        renderTurnMemoryContext, structured logs, content-hash, query
+ *        plumbing, scope load constants)
+ *   02 — @agent-assistant/harness memory tool registry
+ *        (createMemoryToolRegistry exposing memory_remember/recall/forget)
+ *   03 — Final review, commit, push, open PR
+ */
+
+// Resolve from the script being executed (process.argv[1]) since the
+// agent-assistant repo's tsx runtime transpiles to CJS where import.meta
+// is unavailable. The master is always invoked as
+//   npx tsx workflows/improve-memory-primitives/00-execute.ts
+// from the agent-assistant repo root.
+const __dirname = path.dirname(path.resolve(process.argv[1] ?? __filename));
+
+const SUBS = [
+  '01-memory-package.ts',
+  '02-harness-memory-tools.ts',
+  '03-publish-pr.ts',
+] as const;
+
+const FEATURE_BRANCH = 'feat/memory-primitives-and-harness-tools';
+
+function exec(command: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn('bash', ['-lc', command], { stdio: ['inherit', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => {
+      const t = c.toString();
+      stdout += t;
+      process.stdout.write(t);
+    });
+    child.stderr.on('data', (c) => {
+      const t = c.toString();
+      stderr += t;
+      process.stderr.write(t);
+    });
+    child.on('exit', (code) => resolve({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+function runSub(file: string): Promise<{ code: number; failedMarker: boolean }> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      'agent-relay',
+      ['run', path.join(__dirname, file)],
+      { stdio: ['inherit', 'pipe', 'pipe'], cwd: process.cwd() },
+    );
+    let failedMarker = false;
+    const onChunk = (chunk: Buffer, sink: NodeJS.WriteStream) => {
+      const text = chunk.toString();
+      if (/Workflow status:\s*failed/i.test(text)) failedMarker = true;
+      sink.write(text);
+    };
+    child.stdout.on('data', (c) => onChunk(c, process.stdout));
+    child.stderr.on('data', (c) => onChunk(c, process.stderr));
+    child.on('exit', (code) => resolve({ code: code ?? 1, failedMarker }));
+  });
+}
+
+async function ensureCleanBranch(): Promise<void> {
+  const status = await exec('git status --porcelain');
+  if (status.stdout.trim().length > 0) {
+    console.error(
+      '[master] working tree is dirty. Commit or stash before running this workflow:\n' + status.stdout,
+    );
+    process.exit(1);
+  }
+
+  const head = await exec('git rev-parse --abbrev-ref HEAD');
+  const currentBranch = head.stdout.trim();
+
+  if (currentBranch === FEATURE_BRANCH) {
+    console.log(`[master] already on ${FEATURE_BRANCH}`);
+    return;
+  }
+
+  const branchExists = await exec(`git show-ref --verify --quiet refs/heads/${FEATURE_BRANCH}`);
+  if (branchExists.code === 0) {
+    console.log(`[master] switching to existing ${FEATURE_BRANCH}`);
+    const checkout = await exec(`git checkout ${FEATURE_BRANCH}`);
+    if (checkout.code !== 0) {
+      console.error('[master] checkout failed');
+      process.exit(1);
+    }
+  } else {
+    console.log(`[master] creating ${FEATURE_BRANCH} from ${currentBranch}`);
+    const create = await exec(`git checkout -b ${FEATURE_BRANCH}`);
+    if (create.code !== 0) {
+      console.error('[master] branch create failed');
+      process.exit(1);
+    }
+  }
+}
+
+async function main() {
+  console.log('[master] improve-memory-primitives starting at', new Date().toISOString());
+  await ensureCleanBranch();
+
+  for (const sub of SUBS) {
+    console.log(`[master] → ${sub}`);
+    const { code, failedMarker } = await runSub(sub);
+    if (code !== 0 || failedMarker) {
+      console.error(
+        `[master] ${sub} failed (exit=${code}, failedMarker=${failedMarker}). Stopping. Branch left at ${FEATURE_BRANCH} for inspection.`,
+      );
+      process.exit(1);
+    }
+    console.log(`[master] ✓ ${sub} ok`);
+  }
+
+  console.log('[master] all sub-workflows passed. PR opened by 03.');
+  console.log('[master] After merge, the existing release workflow will publish @agent-assistant/memory + harness new minors. Then run improve-sage-memory in the sage repo.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-memory-primitives/00-execute.ts
+++ b/workflows/improve-memory-primitives/00-execute.ts
@@ -1,129 +1,112 @@
-import { spawn } from 'node:child_process';
-import * as path from 'node:path';
-
 /**
- * Master executor for improve-memory-primitives.
+ * Master workflow for improve-memory-primitives.
  *
- * Sets up a feature branch on agent-assistant, runs subs sequentially,
- * fails fast. Final sub commits + opens PR. Sage adoption is a separate
- * workflow in the sage repo (improve-sage-memory) that runs AFTER this PR
- * merges and the new package versions publish.
+ * Mirrors the proactive-signals master pattern: applies
+ * `applyAgentAssistantRepoSetup` ONCE for the whole run (setup-branch +
+ * install-deps + workspace build), then runs each sub-workflow as a
+ * deterministic shell step that inherits the master's worktree. Subs do
+ * NOT need their own setup helper because they execute in the same
+ * working directory the master prepared.
  *
- * Subs:
+ * This satisfies `workflows/AGENTS.md` ("every cloud-sandboxed workflow
+ * that produces code changes MUST use the shared setup helper") at the
+ * orchestration layer — the same pattern proactive-signals/00-master.ts
+ * uses. Per Devin/codex review on PR #68 (comment IDs 3151086913,
+ * 3151086941, 3151106923, 3151413279).
+ *
+ * Subs (run in order; final sub commits + opens PR):
  *   01 — @agent-assistant/memory primitives (formatRelativeAge,
  *        renderTurnMemoryContext, structured logs, content-hash, query
  *        plumbing, scope load constants)
  *   02 — @agent-assistant/harness memory tool registry
  *        (createMemoryToolRegistry exposing memory_remember/recall/forget)
+ *   04 — Loosen redundant-tool-loop detector + large-output advisory
  *   03 — Final review, commit, push, open PR
+ *
+ * Per memory [agent-relay run exit code]: each sub-shell-step greps log
+ * for "Workflow status: failed" AND checks pipeline exit via PIPESTATUS,
+ * because the runner can exit 0 even when the inner workflow fails.
  */
 
-// Resolve from the script being executed (process.argv[1]) since the
-// agent-assistant repo's tsx runtime transpiles to CJS where import.meta
-// is unavailable. The master is always invoked as
-//   npx tsx workflows/improve-memory-primitives/00-execute.ts
-// from the agent-assistant repo root.
-const __dirname = path.dirname(path.resolve(process.argv[1] ?? __filename));
+import { workflow } from '@agent-relay/sdk/workflows';
+import { mkdirSync } from 'node:fs';
 
-const SUBS = [
-  '01-memory-package.ts',
-  '02-harness-memory-tools.ts',
-  '03-publish-pr.ts',
-] as const;
+import { applyAgentAssistantRepoSetup } from '../lib/agent-assistant-repo-setup.ts';
 
-const FEATURE_BRANCH = 'feat/memory-primitives-and-harness-tools';
+const BRANCH = 'feat/memory-primitives-and-harness-tools';
+const LOG_DIR = 'logs/improve-memory-primitives-master';
 
-function exec(command: string): Promise<{ code: number; stdout: string; stderr: string }> {
-  return new Promise((resolve) => {
-    const child = spawn('bash', ['-lc', command], { stdio: ['inherit', 'pipe', 'pipe'] });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (c) => {
-      const t = c.toString();
-      stdout += t;
-      process.stdout.write(t);
-    });
-    child.stderr.on('data', (c) => {
-      const t = c.toString();
-      stderr += t;
-      process.stderr.write(t);
-    });
-    child.on('exit', (code) => resolve({ code: code ?? 1, stdout, stderr }));
-  });
-}
-
-function runSub(file: string): Promise<{ code: number; failedMarker: boolean }> {
-  return new Promise((resolve) => {
-    const child = spawn(
-      'agent-relay',
-      ['run', path.join(__dirname, file)],
-      { stdio: ['inherit', 'pipe', 'pipe'], cwd: process.cwd() },
-    );
-    let failedMarker = false;
-    const onChunk = (chunk: Buffer, sink: NodeJS.WriteStream) => {
-      const text = chunk.toString();
-      if (/Workflow status:\s*failed/i.test(text)) failedMarker = true;
-      sink.write(text);
-    };
-    child.stdout.on('data', (c) => onChunk(c, process.stdout));
-    child.stderr.on('data', (c) => onChunk(c, process.stderr));
-    child.on('exit', (code) => resolve({ code: code ?? 1, failedMarker }));
-  });
-}
-
-async function ensureCleanBranch(): Promise<void> {
-  const status = await exec('git status --porcelain');
-  if (status.stdout.trim().length > 0) {
-    console.error(
-      '[master] working tree is dirty. Commit or stash before running this workflow:\n' + status.stdout,
-    );
-    process.exit(1);
-  }
-
-  const head = await exec('git rev-parse --abbrev-ref HEAD');
-  const currentBranch = head.stdout.trim();
-
-  if (currentBranch === FEATURE_BRANCH) {
-    console.log(`[master] already on ${FEATURE_BRANCH}`);
-    return;
-  }
-
-  const branchExists = await exec(`git show-ref --verify --quiet refs/heads/${FEATURE_BRANCH}`);
-  if (branchExists.code === 0) {
-    console.log(`[master] switching to existing ${FEATURE_BRANCH}`);
-    const checkout = await exec(`git checkout ${FEATURE_BRANCH}`);
-    if (checkout.code !== 0) {
-      console.error('[master] checkout failed');
-      process.exit(1);
-    }
-  } else {
-    console.log(`[master] creating ${FEATURE_BRANCH} from ${currentBranch}`);
-    const create = await exec(`git checkout -b ${FEATURE_BRANCH}`);
-    if (create.code !== 0) {
-      console.error('[master] branch create failed');
-      process.exit(1);
-    }
-  }
-}
+// Wrapped in bash -c '...' (SINGLE quotes) because cloud /bin/sh is dash,
+// which doesn't support ${PIPESTATUS[0]}. Single quotes prevent sh from
+// expanding $status / ${PIPESTATUS[0]} before bash sees them. Same
+// rationale as proactive-signals/00-master.ts.
+const SUB = (file: string) => {
+  const logPath = `${LOG_DIR}/${file}.log`;
+  const script = [
+    `set -o pipefail`,
+    `agent-relay run workflows/improve-memory-primitives/${file} 2>&1 | tee ${logPath}`,
+    `status=\${PIPESTATUS[0]}`,
+    `if [ "$status" -ne 0 ]; then echo "SUB_WORKFLOW_EXIT_NONZERO: $status"; exit $status; fi`,
+    `if grep -q "Workflow status: failed" ${logPath}; then echo "SUB_WORKFLOW_REPORTED_FAILED"; exit 1; fi`,
+    `echo "SUB_WORKFLOW_OK: ${file}"`,
+  ].join('; ');
+  return `bash -c '${script}'`;
+};
 
 async function main() {
-  console.log('[master] improve-memory-primitives starting at', new Date().toISOString());
-  await ensureCleanBranch();
+  mkdirSync(LOG_DIR, { recursive: true });
 
-  for (const sub of SUBS) {
-    console.log(`[master] → ${sub}`);
-    const { code, failedMarker } = await runSub(sub);
-    if (code !== 0 || failedMarker) {
-      console.error(
-        `[master] ${sub} failed (exit=${code}, failedMarker=${failedMarker}). Stopping. Branch left at ${FEATURE_BRANCH} for inspection.`,
-      );
-      process.exit(1);
-    }
-    console.log(`[master] ✓ ${sub} ok`);
-  }
+  const baseWf = workflow('aa-improve-memory-primitives-master')
+    .description(
+      'Master — setup-branch + install-deps via shared helper, then 01 → 02 → 04 → 03 sequentially. 03 commits + opens PR.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-improve-memory-primitives-master')
+    .maxConcurrency(2)
+    .timeout(7_200_000); // 2h
 
-  console.log('[master] all sub-workflows passed. PR opened by 03.');
-  console.log('[master] After merge, the existing release workflow will publish @agent-assistant/memory + harness new minors. Then run improve-sage-memory in the sage repo.');
+  // ─── Phase 0: Setup branch + deps (shared helper) ───────
+  // Per workflows/AGENTS.md and the proactive-signals reference pattern,
+  // this is where setup-branch and install-deps land. Subs run as
+  // deterministic shell steps below and inherit this working directory.
+  const wf = applyAgentAssistantRepoSetup(baseWf, {
+    branch: BRANCH,
+    committerName: 'Memory Primitives Bot',
+  });
+
+  const result = await wf
+    .step('sub-01-memory-package', {
+      type: 'deterministic',
+      dependsOn: ['install-deps'],
+      command: SUB('01-memory-package.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-02-harness-memory-tools', {
+      type: 'deterministic',
+      dependsOn: ['sub-01-memory-package'],
+      command: SUB('02-harness-memory-tools.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-04-loosen-detector', {
+      type: 'deterministic',
+      dependsOn: ['sub-02-harness-memory-tools'],
+      command: SUB('04-loosen-detector-and-large-output-advisory.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-03-publish-pr', {
+      type: 'deterministic',
+      dependsOn: ['sub-04-loosen-detector'],
+      command: SUB('03-publish-pr.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
 }
 
 main().catch((error) => {

--- a/workflows/improve-memory-primitives/01-memory-package.ts
+++ b/workflows/improve-memory-primitives/01-memory-package.ts
@@ -1,0 +1,253 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 1 — @agent-assistant/memory primitives.
+ *
+ * Adds the building blocks that any memory consumer (sage today, others
+ * later) needs but currently has to inline locally:
+ *   - formatRelativeAge(entry): "just now" / "N minutes ago" / etc.
+ *   - renderTurnMemoryContext(context, options): scope+age attributed text
+ *     suitable for direct injection into a system prompt
+ *   - SCOPE_LOAD_LIMITS named constants (SESSION/USER/WORKSPACE) so callers
+ *     stop hand-tuning numbers
+ *   - logMemoryOp({ op, scope, status, durationMs, ... }): structured
+ *     console.info JSON event for observability — same shape across save /
+ *     load / promote / close paths
+ *   - hashMemoryContent(content): SHA-256 helper for content-hash dedup
+ *   - retrieveTurnMemoryContext now accepts an optional `query` and
+ *     forwards it to MemoryStore.retrieve so backends with semantic search
+ *     can rank by relevance to the current turn
+ *
+ * Bumps @agent-assistant/memory minor version. Fully backwards-compatible:
+ * existing helpers keep their current signatures, new args are optional.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-memory-primitives-01-package')
+    .description(
+      'Add formatRelativeAge, renderTurnMemoryContext, scope load constants, logMemoryOp, hashMemoryContent, and query-aware retrieve to @agent-assistant/memory. Backwards compatible.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-memory-01')
+    .maxConcurrency(2)
+    .timeout(2_700_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the memory package surface.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the memory primitives + tests.',
+      retries: 2,
+    })
+
+    .step('read-memory-pkg', {
+      type: 'deterministic',
+      command:
+        'cat packages/memory/src/types.ts && echo --- && ' +
+        'cat packages/memory/src/turn-memory.ts && echo --- && ' +
+        'cat packages/memory/src/index.ts',
+      captureOutput: true,
+    })
+    .step('read-memory-tests', {
+      type: 'deterministic',
+      command: 'cat packages/memory/src/turn-memory.test.ts | head -120',
+      captureOutput: true,
+    })
+    .step('read-existing-pkg-version', {
+      type: 'deterministic',
+      command: 'grep "\\"version\\"" packages/memory/package.json | head -1',
+      captureOutput: true,
+    })
+
+    // ── Implement primitives ──────────────────────────────────────
+    .step('implement', {
+      agent: 'impl',
+      dependsOn: ['read-memory-pkg', 'read-memory-tests', 'read-existing-pkg-version'],
+      task: `Edit packages/memory/src/turn-memory.ts (and create packages/memory/src/observability.ts if needed for log + hash helpers — keep small files focused).
+
+Current memory package surface:
+{{steps.read-memory-pkg.output}}
+
+CONTRACT:
+
+1. Export from a NEW file packages/memory/src/observability.ts:
+   - export type MemoryOpName = 'load' | 'save' | 'promote' | 'compact' | 'close' | 'init' | 'forget'
+   - export interface MemoryOpEvent { event: 'memory_op'; op: MemoryOpName; scope?: 'session' | 'user' | 'workspace'; workspaceId?: string; sessionId?: string; userId?: string; entryCount?: number; contentChars?: number; status: 'ok' | 'failed'; error?: string; durationMs: number; }
+   - export function logMemoryOp(event: MemoryOpEvent): void  — single-line JSON.stringify console.info; safe for production
+   - export async function measureMemoryOp<T>(meta: Omit<MemoryOpEvent, 'event' | 'status' | 'durationMs'>, fn: () => Promise<T>): Promise<T>
+     wrap fn(); on success, log status='ok' with durationMs; on throw, log status='failed' with error message AND re-throw the original error.
+   - export function hashMemoryContent(content: string): string  — SHA-256 base64url of content, 22 chars; pure (no IO).
+
+2. Export from a NEW file packages/memory/src/relative-age.ts:
+   - export function formatRelativeAge(entry: { createdAt?: string | Date | number }, now?: Date): string
+     returns "just now" (<60s), "N minutes ago" (<60min), "N hours ago" (<24h), "N days ago" (<7d), "N weeks ago" (<5w), "N months ago" (<12mo), "N years ago" (>=12mo). Singular/plural correct ("1 minute ago" not "1 minutes ago"). Returns "unknown age" if createdAt missing/invalid.
+
+3. Export from packages/memory/src/turn-memory.ts:
+   - export const SESSION_LOAD_LIMIT = 6
+   - export const USER_LOAD_LIMIT = 8
+   - export const WORKSPACE_LOAD_LIMIT = 4
+   - Modify retrieveTurnMemoryContext to accept perScopeLimits?: { session?: number; user?: number; workspace?: number } that, when provided, overrides perScopeLimit per scope. Existing perScopeLimit + limit args keep working unchanged.
+   - Modify retrieveTurnMemoryContext to accept query?: string. When provided, pass it through into the per-scope store.retrieve call as MemoryQuery.query (the field already exists on MemoryQuery — see types.ts). Backends that ignore it stay correct.
+   - export interface RenderTurnMemoryContextOptions { now?: Date; scopeLabels?: { session?: string; user?: string; workspace?: string } }
+   - export function renderTurnMemoryContext(context: TurnMemoryContext, options?: RenderTurnMemoryContextOptions): string
+     For each entry across all three scopes, emit one line:
+       [<scopeLabel>, <relativeAge>] <entry.content>
+     Scope label defaults: thread / user / workspace (override-able). Order: session entries first (most recent), then user, then workspace. Skip empty content. If context.entries is empty, return ''.
+
+4. Wrap every internal store.retrieve / store.write / store.promote call inside retrieveTurnMemoryContext + promoteLatestSessionMemory + createRelayBackedMemoryStore in a measureMemoryOp(...) so the standard observability event lands without callers needing to wire it.
+
+5. packages/memory/src/index.ts: re-export everything new (logMemoryOp, measureMemoryOp, hashMemoryContent, formatRelativeAge, SESSION_LOAD_LIMIT, USER_LOAD_LIMIT, WORKSPACE_LOAD_LIMIT, renderTurnMemoryContext, RenderTurnMemoryContextOptions, MemoryOpEvent, MemoryOpName).
+
+6. Bump packages/memory/package.json version: minor bump from current to next minor (e.g. 0.3.10 → 0.4.0). Adding new exports is a minor under semver.
+
+Only edit packages/memory/. Do NOT touch other packages.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement'],
+      command:
+        'test -f packages/memory/src/observability.ts && ' +
+        'test -f packages/memory/src/relative-age.ts && ' +
+        'grep -Eq "logMemoryOp|measureMemoryOp|hashMemoryContent" packages/memory/src/observability.ts && ' +
+        'grep -Eq "formatRelativeAge" packages/memory/src/relative-age.ts && ' +
+        'grep -Eq "renderTurnMemoryContext|SESSION_LOAD_LIMIT|USER_LOAD_LIMIT|WORKSPACE_LOAD_LIMIT" packages/memory/src/turn-memory.ts && ' +
+        'grep -Eq "renderTurnMemoryContext|formatRelativeAge|hashMemoryContent" packages/memory/src/index.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Tests ─────────────────────────────────────────────────────
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-impl'],
+      task: `Add tests:
+
+1. packages/memory/src/relative-age.test.ts (vitest):
+   - "just now" for entries <60s old
+   - "1 minute ago" exactly at 60s; "59 minutes ago" at 59min; "1 hour ago" at 60min
+   - Plural correctness: "2 hours ago", "1 day ago", "2 days ago", "1 week ago", "1 month ago", "1 year ago"
+   - createdAt accepts string ISO, Date, number (epoch ms)
+   - "unknown age" when createdAt is undefined or unparseable
+
+2. packages/memory/src/observability.test.ts (vitest):
+   - logMemoryOp emits ONE line of JSON.stringify via console.info
+   - measureMemoryOp on success calls the inner fn, returns its value, logs status='ok' with durationMs >= 0
+   - measureMemoryOp on throw still logs status='failed' with error message and re-throws the original error (assert via expect(...).rejects.toThrow)
+   - hashMemoryContent returns 22 chars; same input → same output; different input → different output
+
+3. Extend packages/memory/src/turn-memory.test.ts:
+   - retrieveTurnMemoryContext respects perScopeLimits override
+   - retrieveTurnMemoryContext forwards query argument to store.retrieve (use a vi.fn() store and assert query in the args)
+   - renderTurnMemoryContext outputs lines in shape "[<scope>, <age>] <content>", session first, then user, then workspace
+   - renderTurnMemoryContext respects scopeLabels override
+   - renderTurnMemoryContext returns '' for empty TurnMemoryContext
+
+Use vitest. Mirror existing test patterns in packages/memory/src/.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command:
+        'test -f packages/memory/src/relative-age.test.ts && ' +
+        'test -f packages/memory/src/observability.test.ts && ' +
+        'grep -Eq "renderTurnMemoryContext|perScopeLimits|forwards query" packages/memory/src/turn-memory.test.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests'],
+      command: 'npx vitest run packages/memory/ 2>&1 | tail -80',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures from:
+{{steps.run-tests.output}}
+If green, no-op. Don't loosen assertions. Re-run: npx vitest run packages/memory/`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/memory/ 2>&1 | tail -40',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/memory && npx tsc --noEmit 2>&1 | tail -30; echo EXIT=$?',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-typecheck', {
+      agent: 'impl',
+      dependsOn: ['typecheck'],
+      task: `If errors, fix. If EXIT=0, no-op.
+{{steps.typecheck.output}}
+Re-run: cd packages/memory && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-typecheck'],
+      command: 'cd packages/memory && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/memory/
+
+Verify:
+1. Existing exports / signatures unchanged. New args (perScopeLimits, query) are optional. retrieveTurnMemoryContext + promoteLatestSessionMemory still callable with the old signature.
+2. measureMemoryOp NEVER swallows the original error. Re-throws are not wrapped.
+3. logMemoryOp output is JSON.parseable (no template literals, no inline objects).
+4. hashMemoryContent is deterministic across runs (no Date.now / Math.random in input).
+5. renderTurnMemoryContext is dedup-free in this PR (dedup is a later concern). Don't introduce dedup here.
+6. Version bump is minor not patch (new exports = minor under semver).
+
+Edit files directly to fix. Re-run npx vitest run packages/memory/ + cd packages/memory && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/memory/ 2>&1 | tail -30 && echo --- && ' +
+        'cd packages/memory && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-memory-primitives/02-harness-memory-tools.ts
+++ b/workflows/improve-memory-primitives/02-harness-memory-tools.ts
@@ -1,0 +1,306 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 2 — @agent-assistant/harness memory tool registry.
+ *
+ * Adds createMemoryToolRegistry({ store }) — analogous to the existing
+ * createWorkspaceToolRegistry({ provider }). Exposes three tools the
+ * harness model can call deliberately:
+ *   - memory_remember(content, scope?, tags?, expiresInDays?)
+ *   - memory_recall(query, scope?, limit?)
+ *   - memory_forget(entryId)
+ *
+ * Wires through to MemoryStore (the interface from @agent-assistant/memory).
+ * Scope-aware: callers wire workspaceId/userId/sessionId through context.
+ *
+ * Bumps @agent-assistant/harness minor version. Existing tool registries
+ * untouched.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-memory-primitives-02-harness-tools')
+    .description(
+      'Add createMemoryToolRegistry to @agent-assistant/harness exposing memory_remember, memory_recall, memory_forget tools that any harness consumer can compose alongside workspace + bash tools.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-memory-02')
+    .maxConcurrency(2)
+    .timeout(2_700_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the harness memory tool surface.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the new memory tool registry + tests.',
+      retries: 2,
+    })
+
+    .step('read-workspace-tool-registry', {
+      type: 'deterministic',
+      command:
+        'cat packages/harness/src/tools/workspace-tool-registry.ts | head -200 && echo --- && ' +
+        'cat packages/harness/src/tools/bash-tool-registry.ts | head -100',
+      captureOutput: true,
+    })
+    .step('read-harness-types', {
+      type: 'deterministic',
+      command: 'cat packages/harness/src/types.ts | head -150',
+      captureOutput: true,
+    })
+    .step('read-memory-store', {
+      type: 'deterministic',
+      command:
+        'cat packages/memory/src/types.ts && echo --- && ' +
+        'cat packages/memory/src/index.ts',
+      captureOutput: true,
+    })
+    .step('read-harness-package-json', {
+      type: 'deterministic',
+      command: 'cat packages/harness/package.json',
+      captureOutput: true,
+    })
+
+    // ── Implement ─────────────────────────────────────────────────
+    .step('implement', {
+      agent: 'impl',
+      dependsOn: ['read-workspace-tool-registry', 'read-harness-types', 'read-memory-store', 'read-harness-package-json'],
+      task: `Create packages/harness/src/tools/memory-tool-registry.ts modelled on workspace-tool-registry.ts.
+
+Reference (mirror naming, exports, validation patterns):
+{{steps.read-workspace-tool-registry.output}}
+
+HarnessToolRegistry interface (don't deviate):
+{{steps.read-harness-types.output}}
+
+MemoryStore + scope types from @agent-assistant/memory:
+{{steps.read-memory-store.output}}
+
+CONTRACT:
+
+1. Export const names:
+   MEMORY_REMEMBER_TOOL_NAME = 'memory_remember'
+   MEMORY_RECALL_TOOL_NAME   = 'memory_recall'
+   MEMORY_FORGET_TOOL_NAME   = 'memory_forget'
+   MEMORY_TOOL_NAMES = readonly tuple of the three.
+
+2. Tool definitions (HarnessToolDefinition) with input schemas:
+
+   memory_remember:
+     description: "Save a durable fact to memory. Use when the user shares a preference, project context, ownership info, deadline, or any fact you should recall in future turns. Pick the narrowest scope that's still useful: 'session' for thread-only context, 'user' for per-person facts, 'workspace' for org-wide context shared by everyone in this Slack workspace."
+     input: { content: string (1..2000 chars), scope: enum('session','user','workspace'), tags?: string[] (max 10), expiresInDays?: number (1..365) }
+
+   memory_recall:
+     description: "Search memory for relevant facts. Use when the user asks about prior context, when you need to verify a preference before acting, or before answering questions where you suspect prior context exists. Returns up to limit entries ranked by recency and (when supported) semantic relevance."
+     input: { query: string (1..500 chars), scope?: enum('session','user','workspace','any'), limit?: number (1..20, default 5) }
+
+   memory_forget:
+     description: "Delete a specific memory entry by id. Use when the user explicitly asks you to forget something, or when you discover a stored fact is wrong / superseded. Pass the id from a memory_recall result."
+     input: { entryId: string (1..200 chars) }
+
+3. Export interface MemoryToolRegistryOptions:
+     store: MemoryStore | null   // null disables the registry (listAvailable returns [])
+     resolveScopeContext: (input: HarnessToolExecutionContext) => {
+       workspaceId?: string;
+       userId?: string;
+       sessionId?: string;
+     }
+     // Resolves scope identifiers from the harness execution context. Lets
+     // each consumer (sage / future) decide how userId/workspaceId/sessionId
+     // map from their own session model.
+
+4. Export createMemoryToolRegistry(options: MemoryToolRegistryOptions): HarnessToolRegistry
+
+5. execute() per tool:
+
+   memory_remember:
+     - validate input (use the same isRecord / readRequiredString patterns as workspace-tool-registry)
+     - resolve scope using options.resolveScopeContext(call.context)
+     - if scope='user' and resolved.userId is missing → invalidInputResult ("memory_remember scope='user' requires user identity in execution context")
+     - same guard for scope='session' (sessionId) and scope='workspace' (workspaceId)
+     - build WriteMemoryInput with scope { kind: scope, ...id }, content, tags, expiresAt
+     - call store.write; on success return { status: 'success', output: JSON.stringify({ id: written.id, scope, expiresAt }), structuredOutput: { entry: written } }
+     - wrap in measureMemoryOp from @agent-assistant/memory so the structured log lands
+
+   memory_recall:
+     - validate
+     - if scope='any' or omitted, call retrieveTurnMemoryContext (from @agent-assistant/memory) with the resolved context + query; output is the rendered text via renderTurnMemoryContext
+     - if specific scope, call store.retrieve directly with that scope + query, render same shape
+     - return { status: 'success', output: rendered, structuredOutput: { entries } }
+     - wrap in measureMemoryOp
+
+   memory_forget:
+     - validate entryId
+     - call store.delete(entryId) (Note: MemoryStore.delete already exists — verify in types.ts)
+     - return { status: 'success', output: 'forgotten' }
+     - if delete throws MemoryEntryNotFoundError → return { status: 'error', error: { code: 'not_found', message: ..., retryable: false } }
+     - wrap in measureMemoryOp
+
+6. listAvailable: same shape as workspace-tool-registry — return all 3 tools when options.store, [] when null. Honor input.allowedToolNames if non-empty.
+
+7. Re-export from packages/harness/src/index.ts: createMemoryToolRegistry, MEMORY_TOOL_NAMES, MEMORY_REMEMBER_TOOL_NAME, MEMORY_RECALL_TOOL_NAME, MEMORY_FORGET_TOOL_NAME, MemoryToolRegistryOptions.
+
+8. Bump packages/harness/package.json minor: e.g. 0.6.12 → 0.7.0. Add "@agent-assistant/memory" to dependencies (with the version bumped in Sub 1).
+
+Only edit packages/harness/.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement'],
+      command:
+        'test -f packages/harness/src/tools/memory-tool-registry.ts && ' +
+        'grep -Eq "memory_remember|memory_recall|memory_forget" packages/harness/src/tools/memory-tool-registry.ts && ' +
+        'grep -Eq "createMemoryToolRegistry" packages/harness/src/tools/memory-tool-registry.ts && ' +
+        'grep -Eq "createMemoryToolRegistry" packages/harness/src/index.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Tests ─────────────────────────────────────────────────────
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-impl'],
+      task: `Create packages/harness/src/tools/memory-tool-registry.test.ts (vitest). Mirror conventions in workspace-tool-registry.test.ts.
+
+Required cases:
+
+A. listAvailable:
+   - returns all three tools when store is provided
+   - returns [] when store is null
+   - filters to allowedToolNames when set
+
+B. memory_remember happy path:
+   - stub MemoryStore.write returning a synthesized MemoryEntry
+   - resolveScopeContext returns { userId: 'u1', workspaceId: 'ws1', sessionId: 's1' }
+   - scope='session', valid content
+   - assert store.write called with scope { kind: 'session', sessionId: 's1' }, content matches, tags forwarded
+   - assert output JSON parses to { id, scope, expiresAt? }
+
+C. memory_remember scope guards:
+   - scope='user' with no userId in context → invalid_input
+   - scope='session' with no sessionId → invalid_input
+   - scope='workspace' with no workspaceId → invalid_input
+   - content > 2000 chars → invalid_input
+   - missing scope → invalid_input
+
+D. memory_recall:
+   - scope omitted → calls retrieveTurnMemoryContext, output uses renderTurnMemoryContext shape
+   - scope='user' → calls store.retrieve directly with scope + query
+   - empty result → output is empty string but status='success'
+
+E. memory_forget:
+   - happy path returns 'forgotten'
+   - MemoryEntryNotFoundError → status='error', code='not_found'
+
+F. observability:
+   - on success, console.info is called with one JSON line whose payload has event='memory_op'
+   - on store.write throw, the error propagates AND a status='failed' event is logged
+
+Use vi.spyOn(console, 'info') for the log assertions.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command:
+        'test -f packages/harness/src/tools/memory-tool-registry.test.ts && ' +
+        'grep -Eq "memory_remember|memory_recall|memory_forget|scope guards" packages/harness/src/tools/memory-tool-registry.test.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests'],
+      command: 'npx vitest run packages/harness/ 2>&1 | tail -80',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures.
+{{steps.run-tests.output}}
+If green, no-op. Re-run: npx vitest run packages/harness/`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/ 2>&1 | tail -40',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -30; echo EXIT=$?',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-typecheck', {
+      agent: 'impl',
+      dependsOn: ['typecheck'],
+      task: `If errors, fix. If EXIT=0, no-op.
+{{steps.typecheck.output}}
+Re-run: cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-typecheck'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/harness/src/tools/memory-tool-registry.ts packages/harness/src/index.ts packages/harness/package.json
+
+Verify:
+1. memory_remember scope guards reject ambiguous calls (no implicit fallback to workspace).
+2. memory_recall renders identical shape to renderTurnMemoryContext from Sub 1 — same scope+age prefix.
+3. memory_forget returns invalid-input not server-error when store doesn't support delete.
+4. resolveScopeContext is the consumer's hook — no sage-specific knowledge baked in.
+5. measureMemoryOp wrapping does not catch errors; observability is additive.
+6. Version bump is minor (new tools = minor under semver).
+7. The new file follows workspace-tool-registry.ts conventions — same isRecord, validate*, output shape, error code naming.
+
+Edit files to fix. Re-run npx vitest run packages/harness/ + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/ 2>&1 | tail -30 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-memory-primitives/03-publish-pr.ts
+++ b/workflows/improve-memory-primitives/03-publish-pr.ts
@@ -1,0 +1,183 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 3 — Holistic review, commit, push, open PR.
+ *
+ * Does NOT publish to npm — that's the existing release workflow's job
+ * once the PR merges. This sub just gets the change set into a single
+ * reviewable PR with the cross-cutting message.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-memory-primitives-03-pr')
+    .description(
+      'Final cross-package review of @agent-assistant/memory + @agent-assistant/harness changes, single commit, push, open PR.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-memory-03')
+    .maxConcurrency(2)
+    .timeout(1_800_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Senior reviewer with authority to send work back.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for any final review-driven fixes.',
+      retries: 2,
+    })
+
+    .step('check-branch', {
+      type: 'deterministic',
+      command:
+        'branch=$(git rev-parse --abbrev-ref HEAD); ' +
+        'echo "Current branch: $branch"; ' +
+        'if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then ' +
+        '  echo "REFUSE: not on a feature branch — master executor should have created one"; exit 1; ' +
+        'fi; ' +
+        'git status --short',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('show-diff-stat', {
+      type: 'deterministic',
+      dependsOn: ['check-branch'],
+      command: 'git diff --stat HEAD; echo ---; git log --oneline origin/main..HEAD',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['show-diff-stat'],
+      task: `Review the full diff via: git diff HEAD
+
+Required pass criteria:
+1. @agent-assistant/memory exports: formatRelativeAge, renderTurnMemoryContext, SESSION/USER/WORKSPACE_LOAD_LIMIT, logMemoryOp, measureMemoryOp, hashMemoryContent, MemoryOpEvent, MemoryOpName.
+2. @agent-assistant/harness exports: createMemoryToolRegistry, MEMORY_TOOL_NAMES, MEMORY_REMEMBER/RECALL/FORGET_TOOL_NAME, MemoryToolRegistryOptions.
+3. Existing function signatures (retrieveTurnMemoryContext, promoteLatestSessionMemory, createRelayBackedMemoryStore) are backwards compatible — new args optional.
+4. Both package.json bumps are minor (new exports = minor under semver). harness depends on the new memory minor.
+5. measureMemoryOp NEVER swallows errors anywhere it's used.
+6. memory_remember scope guards prevent accidental writes when the resolver returns no id for the chosen scope.
+7. No leftover .skip / .only / console.log debug in tests or src.
+8. Tests cover happy + edge + failure paths for every new helper.
+
+If anything is wrong, fix directly. Then re-run:
+  npx vitest run packages/memory/ packages/harness/
+  cd packages/memory && npx tsc --noEmit
+  cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+
+    .step('post-review-tests', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/memory/ packages/harness/ 2>&1 | tail -30 && echo --- && ' +
+        'cd packages/memory && npx tsc --noEmit 2>&1 | tail -10 && echo --- && ' +
+        'cd ../harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('commit', {
+      type: 'deterministic',
+      dependsOn: ['post-review-tests'],
+      command:
+        'git add packages/memory/ packages/harness/ && ' +
+        "git commit -m 'feat(memory,harness): scope-attributed render, structured logs, content-hash, memory tool registry' " +
+        "           -m 'Adds the primitives any harness consumer needs to surface memory to its model. memory: formatRelativeAge, renderTurnMemoryContext, SESSION/USER/WORKSPACE_LOAD_LIMIT, logMemoryOp/measureMemoryOp, hashMemoryContent, query-aware retrieveTurnMemoryContext. harness: createMemoryToolRegistry exposing memory_remember/memory_recall/memory_forget tools wired to MemoryStore via resolveScopeContext. Fully backwards compatible; new args optional, existing signatures unchanged. Minor bumps on both packages.'",
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('push', {
+      type: 'deterministic',
+      dependsOn: ['commit'],
+      command:
+        'branch=$(git rev-parse --abbrev-ref HEAD) && git push -u origin "$branch"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-pr-body', {
+      type: 'deterministic',
+      dependsOn: ['push'],
+      // Single bash heredoc — pattern from sage workflow that proved robust
+      // against shell quoting hell with backticks in body content.
+      command: `mkdir -p tmp && cat > tmp/aa-memory-pr-body.md <<'PRBODY'
+## Summary
+
+Adds memory primitives that any \`@agent-assistant/harness\` consumer needs to surface memory to its model. Sage's existing memory layer reinvented several of these locally; consolidating upstream lets new consumers (and the next iteration of sage) build on a shared foundation.
+
+## @agent-assistant/memory (minor bump)
+
+- \`formatRelativeAge(entry, now?)\` — "just now" / "N minutes ago" / etc. Pluralization correct, accepts string ISO / Date / number.
+- \`renderTurnMemoryContext(context, options?)\` — turns a \`TurnMemoryContext\` into scope+age attributed lines (\`[<scope>, <age>] <content>\`). Session first, then user, then workspace. Override-able scope labels.
+- \`SESSION_LOAD_LIMIT\`, \`USER_LOAD_LIMIT\`, \`WORKSPACE_LOAD_LIMIT\` constants — stop callers from hand-tuning.
+- \`retrieveTurnMemoryContext\` — accepts optional \`perScopeLimits\` override map and \`query\` (forwarded to \`MemoryStore.retrieve\`'s \`MemoryQuery.query\` so semantic backends can rank relevance).
+- \`logMemoryOp(event)\` + \`measureMemoryOp(meta, fn)\` — single-line JSON \`event=memory_op\` console.info events for every save / load / promote / close / init / forget. measureMemoryOp re-throws originals; observability is additive, not control flow.
+- \`hashMemoryContent(content)\` — SHA-256 base64url helper for content-hash dedup at the consumer.
+
+## @agent-assistant/harness (minor bump)
+
+- \`createMemoryToolRegistry({ store, resolveScopeContext })\` — analogous to \`createWorkspaceToolRegistry({ provider })\`. Exposes three tools the harness model can call deliberately:
+  - \`memory_remember(content, scope, tags?, expiresInDays?)\`
+  - \`memory_recall(query, scope?, limit?)\`
+  - \`memory_forget(entryId)\`
+- \`resolveScopeContext\` is the consumer's hook — sage will map workspaceId from its session, future consumers map differently.
+- Scope guards reject \`memory_remember scope='user'\` when no userId is in the execution context (and equivalents for session/workspace).
+- All ops wrapped in \`measureMemoryOp\` so the structured \`memory_op\` event lands without callers wiring it.
+
+## Why this matters
+
+Sage's harness model currently has zero agency over memory — the framework auto-summarizes every Slack turn into a 600-char blob and a regex decides whether to promote it to user scope. The model can't choose what to remember, can't recall a specific fact, can't forget something the user retracts. With these tools the model can do all three, and the existing passive auto-save remains as a fallback. Sage's adoption ships in a follow-up PR (\`workflows/improve-sage-memory/\` over in the sage repo).
+
+## Test plan
+
+- [x] \`npx vitest run packages/memory/ packages/harness/\` — green.
+- [x] \`cd packages/memory && npx tsc --noEmit\` — clean.
+- [x] \`cd packages/harness && npx tsc --noEmit\` — clean.
+- [x] Backwards-compat: existing signatures unchanged; new args optional.
+- [x] Failure-path tests: measureMemoryOp re-throws original errors; memory_forget returns \`not_found\` (not server error) when entry missing.
+
+## Followups
+
+- Sage adoption (separate PR in the sage repo) — wires \`createMemoryToolRegistry\` into \`SageHarnessRegistryDeps\`, swaps capabilities prompt, swaps \`thread-context\` layer to call \`renderTurnMemoryContext\`, and unifies the slack/client-api write paths.
+- Consider a dedicated content-hash dedup helper in the store layer (today \`hashMemoryContent\` is only the building block).
+- Compaction strategy across user-scope duplicates — defer until usage data arrives.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PRBODY
+wc -l tmp/aa-memory-pr-body.md`,
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('open-pr', {
+      type: 'deterministic',
+      dependsOn: ['write-pr-body'],
+      command:
+        'PR_URL=$(gh pr create --title "feat(memory,harness): scope-attributed render, structured logs, memory tool registry" --body-file tmp/aa-memory-pr-body.md) && echo "PR: $PR_URL"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-memory-primitives/04-loosen-detector-and-large-output-advisory.ts
+++ b/workflows/improve-memory-primitives/04-loosen-detector-and-large-output-advisory.ts
@@ -1,0 +1,316 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 4 — Loosen the redundant-tool-loop detector + add large-output
+ * advisory to workspace tool results.
+ *
+ * Captured live (sage prod turn slack-1777335112549-8npk7r): the model
+ * called workspace_list /github/repos/AgentWorkforce/relay depth=2 five
+ * times back-to-back with identical args, interleaving one
+ * workspace_search at iteration 6 to dodge the existing redundant-loop
+ * detector (which only trips on 3 CONSECUTIVE identical results). Hit
+ * max_iterations_reached on iter 9. Slack reply was the user-facing
+ * fallback "I could not complete that request right now."
+ *
+ * Two upstream changes:
+ *
+ * A. @agent-assistant/harness redundant-loop detector — change from
+ *    "last 3 consecutive identical" to "M of last K identical, regardless
+ *    of order, by (toolName, outputHash)". Defaults M=4, K=6 — tunable
+ *    via createHarness limits config. Backwards compatible: the looser
+ *    detector subsumes the strict one.
+ *
+ * B. @agent-assistant/harness workspace-tool-registry — when a tool's
+ *    output exceeds 5KB, append a structured `_advisory: { kind:
+ *    'large_output', hint: 'drill in via workspace_read on a specific
+ *    file or workspace_list on a deeper subpath; do not re-call with
+ *    identical args' }` field on the OUTER object (alongside the items
+ *    array). This reaches every consumer, not just sage.
+ *
+ * Bumps @agent-assistant/harness minor (additive change).
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-memory-primitives-04-detector-and-advisory')
+    .description(
+      'Loosen the harness redundant-tool-loop detector and add a large-output advisory to workspace tool results so future regressions trip as redundant_tool_loop instead of max_iterations_reached.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-memory-04')
+    .maxConcurrency(2)
+    .timeout(2_700_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the harness detector + advisory shape.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for harness.ts detector tuning + workspace-tool-registry advisory + tests.',
+      retries: 2,
+    })
+
+    // Read context
+    .step('read-harness', {
+      type: 'deterministic',
+      command:
+        'cat packages/harness/src/harness.ts | head -250 && echo --- && ' +
+        'cat packages/harness/src/types.ts | head -150',
+      captureOutput: true,
+    })
+    .step('read-workspace-tool-registry', {
+      type: 'deterministic',
+      command: 'cat packages/harness/src/tools/workspace-tool-registry.ts',
+      captureOutput: true,
+    })
+    .step('read-existing-detector-test', {
+      type: 'deterministic',
+      command:
+        'grep -nE "redundant_tool_loop|outputHash|lastThree" packages/harness/src/harness.ts && echo --- && ' +
+        'grep -lE "redundant_tool_loop|outputHash" packages/harness/src/*.test.ts 2>/dev/null',
+      captureOutput: true,
+    })
+
+    // ── A. Loosen the detector ────────────────────────────────────
+    .step('implement-detector', {
+      agent: 'impl',
+      dependsOn: ['read-harness', 'read-existing-detector-test'],
+      task: `Edit packages/harness/src/harness.ts. The current detector lives near \`buildLimitResult(..., 'redundant_tool_loop')\` and uses a \`lastThree\` window:
+{{steps.read-existing-detector-test.output}}
+
+Reference (search for 'lastThree' to find the exact block):
+{{steps.read-harness.output}}
+
+CONTRACT:
+
+1. Replace the strict "last 3 consecutive identical" check with a windowed "M of last K identical, regardless of order" check:
+   - Keep tracking each tool result's \`{ toolName, outputHash }\` in a per-turn ring buffer of size K.
+   - When the buffer has K entries (or more), count occurrences by \`\${toolName}::\${outputHash}\` and trip if ANY signature appears >= M times in that window.
+   - Defaults: M=4, K=6.
+
+2. Make M and K configurable via createHarness limits:
+     limits: {
+       maxIterations,
+       maxToolCalls,
+       maxElapsedMs,
+       redundantToolLoopThreshold?: { matches: number; window: number };
+     }
+   - Default value when unset: \`{ matches: 4, window: 6 }\`.
+   - Validate: matches must be >= 2 AND <= window AND window must be >= matches AND <= 20. Invalid values fall back to defaults with a single console.warn.
+
+3. Keep the trip behavior the same: \`buildLimitResult(config, input, state, 'redundant_tool_loop')\` and \`outcome === 'failed'\` for that stop reason.
+
+4. Existing tests that assert the strict "3 consecutive identical" trip MUST still pass — the looser detector subsumes the strict pattern (3 consecutive identical is also 3 of last 3, which is 3+ of any window K >= 3 with M <= 3). If a test relied on a NON-trip with 3 consecutive non-matching but 4 of 6 matching, that's the regression we're fixing — update the test to assert the trip.
+
+5. Export the threshold type:
+     export interface RedundantToolLoopThreshold {
+       matches: number;
+       window: number;
+     }
+
+Only edit packages/harness/src/harness.ts (and types.ts if the threshold type lives there).`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-detector-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement-detector'],
+      command:
+        'if git diff --quiet packages/harness/src/harness.ts; then echo "NOT MODIFIED"; exit 1; fi; ' +
+        'grep -Eq "redundantToolLoopThreshold|RedundantToolLoopThreshold|matches.*window" packages/harness/src/harness.ts packages/harness/src/types.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── B. Large-output advisory in workspace-tool-registry ───────
+    .step('implement-advisory', {
+      agent: 'impl',
+      dependsOn: ['read-workspace-tool-registry', 'verify-detector-impl'],
+      task: `Edit packages/harness/src/tools/workspace-tool-registry.ts.
+
+Current contents:
+{{steps.read-workspace-tool-registry.output}}
+
+CONTRACT:
+
+1. Add a module-level constant: \`LARGE_OUTPUT_ADVISORY_BYTES = 5 * 1024\` (5 KB).
+
+2. After stringifyArrayOutput / stringifyObjectOutput produces the final JSON string for a tool result, BEFORE returning successResult: if byteLength(output) > LARGE_OUTPUT_ADVISORY_BYTES AND the tool name is workspace_list OR workspace_search, wrap the output:
+   - Parse the existing output as JSON
+   - If it's an array of items (workspace_list / workspace_search): wrap as
+       { items: <originalArray>, _advisory: { kind: 'large_output', hint: 'This result is large. Do NOT re-call this tool with identical args (output will be identical). Drill in via workspace_read on a specific file from the listing (package.json, README.md, CHANGELOG.md, tsconfig.json) or workspace_list on a deeper subpath.' } }
+   - If it's a single object (workspace_read_json): leave it; the JSON file's structure is the consumer's concern, not ours.
+   - If it's raw text (workspace_read returning content): leave it; raw text doesn't have a place for a JSON advisory field.
+
+3. Re-stringify the wrapped object via stringifyOutput. The truncation cap MAX_OUTPUT_BYTES (50KB) still applies.
+
+4. Add an export so consumers can read the constant:
+     export const WORKSPACE_LARGE_OUTPUT_ADVISORY_BYTES = LARGE_OUTPUT_ADVISORY_BYTES;
+
+5. Backwards compatibility: small results (under 5 KB) are unchanged — same array shape consumers expect today. Only large results gain the wrapping object. Document this in a code comment so a consumer's runtime check on \`Array.isArray(parsed)\` knows to also handle \`parsed.items\`.
+
+Only edit packages/harness/src/tools/workspace-tool-registry.ts.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-advisory-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement-advisory'],
+      command:
+        'if git diff --quiet packages/harness/src/tools/workspace-tool-registry.ts; then echo "NOT MODIFIED"; exit 1; fi; ' +
+        'grep -Eq "LARGE_OUTPUT_ADVISORY_BYTES|_advisory|large_output" packages/harness/src/tools/workspace-tool-registry.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Tests ─────────────────────────────────────────────────────
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-advisory-impl'],
+      task: `Add / extend tests:
+
+1. packages/harness/src/harness.test.ts (extend) — redundant-loop detector:
+   a) "trips with default 4 of last 6 when model interleaves":
+      - Stub model to emit the sage prod sequence: list_A, list_A, search_A, list_A, list_A, list_A
+      - Assert turn outcome=failed, stopReason='redundant_tool_loop'
+      - This is the regression-under-fix from sage turn slack-1777335112549-8npk7r
+   b) "still trips on 3 consecutive identical when threshold matches=3 window=3 (strict mode)":
+      - Pass redundantToolLoopThreshold: { matches: 3, window: 3 }
+      - Stub model to emit 3 identical calls
+      - Assert trip
+   c) "does NOT trip on 4 of last 6 when threshold matches=5 window=6":
+      - Pass threshold { matches: 5, window: 6 }
+      - Stub the same interleaved sequence; asserts no trip until 5 identical
+   d) "validates threshold inputs and falls back to defaults on invalid values":
+      - matches=1 (< 2) → falls back, single warn
+      - matches > window → falls back
+      - window > 20 → falls back
+
+2. packages/harness/src/tools/workspace-tool-registry.test.ts (extend) — large-output advisory:
+   a) "small workspace_list output passes through as plain array (no advisory)":
+      - Stub provider returning a tiny listing
+      - Assert parsed output is Array.isArray, no _advisory key
+   b) "large workspace_list output is wrapped with _advisory":
+      - Stub provider returning ~6 KB of entries
+      - Assert parsed output has shape { items: [...], _advisory: { kind: 'large_output', hint: <string with 'drill in' or 'do not re-call'> } }
+      - Assert items.length matches the original
+   c) "workspace_search large output also wrapped":
+      - Same as (b) but via workspace_search
+   d) "workspace_read raw text is NOT wrapped":
+      - Stub a 6KB raw text read
+      - Assert output is raw text (no _advisory wrapping)
+   e) "workspace_read_json large output is NOT wrapped":
+      - Stub returning a large JSON-parseable object
+      - Assert output is the original WorkspaceReadJsonOutput shape (no _advisory)
+
+Use vitest. Mirror existing patterns in packages/harness/src/.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command:
+        'grep -cE "redundantToolLoopThreshold|4 of last 6|interleaves|large_output|_advisory" ' +
+        'packages/harness/src/harness.test.ts ' +
+        'packages/harness/src/tools/workspace-tool-registry.test.ts ' +
+        '2>/dev/null && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests'],
+      command: 'npx vitest run packages/harness/ 2>&1 | tail -100',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures:
+{{steps.run-tests.output}}
+If green, no-op. Don't loosen the new assertions. The most likely cause of failures is an EXISTING test that asserted the strict "3 consecutive identical" behavior on a sequence that ALSO matches "M of K identical, regardless of order" — those tests still pass because the looser detector subsumes the strict one. If a test asserts NON-trip on a sequence that the new detector trips on, that test is testing the bug — update it to assert the trip.
+Re-run: npx vitest run packages/harness/`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/ 2>&1 | tail -50',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    // ── Bump harness package version ──────────────────────────────
+    .step('bump-version', {
+      agent: 'impl',
+      dependsOn: ['run-tests-final'],
+      task: `Bump packages/harness/package.json minor (e.g. if Sub 2 already bumped to 0.7.0, this Sub bumps to 0.7.1 — patch is fine since it adds optional new exports plus the looser detector behavior. Or bump to 0.8.0 if you treat detector behavior change as minor. Pick whichever matches the repo's prior cadence; the previous bumps in this session went minor.).
+
+Print the new version when done.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('verify-bump', {
+      type: 'deterministic',
+      dependsOn: ['bump-version'],
+      command:
+        'if git diff --quiet packages/harness/package.json; then echo "NOT BUMPED"; exit 1; fi; ' +
+        'grep "\\"version\\"" packages/harness/package.json | head -1',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['verify-bump'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/harness/
+
+Verify:
+1. Detector tuning: the new "M of last K identical" detector subsumes the strict "3 consecutive identical" — every sequence that tripped before still trips. Confirm by looking at the test suite — no existing trip-asserting test failed.
+2. The detector's ring buffer is bounded — it doesn't grow unboundedly across iterations. K is the max size.
+3. Threshold validation has a sensible default fallback path (matches=4, window=6) and a single console.warn on invalid inputs.
+4. Large-output advisory wrapping changes the JSON shape on the wire for outputs > 5 KB. Document this in workspace-tool-registry.ts so consumers know to handle parsed.items in addition to bare arrays.
+5. Tests cover the EXACT regression sequence from sage turn slack-1777335112549-8npk7r (list_A x2, search_A, list_A x3, with the search interleave that dodged the strict detector).
+6. Version bump is appropriate — minor for behavior change OR patch for additive (your call; document in commit message).
+
+Edit files to fix. Re-run npx vitest run packages/harness/ + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/ 2>&1 | tail -30 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-memory-primitives/README.md
+++ b/workflows/improve-memory-primitives/README.md
@@ -1,0 +1,89 @@
+# improve-memory-primitives
+
+Adds the memory primitives any `@agent-assistant/harness` consumer needs to
+surface memory to its model. Sage today reinvents most of these locally;
+consolidating upstream lets future consumers (and the next iteration of
+sage) build on a shared foundation.
+
+## What ships in this workflow
+
+### `@agent-assistant/memory` (minor bump)
+
+| Symbol | Purpose |
+|---|---|
+| `formatRelativeAge(entry, now?)` | "just now" / "N minutes ago" / etc. |
+| `renderTurnMemoryContext(context, opts?)` | `[<scope>, <age>] <content>` lines for direct prompt injection |
+| `SESSION_LOAD_LIMIT`, `USER_LOAD_LIMIT`, `WORKSPACE_LOAD_LIMIT` | Named per-scope load constants |
+| `retrieveTurnMemoryContext(input)` | Now accepts optional `perScopeLimits` and `query` (forwarded to `MemoryStore.retrieve`) |
+| `logMemoryOp(event)` + `measureMemoryOp(meta, fn)` | Single-line JSON `event=memory_op` console.info for save/load/promote/close/init/forget. `measureMemoryOp` re-throws originals — observability is additive. |
+| `hashMemoryContent(content)` | SHA-256 base64url helper for content-hash dedup |
+
+### `@agent-assistant/harness` (minor bump)
+
+| Symbol | Purpose |
+|---|---|
+| `createMemoryToolRegistry({ store, resolveScopeContext })` | Analogous to `createWorkspaceToolRegistry({ provider })` |
+| `MEMORY_TOOL_NAMES`, `MEMORY_REMEMBER_TOOL_NAME`, `MEMORY_RECALL_TOOL_NAME`, `MEMORY_FORGET_TOOL_NAME` | Tool name constants |
+| Tools: `memory_remember`, `memory_recall`, `memory_forget` | Model-callable memory ops with scope guards |
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `00-execute.ts` | Master — branch + sequential subs + fail-fast |
+| `01-memory-package.ts` | `@agent-assistant/memory` primitives + tests |
+| `02-harness-memory-tools.ts` | `createMemoryToolRegistry` + tests |
+| `03-publish-pr.ts` | Lead review + commit + push + PR |
+
+## Run
+
+```bash
+cd ../agent-assistant
+npx tsx workflows/improve-memory-primitives/00-execute.ts
+```
+
+Each sub also calls `process.exit(1)` on `result.status === 'failed'`; the
+master greps stdout for `Workflow status: failed` as a second guard. Branch
+left in place on failure for inspection.
+
+## What this is NOT doing
+
+- Not changing how sage consumes memory (that's the followup workflow in
+  the sage repo, `workflows/improve-sage-memory/`, which depends on the
+  versions published by this PR's merge).
+- Not introducing dedup at the store layer — `hashMemoryContent` is the
+  building block; consumers decide whether to dedup at write.
+- Not changing existing function signatures — every new arg is optional;
+  every existing helper keeps its current shape so out-of-tree consumers
+  don't break.
+- Not publishing to npm — that's the existing `@agent-assistant` release
+  workflow's job, fired automatically on PR merge.
+
+## Why upstream first
+
+Per the AgentWorkforce convention (see `.claude/rules/...` in sage):
+"primitives that any consumer needs belong in `@agent-assistant`; sage
+consumes via semver." Mirroring `formatRelativeAge` / a memory tool
+registry inside sage would block the next consumer from getting them
+without a copy-paste.
+
+## Acceptance contract
+
+`gh pr view <pr#> --json mergeStateStatus` returns `MERGEABLE` after lead
+review approves and CI passes. The two version bumps are minor (new
+exports = minor under semver). Once merged, the release workflow fires and
+the published versions (e.g. `@agent-assistant/memory@0.4.0`,
+`@agent-assistant/harness@0.7.0`) become the minimum sage will pin to.
+
+## Followup
+
+After merge + publish, run `workflows/improve-sage-memory/00-execute.ts` in
+the sage repo. That workflow:
+1. Bumps sage's deps to the new minors.
+2. Replaces sage's local memory render with `renderTurnMemoryContext`.
+3. Wires `createMemoryToolRegistry` into `SageHarnessRegistryDeps` so the
+   slack-runner harness model can call `memory_remember/recall/forget`.
+4. Updates the capabilities + thread-context prompt layers to describe the
+   new model agency truthfully.
+5. Adds smarter heuristic improvements (LLM-judge promotion, query
+   plumbing) and unifies the slack/client-api write paths.

--- a/workflows/improve-memory-primitives/README.md
+++ b/workflows/improve-memory-primitives/README.md
@@ -25,6 +25,8 @@ sage) build on a shared foundation.
 | `createMemoryToolRegistry({ store, resolveScopeContext })` | Analogous to `createWorkspaceToolRegistry({ provider })` |
 | `MEMORY_TOOL_NAMES`, `MEMORY_REMEMBER_TOOL_NAME`, `MEMORY_RECALL_TOOL_NAME`, `MEMORY_FORGET_TOOL_NAME` | Tool name constants |
 | Tools: `memory_remember`, `memory_recall`, `memory_forget` | Model-callable memory ops with scope guards |
+| `RedundantToolLoopThreshold` + `createHarness({ limits: { redundantToolLoopThreshold } })` | Replaces "last 3 consecutive identical" with "M of last K identical, regardless of order" (defaults M=4, K=6). Models can no longer dodge the detector by interleaving one different call. |
+| `WORKSPACE_LARGE_OUTPUT_ADVISORY_BYTES` constant + `_advisory` wrap on workspace_list / workspace_search outputs > 5 KB | Tells the model to drill in via `workspace_read` on a specific file or `workspace_list` on a deeper subpath; do not re-call with identical args. |
 
 ## Layout
 
@@ -33,7 +35,8 @@ sage) build on a shared foundation.
 | `00-execute.ts` | Master — branch + sequential subs + fail-fast |
 | `01-memory-package.ts` | `@agent-assistant/memory` primitives + tests |
 | `02-harness-memory-tools.ts` | `createMemoryToolRegistry` + tests |
-| `03-publish-pr.ts` | Lead review + commit + push + PR |
+| `04-loosen-detector-and-large-output-advisory.ts` | Loosen redundant-tool-loop detector ("M of last K identical, regardless of order") + add `_advisory` wrap on workspace tool outputs > 5 KB |
+| `03-publish-pr.ts` | Lead review + commit + push + PR (runs last so PR includes Sub 4) |
 
 ## Run
 


### PR DESCRIPTION
## Summary

Adds memory primitives that any `@agent-assistant/harness` consumer needs to surface memory to its model. Sage's existing memory layer reinvented several of these locally; consolidating upstream lets new consumers (and the next iteration of sage) build on a shared foundation.

## @agent-assistant/memory (minor bump)

- `formatRelativeAge(entry, now?)` — "just now" / "N minutes ago" / etc. Pluralization correct, accepts string ISO / Date / number.
- `renderTurnMemoryContext(context, options?)` — turns a `TurnMemoryContext` into scope+age attributed lines (`[<scope>, <age>] <content>`). Session first, then user, then workspace. Override-able scope labels.
- `SESSION_LOAD_LIMIT`, `USER_LOAD_LIMIT`, `WORKSPACE_LOAD_LIMIT` constants — stop callers from hand-tuning.
- `retrieveTurnMemoryContext` — accepts optional `perScopeLimits` override map and `query` (forwarded to `MemoryStore.retrieve`'s `MemoryQuery.query` so semantic backends can rank relevance).
- `logMemoryOp(event)` + `measureMemoryOp(meta, fn)` — single-line JSON `event=memory_op` console.info events for every save / load / promote / close / init / forget. measureMemoryOp re-throws originals; observability is additive, not control flow.
- `hashMemoryContent(content)` — SHA-256 base64url helper for content-hash dedup at the consumer.

## @agent-assistant/harness (minor bump)

- `createMemoryToolRegistry({ store, resolveScopeContext })` — analogous to `createWorkspaceToolRegistry({ provider })`. Exposes three tools the harness model can call deliberately:
  - `memory_remember(content, scope, tags?, expiresInDays?)`
  - `memory_recall(query, scope?, limit?)`
  - `memory_forget(entryId)`
- `resolveScopeContext` is the consumer's hook — sage will map workspaceId from its session, future consumers map differently.
- Scope guards reject `memory_remember scope='user'` when no userId is in the execution context (and equivalents for session/workspace).
- All ops wrapped in `measureMemoryOp` so the structured `memory_op` event lands without callers wiring it.

## Why this matters

Sage's harness model currently has zero agency over memory — the framework auto-summarizes every Slack turn into a 600-char blob and a regex decides whether to promote it to user scope. The model can't choose what to remember, can't recall a specific fact, can't forget something the user retracts. With these tools the model can do all three, and the existing passive auto-save remains as a fallback. Sage's adoption ships in a follow-up PR (`workflows/improve-sage-memory/` over in the sage repo).

## Test plan

- [x] `npx vitest run packages/memory/ packages/harness/` — green.
- [x] `cd packages/memory && npx tsc --noEmit` — clean.
- [x] `cd packages/harness && npx tsc --noEmit` — clean.
- [x] Backwards-compat: existing signatures unchanged; new args optional.
- [x] Failure-path tests: measureMemoryOp re-throws original errors; memory_forget returns `not_found` (not server error) when entry missing.

## Followups

- Sage adoption (separate PR in the sage repo) — wires `createMemoryToolRegistry` into `SageHarnessRegistryDeps`, swaps capabilities prompt, swaps `thread-context` layer to call `renderTurnMemoryContext`, and unifies the slack/client-api write paths.
- Consider a dedicated content-hash dedup helper in the store layer (today `hashMemoryContent` is only the building block).
- Compaction strategy across user-scope duplicates — defer until usage data arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
