### PR TITLE
chore(workflows): add improve-harness-primitives — five primitives lifted from sage

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  classifyOpenRouterError,
+  OpenRouterModelAdapter,
+} from './openrouter-model-adapter.js';
+import type { HarnessInvalidOutput, HarnessModelInput } from '../types.js';
+
+function makeInput(overrides: Partial<HarnessModelInput> = {}): HarnessModelInput {
+  return {
+    assistantId: 'a1',
+    turnId: 't1',
+    message: { id: 'm1', text: 'Hello', receivedAt: '2024-01-01T00:00:00Z' },
+    instructions: { systemPrompt: 'You are helpful.' },
+    transcript: [],
+    availableTools: [],
+    iteration: 0,
+    toolCallCount: 0,
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
+function makeJsonResponse(body: unknown, status = 200): Promise<Response> {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function makeMalformedJsonResponse(status = 200): Promise<Response> {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+  } as Response);
+}
+
+function expectInvalid(result: Awaited<ReturnType<OpenRouterModelAdapter['nextStep']>>): HarnessInvalidOutput {
+  expect(result.type).toBe('invalid');
+  return result as HarnessInvalidOutput;
+}
+
+describe('OpenRouterModelAdapter error codes', () => {
+  it('maps 402 credit errors to provider_error + credits_exhausted', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'You need more credits to continue.' } }, 402),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('provider_error');
+    expect(result.code).toBe('credits_exhausted');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps 429 responses to transient + rate_limited', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Too many requests' } }, 429),
+    );
+    const adapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl,
+      transientRetryDelayMs: 0,
+    });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('transient');
+    expect(result.code).toBe('rate_limited');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps 408 responses to transient + timeout', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Request timeout' } }, 408),
+    );
+    const adapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl,
+      transientRetryDelayMs: 0,
+    });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('transient');
+    expect(result.code).toBe('timeout');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps 401 responses to provider_error + auth_failed', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Unauthorized' } }, 401),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('provider_error');
+    expect(result.code).toBe('auth_failed');
+  });
+
+  it('maps 403 responses to provider_error + auth_failed', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Forbidden' } }, 403),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('provider_error');
+    expect(result.code).toBe('auth_failed');
+  });
+
+  it('maps 400 responses to provider_error + invalid_request', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Invalid request payload' } }, 400),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('provider_error');
+    expect(result.code).toBe('invalid_request');
+  });
+
+  it('maps 404 responses to provider_error + model_not_found', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Model not found' } }, 404),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('provider_error');
+    expect(result.code).toBe('model_not_found');
+  });
+
+  it('maps 500 responses to transient + unknown', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Internal server error' } }, 500),
+    );
+    const adapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl,
+      transientRetryDelayMs: 0,
+    });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('transient');
+    expect(result.code).toBe('unknown');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('prefers context length error text over an otherwise unrelated status code', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Context length exceeded for this model.' } }, 418),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.code).toBe('context_length_exceeded');
+  });
+
+  it('prefers insufficient-credit text over an otherwise unrelated status code', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(
+      makeJsonResponse({ error: { message: 'Insufficient balance for this request.' } }, 418),
+    );
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.code).toBe('credits_exhausted');
+  });
+
+  it('maps AbortError timeouts to transient + timeout', async () => {
+    const fetchImpl = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    const adapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl,
+      timeoutMs: 10,
+      transientRetryDelayMs: 0,
+    });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('transient');
+    expect(result.code).toBe('timeout');
+    expect(result.reason).toBe('timeout');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps thrown generic credit errors to transient + credits_exhausted', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error('openrouter says you need more credits'));
+    const adapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl,
+      transientRetryDelayMs: 0,
+    });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('transient');
+    expect(result.code).toBe('credits_exhausted');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('maps ok responses with malformed JSON to provider_error + unknown', async () => {
+    const fetchImpl = vi.fn().mockReturnValue(makeMalformedJsonResponse());
+    const adapter = new OpenRouterModelAdapter({ apiKey: 'test-key', fetchImpl });
+
+    const result = expectInvalid(await adapter.nextStep(makeInput()));
+
+    expect(result.kind).toBe('provider_error');
+    expect(result.code).toBe('unknown');
+    expect(result.reason).toContain('not valid JSON');
+  });
+
+  it('preserves the pre-existing kind split for 429 and 402 credit failures', async () => {
+    const rateLimitedAdapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl: vi.fn().mockReturnValue(
+        makeJsonResponse({ error: { message: 'Too many requests' } }, 429),
+      ),
+      transientRetryDelayMs: 0,
+    });
+    const creditsAdapter = new OpenRouterModelAdapter({
+      apiKey: 'test-key',
+      fetchImpl: vi.fn().mockReturnValue(
+        makeJsonResponse({ error: { message: 'Please add more credits.' } }, 402),
+      ),
+    });
+
+    const rateLimited = expectInvalid(await rateLimitedAdapter.nextStep(makeInput()));
+    const credits = expectInvalid(await creditsAdapter.nextStep(makeInput()));
+
+    expect(rateLimited.kind).toBe('transient');
+    expect(rateLimited.code).toBe('rate_limited');
+    expect(credits.kind).toBe('provider_error');
+    expect(credits.code).toBe('credits_exhausted');
+  });
+
+  it('classifies helper-level 429 errors as rate_limited', () => {
+    expect(classifyOpenRouterError(429, 'too many requests')).toBe('rate_limited');
+  });
+});

--- a/packages/harness/src/adapter/openrouter-model-adapter.ts
+++ b/packages/harness/src/adapter/openrouter-model-adapter.ts
@@ -3,6 +3,7 @@ import type {
   HarnessModelInput,
   HarnessModelOutput,
   HarnessInvalidOutput,
+  HarnessInvalidOutputCode,
   HarnessToolCall,
   HarnessToolDefinition,
   HarnessTranscriptItem,
@@ -442,6 +443,46 @@ function invalidOutput(
   };
 }
 
+export function classifyOpenRouterError(
+  httpStatus: number | undefined,
+  reason: string | undefined,
+): HarnessInvalidOutputCode {
+  const text = (reason ?? '').toLowerCase();
+
+  if (text.includes('credits') || text.includes('afford') || text.includes('insufficient')) {
+    return 'credits_exhausted';
+  }
+  if (
+    text.includes('context length') ||
+    text.includes('maximum context') ||
+    text.includes('token limit')
+  ) {
+    return 'context_length_exceeded';
+  }
+  if (text === 'timeout') {
+    return 'timeout';
+  }
+
+  switch (httpStatus) {
+    case 400:
+      return 'invalid_request';
+    case 401:
+    case 403:
+      return 'auth_failed';
+    case 404:
+      return 'model_not_found';
+    case 408:
+      return 'timeout';
+    case 429:
+      return 'rate_limited';
+    default:
+      if (httpStatus !== undefined && httpStatus >= 500) {
+        return 'unknown';
+      }
+      return 'unknown';
+  }
+}
+
 function isTransientHttpStatus(status: number): boolean {
   return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
 }
@@ -486,6 +527,7 @@ function classifyCanonicalResponse(
 
   if (canonical.refusal) {
     return invalidOutput('model_refused', canonical.refusal, {
+      code: 'unknown',
       raw: body,
       metadata,
       ...(usage ? { usage } : {}),
@@ -498,6 +540,7 @@ function classifyCanonicalResponse(
       const parsed = parseToolCallInput(tc.arguments);
       if (!parsed) {
         return invalidOutput('schema_mismatch', 'tool_call arguments are not valid JSON object', {
+          code: 'invalid_request',
           raw: body,
           metadata,
           ...(usage ? { usage } : {}),
@@ -520,6 +563,7 @@ function classifyCanonicalResponse(
       ? 'OpenRouter response did not include usable assistant content'
       : 'OpenRouter response did not include a message choice',
     {
+      code: 'unknown',
       raw: body,
       metadata,
       ...(usage ? { usage } : {}),
@@ -554,7 +598,10 @@ export class OpenRouterModelAdapter implements HarnessModelAdapter {
 
   async nextStep(input: HarnessModelInput): Promise<HarnessModelOutput> {
     if (!this.apiKey) {
-      return invalidOutput('provider_error', 'OpenRouter API key is not configured.');
+      return invalidOutput('provider_error', 'OpenRouter API key is not configured.', {
+        code: 'auth_failed',
+        metadata: { modelId: this.model },
+      });
     }
 
     let retriedAt: string | undefined;
@@ -569,7 +616,10 @@ export class OpenRouterModelAdapter implements HarnessModelAdapter {
       await delay(this.transientRetryDelayMs);
     }
 
-    return invalidOutput('provider_error', 'OpenRouter adapter exhausted retry loop unexpectedly');
+    return invalidOutput('provider_error', 'OpenRouter adapter exhausted retry loop unexpectedly', {
+      code: 'unknown',
+      metadata: { modelId: this.model },
+    });
   }
 
   private async requestOnce(input: HarnessModelInput): Promise<HarnessModelOutput> {
@@ -598,6 +648,7 @@ export class OpenRouterModelAdapter implements HarnessModelAdapter {
           isTransientHttpStatus(response.status) ? 'transient' : 'provider_error',
           reason,
           {
+            code: classifyOpenRouterError(response.status, body?.error?.message),
             raw: body,
             httpStatus: response.status,
             metadata: { modelId: this.model },
@@ -606,18 +657,26 @@ export class OpenRouterModelAdapter implements HarnessModelAdapter {
       }
 
       if (!body) {
-        return invalidOutput('provider_error', 'OpenRouter response body was not valid JSON');
+        return invalidOutput('provider_error', 'OpenRouter response body was not valid JSON', {
+          code: 'unknown',
+          metadata: { modelId: this.model },
+        });
       }
 
       return classifyCanonicalResponse(body, responseToCanonical(body), this.model);
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
-        return invalidOutput('transient', 'timeout', { metadata: { modelId: this.model } });
+        return invalidOutput('transient', 'timeout', {
+          code: 'timeout',
+          metadata: { modelId: this.model },
+        });
       }
+      const reason = error instanceof Error ? error.message : 'Unknown error';
       return invalidOutput(
         'transient',
-        error instanceof Error ? error.message : 'Unknown error',
+        reason,
         {
+          code: classifyOpenRouterError(undefined, error instanceof Error ? error.message : undefined),
           raw: body,
           metadata: { modelId: this.model },
         },

--- a/packages/harness/src/idempotency-guard.test.ts
+++ b/packages/harness/src/idempotency-guard.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createIdempotencyGuard } from './idempotency-guard.js';
+import type {
+  HarnessToolAvailabilityInput,
+  HarnessToolCall,
+  HarnessToolDefinition,
+  HarnessToolExecutionContext,
+  HarnessToolRegistry,
+  HarnessToolResult,
+} from './types.js';
+
+function makeCall(
+  id: string,
+  input: Record<string, unknown> = { q: 'a' },
+  name = 'workspace_search',
+): HarnessToolCall {
+  return { id, name, input };
+}
+
+function makeContext(
+  turnId: string,
+  overrides: Partial<HarnessToolExecutionContext> = {},
+): HarnessToolExecutionContext {
+  return {
+    assistantId: 'assistant-1',
+    turnId,
+    iteration: 0,
+    toolCallIndex: 0,
+    ...overrides,
+  };
+}
+
+function makeAvailabilityInput(
+  overrides: Partial<HarnessToolAvailabilityInput> = {},
+): HarnessToolAvailabilityInput {
+  return {
+    assistantId: 'assistant-1',
+    turnId: 'turn-1',
+    ...overrides,
+  };
+}
+
+function makeResult(
+  call: HarnessToolCall,
+  overrides: Partial<HarnessToolResult> = {},
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'success',
+    output: 'search-results',
+    ...overrides,
+  };
+}
+
+function makeInnerRegistry(args?: {
+  executeImpl?: HarnessToolRegistry['execute'];
+  tools?: HarnessToolDefinition[];
+}) {
+  const tools =
+    args?.tools ??
+    [
+      {
+        name: 'workspace_search',
+        description: 'Search the workspace.',
+      },
+    ];
+  const execute =
+    args?.executeImpl ??
+    vi.fn(async (call: HarnessToolCall) => makeResult(call, { output: `output-for-${call.id}` }));
+  const listAvailable = vi.fn(async () => tools);
+
+  return {
+    listAvailable,
+    execute: vi.fn(execute),
+  } satisfies HarnessToolRegistry & {
+    listAvailable: ReturnType<typeof vi.fn>;
+    execute: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('createIdempotencyGuard', () => {
+  it('passes the first call through unchanged', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const expected = makeResult(call, { output: 'first-pass' });
+    const inner = makeInnerRegistry({
+      executeImpl: vi.fn(async () => expected),
+    });
+
+    const guard = createIdempotencyGuard(inner);
+    const result = await guard.execute(call, context);
+
+    expect(result).toEqual(expected);
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+    expect(inner.execute).toHaveBeenCalledWith(call, context);
+  });
+
+  it('blocks a second identical call within the same turn', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+
+    const first = await guard.execute(call, context);
+    const second = await guard.execute(call, context);
+
+    expect(first.status).toBe('success');
+    expect(second.status).toBe('error');
+    expect(second.error?.code).toBe('redundant_call_blocked');
+    expect(second.error?.retryable).toBe(false);
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not block identical calls across different turn ids', async () => {
+    const call = makeCall('call-1');
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+
+    const first = await guard.execute(call, makeContext('turn-1'));
+    const second = await guard.execute(call, makeContext('turn-2'));
+
+    expect(first.status).toBe('success');
+    expect(second.status).toBe('success');
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not block calls with different inputs in the same turn', async () => {
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+    const context = makeContext('turn-1');
+
+    const first = await guard.execute(makeCall('call-1', { q: 'a' }), context);
+    const second = await guard.execute(makeCall('call-2', { q: 'b' }), context);
+
+    expect(first.status).toBe('success');
+    expect(second.status).toBe('success');
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats objects with different key order as the same signature', async () => {
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+    const context = makeContext('turn-1');
+
+    const first = await guard.execute(makeCall('call-1', { a: 1, b: 2 }), context);
+    const second = await guard.execute(makeCall('call-2', { b: 2, a: 1 }), context);
+
+    expect(first.status).toBe('success');
+    expect(second.status).toBe('error');
+    expect(second.error?.code).toBe('redundant_call_blocked');
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes listAvailable through unchanged', async () => {
+    const tools = [
+      { name: 'workspace_search', description: 'Search the workspace.' },
+      { name: 'memory_recall', description: 'Recall memory.' },
+    ];
+    const inner = makeInnerRegistry({ tools });
+    const guard = createIdempotencyGuard(inner);
+    const input = makeAvailabilityInput({ allowedToolNames: ['workspace_search'] });
+
+    const result = await guard.listAvailable(input);
+
+    expect(result).toEqual(tools);
+    expect(inner.listAvailable).toHaveBeenCalledTimes(1);
+    expect(inner.listAvailable).toHaveBeenCalledWith(input);
+  });
+
+  it('includes alternativesFor output in the blocked error message', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const inner = makeInnerRegistry();
+    const alternativesFor = vi.fn(() => ['try X', 'try Y']);
+    const guard = createIdempotencyGuard(inner, { alternativesFor });
+
+    await guard.execute(call, context);
+    const result = await guard.execute(call, context);
+
+    expect(alternativesFor).toHaveBeenCalledTimes(1);
+    expect(alternativesFor).toHaveBeenCalledWith(call);
+    expect(result.error?.message).toContain('try X');
+    expect(result.error?.message).toContain('try Y');
+  });
+
+  it('uses the default fallback line when alternativesFor is missing or empty', async () => {
+    const defaultTip =
+      'Drill into a specific result from the previous output (cite a path or id) instead of re-searching.';
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+
+    const guardWithoutHook = createIdempotencyGuard(makeInnerRegistry());
+    await guardWithoutHook.execute(call, context);
+    const withoutHook = await guardWithoutHook.execute(call, context);
+
+    const emptyHook = createIdempotencyGuard(makeInnerRegistry(), {
+      alternativesFor: () => ['   ', ''],
+    });
+    await emptyHook.execute(call, context);
+    const emptyAlternatives = await emptyHook.execute(call, context);
+
+    expect(withoutHook.error?.message).toContain(defaultTip);
+    expect(emptyAlternatives.error?.message).toContain(defaultTip);
+  });
+
+  it('evicts the oldest turn when maxTurns is exceeded', async () => {
+    const call = makeCall('call-1');
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner, { maxTurns: 2 });
+
+    await guard.execute(call, makeContext('turn-1'));
+    await guard.execute(call, makeContext('turn-2'));
+    await guard.execute(call, makeContext('turn-3'));
+    const replayedTurnOne = await guard.execute(call, makeContext('turn-1'));
+
+    expect(replayedTurnOne.status).toBe('success');
+    expect(inner.execute).toHaveBeenCalledTimes(4);
+  });
+
+  it('propagates inner exceptions and does not cache a failed attempt', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const error = new Error('boom');
+    const retryResult = makeResult(call, { output: 'retry-ok' });
+    const execute = vi
+      .fn<HarnessToolRegistry['execute']>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(retryResult);
+    const inner = makeInnerRegistry({ executeImpl: execute });
+    const guard = createIdempotencyGuard(inner);
+
+    await expect(guard.execute(call, context)).rejects.toBe(error);
+    const retry = await guard.execute(call, context);
+
+    expect(retry).toEqual(retryResult);
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the original per-turn iteration number in duplicate errors', async () => {
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+    const context = makeContext('turn-1');
+    const firstCall = makeCall('call-1', { q: 'a' });
+    const secondCall = makeCall('call-2', { q: 'b' });
+
+    await guard.execute(firstCall, context);
+    await guard.execute(secondCall, context);
+
+    const duplicateFirst = await guard.execute(makeCall('call-3', { q: 'a' }), context);
+    const duplicateSecond = await guard.execute(makeCall('call-4', { q: 'b' }), context);
+
+    expect(duplicateFirst.error?.message).toContain('iteration 1');
+    expect(duplicateSecond.error?.message).toContain('iteration 2');
+  });
+});

--- a/packages/harness/src/idempotency-guard.ts
+++ b/packages/harness/src/idempotency-guard.ts
@@ -1,0 +1,181 @@
+import type {
+  HarnessToolCall,
+  HarnessToolExecutionContext,
+  HarnessToolRegistry,
+  HarnessToolResult,
+} from './types.js';
+
+export interface IdempotencyGuardOptions {
+  /**
+   * Hook the consumer uses to suggest "given this duplicate call, what
+   * should the model try instead?" Returned strings are bulleted into
+   * the error message. Default: returns a generic single-line tip.
+   */
+  alternativesFor?: (call: HarnessToolCall) => string[];
+
+  /** LRU cap on retained turns. Default 50. */
+  maxTurns?: number;
+}
+
+interface CachedCallRecord {
+  iteration: number;
+  outputChars: number;
+  firstCalledAt: number;
+}
+
+const DEFAULT_MAX_TURNS = 50;
+const DEFAULT_ALTERNATIVE =
+  'Drill into a specific result from the previous output (cite a path or id) instead of re-searching.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeForStableStringify(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForStableStringify(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.keys(value)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = normalizeForStableStringify(value[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeForStableStringify(value));
+}
+
+function getTurnId(context: HarnessToolExecutionContext): string | undefined {
+  if (typeof context.turnId === 'string' && context.turnId.length > 0) {
+    return context.turnId;
+  }
+
+  const metadata = (context as HarnessToolExecutionContext & {
+    metadata?: Record<string, unknown>;
+  }).metadata;
+  return typeof metadata?.turnId === 'string' && metadata.turnId.length > 0
+    ? metadata.turnId
+    : undefined;
+}
+
+function normalizeMaxTurns(value: number | undefined): number {
+  if (!Number.isFinite(value) || value === undefined || value < 1) {
+    return DEFAULT_MAX_TURNS;
+  }
+  return Math.floor(value);
+}
+
+function buildAlternatives(
+  call: HarnessToolCall,
+  options: IdempotencyGuardOptions | undefined,
+): string[] {
+  const alternatives = options?.alternativesFor?.(call)
+    ?.map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  return alternatives && alternatives.length > 0
+    ? alternatives
+    : [DEFAULT_ALTERNATIVE];
+}
+
+function duplicateResult(
+  call: HarnessToolCall,
+  previous: CachedCallRecord,
+  options: IdempotencyGuardOptions | undefined,
+): HarnessToolResult {
+  const message = [
+    `The ${call.name} tool was already called this turn at iteration ${previous.iteration} with the same input (${previous.outputChars} chars of output). Repeating the same call won't return new information. Try one of:`,
+    ...buildAlternatives(call, options).map((item) => `- ${item}`),
+  ].join('\n');
+
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'error',
+    output: '',
+    error: {
+      code: 'redundant_call_blocked',
+      message,
+      retryable: false,
+    },
+  };
+}
+
+function touchTurnCache(
+  turnCaches: Map<string, Map<string, CachedCallRecord>>,
+  turnId: string,
+): Map<string, CachedCallRecord> {
+  const existing = turnCaches.get(turnId);
+  if (existing) {
+    turnCaches.delete(turnId);
+    turnCaches.set(turnId, existing);
+    return existing;
+  }
+
+  const created = new Map<string, CachedCallRecord>();
+  turnCaches.set(turnId, created);
+  return created;
+}
+
+function evictOldestTurnIfNeeded(
+  turnCaches: Map<string, Map<string, CachedCallRecord>>,
+  nextIterations: Map<string, number>,
+  maxTurns: number,
+): void {
+  while (turnCaches.size > maxTurns) {
+    const oldestTurnId = turnCaches.keys().next().value;
+    if (oldestTurnId === undefined) {
+      return;
+    }
+    turnCaches.delete(oldestTurnId);
+    nextIterations.delete(oldestTurnId);
+  }
+}
+
+export function createIdempotencyGuard(
+  inner: HarnessToolRegistry,
+  options?: IdempotencyGuardOptions,
+): HarnessToolRegistry {
+  const maxTurns = normalizeMaxTurns(options?.maxTurns);
+  const turnCaches = new Map<string, Map<string, CachedCallRecord>>();
+  const nextIterations = new Map<string, number>();
+
+  return {
+    listAvailable(input) {
+      return inner.listAvailable(input);
+    },
+
+    async execute(call, context) {
+      const turnId = getTurnId(context);
+      if (!turnId) {
+        return inner.execute(call, context);
+      }
+
+      const signature = `${call.name}::${stableStringify(call.input ?? {})}`;
+      const turnCache = touchTurnCache(turnCaches, turnId);
+      evictOldestTurnIfNeeded(turnCaches, nextIterations, maxTurns);
+
+      const previous = turnCache.get(signature);
+      if (previous) {
+        return duplicateResult(call, previous, options);
+      }
+
+      const result = await inner.execute(call, context);
+      const iteration = nextIterations.get(turnId) ?? 1;
+      turnCache.set(signature, {
+        iteration,
+        outputChars: result.output?.length ?? 0,
+        firstCalledAt: Date.now(),
+      });
+      nextIterations.set(turnId, iteration + 1);
+      return result;
+    },
+  };
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -9,11 +9,25 @@ export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/
 export type { OpenRouterModelAdapterConfig } from './adapter/openrouter-model-adapter.js';
 export { BashToolRegistry, createBashToolRegistry } from './tools/bash-tool-registry.js';
 export type { BashToolConfig } from './tools/bash-tool-registry.js';
+export { GitHubPublicFetcher, GitHubPublicFetchError } from './tools/github-public-fetcher.js';
+export type {
+  GitHubPublicFetcherOptions,
+  GitHubPublicReview,
+} from './tools/github-public-fetcher.js';
+export {
+  createGitHubPublicReviewToolRegistry,
+  GITHUB_PUBLIC_REVIEW_TOOL_NAME,
+} from './tools/github-public-review-tool-registry.js';
+export type { GitHubPublicReviewToolRegistryOptions } from './tools/github-public-review-tool-registry.js';
 export {
   CITE_SOURCE_PATHS_CLAUSE,
   EMPTY_RESULT_HONESTY_CLAUSE,
+  DRILL_IN_DISCIPLINE_CLAUSE,
+  EXTERNAL_REPO_STEER_CLAUSE,
   HALLUCINATION_PREVENTION_CLAUSES,
   SURFACE_TOOL_ERRORS_CLAUSE,
+  TOOL_DISCIPLINE_CLAUSES,
+  TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
 } from './tools/prompt-fragments.js';
 export {
   createWorkspaceToolRegistry,
@@ -39,6 +53,7 @@ export {
 export type {
   ToolEvidenceClarificationOptions,
 } from './tool-evidence-clarification.js';
+export { createIdempotencyGuard, type IdempotencyGuardOptions } from './idempotency-guard.js';
 
 export { OpenRouterSingleShotAdapter, createOpenRouterSingleShotAdapter } from './router/openrouter-singleshot-adapter.js';
 export type { OpenRouterSingleShotAdapterConfig } from './router/openrouter-singleshot-adapter.js';
@@ -78,6 +93,7 @@ export type {
   HarnessFinalAnswerOutput,
   HarnessHooks,
   HarnessInstructions,
+  HarnessInvalidOutputCode,
   HarnessInvalidOutput,
   HarnessLimits,
   HarnessModelAdapter,

--- a/packages/harness/src/tool-evidence-clarification.test.ts
+++ b/packages/harness/src/tool-evidence-clarification.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectToolEvidenceClarification } from './tool-evidence-clarification.js';
+import type { HarnessToolResult } from './types.js';
+
+function makeToolResult(overrides: Partial<HarnessToolResult>): HarnessToolResult {
+  return {
+    callId: 'call-1',
+    toolName: 'memory_recall',
+    status: 'success',
+    ...overrides,
+  };
+}
+
+describe('detectToolEvidenceClarification', () => {
+  it('returns null for an empty-result signal on an excluded tool, but still classifies without exclusions', () => {
+    const result = makeToolResult({
+      structuredOutput: { results: [] },
+    });
+
+    expect(
+      detectToolEvidenceClarification(result, { excludeToolNames: ['memory_recall'] }),
+    ).toBeNull();
+
+    const clarification = detectToolEvidenceClarification(result);
+    expect(clarification).not.toBeNull();
+    expect(clarification?.reason).toBe('empty_results');
+  });
+
+  it('returns null for a transient error on an excluded tool, but still classifies without exclusions', () => {
+    const result = makeToolResult({
+      status: 'error',
+      error: {
+        code: 'rate_limited',
+        message: 'Provider rate limited the request.',
+      },
+    });
+
+    expect(
+      detectToolEvidenceClarification(result, { excludeToolNames: ['memory_recall'] }),
+    ).toBeNull();
+
+    const clarification = detectToolEvidenceClarification(result);
+    expect(clarification).not.toBeNull();
+    expect(clarification?.reason).toBe('transient_provider_error');
+  });
+
+  it('returns null for ambiguous evidence on an excluded tool', () => {
+    const result = makeToolResult({
+      structuredOutput: { ambiguous: true },
+    });
+
+    expect(
+      detectToolEvidenceClarification(result, { excludeToolNames: ['memory_recall'] }),
+    ).toBeNull();
+
+    const clarification = detectToolEvidenceClarification(result);
+    expect(clarification).not.toBeNull();
+    expect(clarification?.reason).toBe('ambiguous_identifier');
+  });
+
+  it('still returns explicit clarification hints even when the tool is excluded', () => {
+    const result = makeToolResult({
+      metadata: {
+        clarification: {
+          question: 'Which scope?',
+        },
+      },
+      structuredOutput: { results: [] },
+    });
+
+    const clarification = detectToolEvidenceClarification(result, {
+      excludeToolNames: ['memory_recall'],
+    });
+
+    expect(clarification).toEqual({
+      question: 'Which scope?',
+      reason: 'custom',
+      metadata: { toolName: 'memory_recall' },
+    });
+  });
+
+  it('supports multiple excluded tool names', () => {
+    const excluded = ['memory_recall', 'workspace_search'] as const;
+
+    const memoryResult = makeToolResult({
+      structuredOutput: { results: [] },
+    });
+    const workspaceResult = makeToolResult({
+      toolName: 'workspace_search',
+      structuredOutput: { ambiguous: true },
+    });
+
+    expect(detectToolEvidenceClarification(memoryResult, { excludeToolNames: excluded })).toBeNull();
+    expect(
+      detectToolEvidenceClarification(workspaceResult, { excludeToolNames: excluded }),
+    ).toBeNull();
+  });
+
+  it('treats empty or undefined excludeToolNames as no behavior change', () => {
+    const result = makeToolResult({
+      structuredOutput: { results: [] },
+    });
+
+    const baseline = detectToolEvidenceClarification(result, {});
+    const undefinedOption = detectToolEvidenceClarification(result, {
+      excludeToolNames: undefined,
+    });
+    const emptyOption = detectToolEvidenceClarification(result, {
+      excludeToolNames: [],
+    });
+
+    expect(baseline?.reason).toBe('empty_results');
+    expect(undefinedOption).toEqual(baseline);
+    expect(emptyOption).toEqual(baseline);
+  });
+});

--- a/packages/harness/src/tool-evidence-clarification.ts
+++ b/packages/harness/src/tool-evidence-clarification.ts
@@ -8,6 +8,18 @@ import type {
 export interface ToolEvidenceClarificationOptions {
   emptyResultKeys?: readonly string[];
   questionForReason?: Partial<Record<HarnessToolEvidenceClarificationReason, string>>;
+  /**
+   * Tool names that should NEVER trigger an evidence-based clarification.
+   * Useful for read-only / "expected to sometimes be empty" tools like
+   * memory_recall where empty results are normal, not a signal that the
+   * model needs to ask the user a clarifying question.
+   *
+   * Note: explicit clarification hints on the tool result itself
+   * (result.metadata.clarification or structuredOutput.clarification)
+   * are still respected — the exclusion only suppresses the implicit
+   * classifier path.
+   */
+  excludeToolNames?: readonly string[];
 }
 
 const DEFAULT_EMPTY_RESULT_KEYS = [
@@ -44,6 +56,11 @@ export function detectToolEvidenceClarification(
   const explicit = readExplicitClarification(result);
   if (explicit) {
     return explicit;
+  }
+
+  const excludedToolNames = options.excludeToolNames ? new Set(options.excludeToolNames) : null;
+  if (excludedToolNames?.has(result.toolName)) {
+    return null;
   }
 
   const reason = classifyToolEvidence(result, options);

--- a/packages/harness/src/tools/github-public-fetcher.test.ts
+++ b/packages/harness/src/tools/github-public-fetcher.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  GitHubPublicFetcher,
+  GitHubPublicFetchError,
+} from './github-public-fetcher.js';
+
+const BASE_URL = 'https://api.github.com/repos/acme/widgets';
+
+function headersObject(headers?: HeadersInit): Record<string, string> {
+  return Object.fromEntries(new Headers(headers).entries());
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: {
+      'content-type': 'application/json',
+      ...headersObject(init.headers),
+    },
+  });
+}
+
+function textResponse(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, {
+    status: init.status ?? 200,
+    headers: headersObject(init.headers),
+  });
+}
+
+function packageJsonContent(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function makeHappyPathResponses(
+  overrides: Partial<Record<string, Response>> = {},
+): Record<string, Response> {
+  return {
+    [BASE_URL]: jsonResponse({
+      description: 'Public widgets',
+      stargazers_count: 42,
+      open_issues_count: 7,
+      default_branch: 'main',
+      html_url: 'https://github.com/acme/widgets',
+      license: { spdx_id: 'MIT' },
+    }),
+    [`${BASE_URL}/readme`]: textResponse('# Widgets\nA public widgets repo.'),
+    [`${BASE_URL}/contents/package.json`]: jsonResponse({
+      content: packageJsonContent(
+        JSON.stringify({
+          name: '@acme/widgets',
+          version: '1.2.3',
+          scripts: {
+            test: 'vitest run',
+          },
+        }),
+      ),
+    }),
+    [`${BASE_URL}/contents/`]: jsonResponse([
+      { path: 'package.json', type: 'file' },
+      { path: 'src', type: 'dir' },
+    ]),
+    [`${BASE_URL}/commits?per_page=5`]: jsonResponse([
+      {
+        sha: 'abcdef1234567890',
+        commit: {
+          message: 'Initial release',
+          author: { date: '2026-04-28T00:00:00Z' },
+        },
+      },
+      {
+        sha: 'fedcba0987654321',
+        commit: {
+          message: 'Fix widget issue',
+          author: { date: '2026-04-27T00:00:00Z' },
+        },
+      },
+    ]),
+    ...overrides,
+  };
+}
+
+function makeFetchMock(
+  responses: Record<string, Response>,
+): typeof globalThis.fetch & ReturnType<typeof vi.fn> {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const response = responses[url];
+    if (!response) {
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    }
+    return response;
+  }) as typeof globalThis.fetch & ReturnType<typeof vi.fn>;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('GitHubPublicFetcher', () => {
+  it('populates all review fields on the happy path', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock(makeHappyPathResponses()),
+    });
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(review).toEqual({
+      owner: 'acme',
+      repo: 'widgets',
+      description: 'Public widgets',
+      license: 'MIT',
+      stargazersCount: 42,
+      openIssuesCount: 7,
+      defaultBranch: 'main',
+      htmlUrl: 'https://github.com/acme/widgets',
+      readme: '# Widgets\nA public widgets repo.',
+      packageJson: {
+        name: '@acme/widgets',
+        version: '1.2.3',
+        scripts: {
+          test: 'vitest run',
+        },
+      },
+      topLevel: [
+        { path: 'package.json', type: 'file' },
+        { path: 'src', type: 'dir' },
+      ],
+      recentCommits: [
+        {
+          sha: 'abcdef1234567890',
+          message: 'Initial release',
+          authorDate: '2026-04-28T00:00:00Z',
+        },
+        {
+          sha: 'fedcba0987654321',
+          message: 'Fix widget issue',
+          authorDate: '2026-04-27T00:00:00Z',
+        },
+      ],
+    });
+  });
+
+  it('throws not_found when the repo metadata endpoint returns 404', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock({
+        [BASE_URL]: textResponse('not found', { status: 404 }),
+      }),
+    });
+
+    await expect(fetcher.fetchReview('acme', 'widgets')).rejects.toMatchObject({
+      name: 'GitHubPublicFetchError',
+      code: 'not_found',
+      status: 404,
+    } satisfies Partial<GitHubPublicFetchError>);
+  });
+
+  it('throws rate_limited when the repo metadata endpoint returns a GitHub rate limit response', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock({
+        [BASE_URL]: textResponse('rate limit', {
+          status: 403,
+          headers: { 'x-ratelimit-remaining': '0' },
+        }),
+      }),
+    });
+
+    await expect(fetcher.fetchReview('acme', 'widgets')).rejects.toMatchObject({
+      name: 'GitHubPublicFetchError',
+      code: 'rate_limited',
+      status: 403,
+    } satisfies Partial<GitHubPublicFetchError>);
+  });
+
+  it('rejects invalid owner input before calling fetch', async () => {
+    const fetchMock = makeFetchMock(makeHappyPathResponses());
+    const fetcher = new GitHubPublicFetcher({ fetchImpl: fetchMock });
+
+    await expect(fetcher.fetchReview('foo/bar', 'widgets')).rejects.toMatchObject({
+      name: 'GitHubPublicFetchError',
+      code: 'invalid_request',
+    } satisfies Partial<GitHubPublicFetchError>);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('omits readme when the README endpoint returns 404', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock(
+        makeHappyPathResponses({
+          [`${BASE_URL}/readme`]: textResponse('not found', { status: 404 }),
+        }),
+      ),
+    });
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(review.readme).toBeUndefined();
+    expect(review.packageJson).toBeDefined();
+  });
+
+  it('omits packageJson when package.json content is malformed', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock(
+        makeHappyPathResponses({
+          [`${BASE_URL}/contents/package.json`]: jsonResponse({
+            content: packageJsonContent('{invalid json'),
+          }),
+        }),
+      ),
+    });
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(review.packageJson).toBeUndefined();
+    expect(review.topLevel).toEqual([
+      { path: 'package.json', type: 'file' },
+      { path: 'src', type: 'dir' },
+    ]);
+  });
+
+  it('omits topLevel when the contents endpoint returns a single file payload', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock(
+        makeHappyPathResponses({
+          [`${BASE_URL}/contents/`]: jsonResponse({
+            path: 'package.json',
+            type: 'file',
+          }),
+        }),
+      ),
+    });
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(review.topLevel).toBeUndefined();
+    expect(review.recentCommits).toBeDefined();
+  });
+
+  it('truncates README content when it exceeds readmeMaxChars', async () => {
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: makeFetchMock(
+        makeHappyPathResponses({
+          [`${BASE_URL}/readme`]: textResponse('0123456789abcdef'),
+        }),
+      ),
+      readmeMaxChars: 8,
+    });
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(review.readme).toBe('01234567\n[truncated]');
+    expect(review.readme?.endsWith('[truncated]')).toBe(true);
+  });
+
+  it('respects the commitsCount option when requesting recent commits', async () => {
+    const fetchMock = makeFetchMock({
+      ...makeHappyPathResponses(),
+      [`${BASE_URL}/commits?per_page=2`]: jsonResponse([
+        {
+          sha: '1111111111111111',
+          commit: {
+            message: 'Commit one',
+            author: { date: '2026-04-26T00:00:00Z' },
+          },
+        },
+        {
+          sha: '2222222222222222',
+          commit: {
+            message: 'Commit two',
+            author: { date: '2026-04-25T00:00:00Z' },
+          },
+        },
+      ]),
+    });
+    const fetcher = new GitHubPublicFetcher({
+      fetchImpl: fetchMock,
+      commitsCount: 2,
+    });
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/commits?per_page=2`,
+      expect.any(Object),
+    );
+    expect(review.recentCommits).toEqual([
+      {
+        sha: '1111111111111111',
+        message: 'Commit one',
+        authorDate: '2026-04-26T00:00:00Z',
+      },
+      {
+        sha: '2222222222222222',
+        message: 'Commit two',
+        authorDate: '2026-04-25T00:00:00Z',
+      },
+    ]);
+  });
+
+  it('uses globalThis.fetch by default when no fetchImpl is provided', async () => {
+    const fetchMock = makeFetchMock(makeHappyPathResponses());
+    vi.stubGlobal('fetch', fetchMock);
+    const fetcher = new GitHubPublicFetcher();
+
+    const review = await fetcher.fetchReview('acme', 'widgets');
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(review.owner).toBe('acme');
+    expect(review.repo).toBe('widgets');
+  });
+});

--- a/packages/harness/src/tools/github-public-fetcher.ts
+++ b/packages/harness/src/tools/github-public-fetcher.ts
@@ -1,0 +1,401 @@
+export interface GitHubPublicReview {
+  owner: string;
+  repo: string;
+  description?: string;
+  license?: string;
+  stargazersCount?: number;
+  openIssuesCount?: number;
+  defaultBranch?: string;
+  htmlUrl?: string;
+  readme?: string;
+  packageJson?: unknown;
+  topLevel?: Array<{ path: string; type: 'file' | 'dir' }>;
+  recentCommits?: Array<{ sha: string; message: string; authorDate: string }>;
+}
+
+export type GitHubPublicFetchErrorCode =
+  | 'not_found'
+  | 'rate_limited'
+  | 'invalid_request'
+  | 'transport'
+  | 'unknown';
+
+export class GitHubPublicFetchError extends Error {
+  readonly status?: number;
+  readonly code: GitHubPublicFetchErrorCode;
+  readonly bodyExcerpt?: string;
+
+  constructor(
+    message: string,
+    options: {
+      code: GitHubPublicFetchErrorCode;
+      status?: number;
+      bodyExcerpt?: string;
+    },
+  ) {
+    super(message);
+    this.name = 'GitHubPublicFetchError';
+    this.code = options.code;
+    this.status = options.status;
+    this.bodyExcerpt = options.bodyExcerpt;
+  }
+}
+
+export interface GitHubPublicFetcherOptions {
+  fetchImpl?: typeof globalThis.fetch;
+  userAgent?: string;
+  readmeMaxChars?: number;
+  commitsCount?: number;
+}
+
+const DEFAULT_USER_AGENT = 'agent-assistant-harness';
+const DEFAULT_README_MAX_CHARS = 16_384;
+const DEFAULT_COMMITS_COUNT = 5;
+const MAX_COMMITS_COUNT = 20;
+const README_TRUNCATION_MARKER = '\n[truncated]';
+const GITHUB_JSON_ACCEPT = 'application/vnd.github+json';
+const GITHUB_RAW_ACCEPT = 'application/vnd.github.raw';
+const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9_.-]+$/;
+const NON_OK_BODY_EXCERPT_CHARS = 500;
+
+interface GitHubRepoResponse {
+  description?: unknown;
+  stargazers_count?: unknown;
+  open_issues_count?: unknown;
+  default_branch?: unknown;
+  html_url?: unknown;
+  license?: {
+    spdx_id?: unknown;
+  } | null;
+}
+
+interface GitHubContentResponse {
+  content?: unknown;
+}
+
+interface GitHubTopLevelEntryResponse {
+  path?: unknown;
+  type?: unknown;
+}
+
+interface GitHubCommitResponse {
+  sha?: unknown;
+  commit?: {
+    message?: unknown;
+    author?: {
+      date?: unknown;
+    } | null;
+  } | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function truncateReadme(readme: string, maxChars: number): string {
+  if (readme.length <= maxChars) {
+    return readme;
+  }
+  return `${readme.slice(0, maxChars)}${README_TRUNCATION_MARKER}`;
+}
+
+function toTransportMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+export class GitHubPublicFetcher {
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly userAgent: string;
+  private readonly readmeMaxChars: number;
+  private readonly commitsCount: number;
+
+  constructor(options: GitHubPublicFetcherOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => globalThis.fetch(input, init));
+    this.userAgent =
+      typeof options.userAgent === 'string' && options.userAgent.trim().length > 0
+        ? options.userAgent
+        : DEFAULT_USER_AGENT;
+    this.readmeMaxChars = normalizePositiveInteger(
+      options.readmeMaxChars,
+      DEFAULT_README_MAX_CHARS,
+    );
+    this.commitsCount = Math.min(
+      MAX_COMMITS_COUNT,
+      normalizePositiveInteger(options.commitsCount, DEFAULT_COMMITS_COUNT),
+    );
+  }
+
+  async fetchReview(owner: string, repo: string): Promise<GitHubPublicReview> {
+    this.validateRepoSegment(owner, 'owner');
+    this.validateRepoSegment(repo, 'repo');
+
+    const baseUrl = `https://api.github.com/repos/${owner}/${repo}`;
+    const repoMetadata = await this.fetchRequiredJson<GitHubRepoResponse>(baseUrl);
+
+    const review: GitHubPublicReview = {
+      owner,
+      repo,
+      ...(optionalString(repoMetadata.description)
+        ? { description: optionalString(repoMetadata.description) }
+        : {}),
+      ...(optionalNumber(repoMetadata.stargazers_count) !== undefined
+        ? { stargazersCount: optionalNumber(repoMetadata.stargazers_count) }
+        : {}),
+      ...(optionalNumber(repoMetadata.open_issues_count) !== undefined
+        ? { openIssuesCount: optionalNumber(repoMetadata.open_issues_count) }
+        : {}),
+      ...(optionalString(repoMetadata.default_branch)
+        ? { defaultBranch: optionalString(repoMetadata.default_branch) }
+        : {}),
+      ...(optionalString(repoMetadata.html_url)
+        ? { htmlUrl: optionalString(repoMetadata.html_url) }
+        : {}),
+      ...(optionalString(repoMetadata.license?.spdx_id)
+        ? { license: optionalString(repoMetadata.license?.spdx_id) }
+        : {}),
+    };
+
+    const readme = await this.fetchOptionalReadme(`${baseUrl}/readme`);
+    if (readme !== undefined) {
+      review.readme = readme;
+    }
+
+    const packageJson = await this.fetchOptionalPackageJson(`${baseUrl}/contents/package.json`);
+    if (packageJson !== undefined) {
+      review.packageJson = packageJson;
+    }
+
+    const topLevel = await this.fetchOptionalTopLevel(`${baseUrl}/contents/`);
+    if (topLevel !== undefined) {
+      review.topLevel = topLevel;
+    }
+
+    const recentCommits = await this.fetchOptionalRecentCommits(
+      `${baseUrl}/commits?per_page=${this.commitsCount}`,
+    );
+    if (recentCommits !== undefined) {
+      review.recentCommits = recentCommits;
+    }
+
+    return review;
+  }
+
+  private validateRepoSegment(value: string, label: 'owner' | 'repo'): void {
+    if (!REPO_SEGMENT_PATTERN.test(value)) {
+      throw new GitHubPublicFetchError(
+        `Invalid GitHub ${label}: must match ${REPO_SEGMENT_PATTERN}`,
+        {
+          code: 'invalid_request',
+        },
+      );
+    }
+  }
+
+  private async fetchRequiredJson<T>(url: string): Promise<T> {
+    const response = await this.fetchResponse(url, GITHUB_JSON_ACCEPT);
+    if (!response.ok) {
+      throw await this.createFetchError(response, url);
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      throw new GitHubPublicFetchError(
+        `GitHub returned invalid JSON for ${url}: ${toTransportMessage(error)}`,
+        {
+          code: 'unknown',
+          status: response.status,
+        },
+      );
+    }
+  }
+
+  private async fetchOptionalReadme(url: string): Promise<string | undefined> {
+    const readme = await this.fetchOptionalText(url, GITHUB_RAW_ACCEPT);
+    return readme === undefined ? undefined : truncateReadme(readme, this.readmeMaxChars);
+  }
+
+  private async fetchOptionalPackageJson(url: string): Promise<unknown> {
+    const payload = await this.fetchOptionalJson<GitHubContentResponse>(url);
+    if (!payload || typeof payload.content !== 'string') {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse(Buffer.from(payload.content, 'base64').toString('utf8')) as unknown;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async fetchOptionalTopLevel(
+    url: string,
+  ): Promise<Array<{ path: string; type: 'file' | 'dir' }> | undefined> {
+    const payload = await this.fetchOptionalJson<unknown>(url);
+    if (!Array.isArray(payload)) {
+      return undefined;
+    }
+
+    return payload.flatMap((entry) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const path = optionalString((entry as GitHubTopLevelEntryResponse).path);
+      const type = (entry as GitHubTopLevelEntryResponse).type;
+      if (!path || (type !== 'file' && type !== 'dir')) {
+        return [];
+      }
+
+      return [{ path, type }];
+    });
+  }
+
+  private async fetchOptionalRecentCommits(
+    url: string,
+  ): Promise<Array<{ sha: string; message: string; authorDate: string }> | undefined> {
+    const payload = await this.fetchOptionalJson<unknown>(url);
+    if (!Array.isArray(payload)) {
+      return undefined;
+    }
+
+    return payload.flatMap((entry) => {
+      if (!isRecord(entry)) {
+        return [];
+      }
+
+      const commitEntry = entry as GitHubCommitResponse;
+      const sha = optionalString(commitEntry.sha);
+      const message = optionalString(commitEntry.commit?.message);
+      const authorDate = optionalString(commitEntry.commit?.author?.date);
+      if (!sha || !message || !authorDate) {
+        return [];
+      }
+
+      return [{ sha, message, authorDate }];
+    });
+  }
+
+  private async fetchOptionalJson<T>(url: string): Promise<T | undefined> {
+    const response = await this.fetchOptionalResponse(url, GITHUB_JSON_ACCEPT);
+    if (!response) {
+      return undefined;
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async fetchOptionalText(url: string, accept: string): Promise<string | undefined> {
+    const response = await this.fetchOptionalResponse(url, accept);
+    if (!response) {
+      return undefined;
+    }
+
+    try {
+      return await response.text();
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async fetchOptionalResponse(
+    url: string,
+    accept: string,
+  ): Promise<Response | undefined> {
+    try {
+      const response = await this.fetchResponse(url, accept);
+      if (!response.ok) {
+        await this.consumeErrorBody(response);
+        return undefined;
+      }
+      return response;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async fetchResponse(url: string, accept: string): Promise<Response> {
+    try {
+      return await this.fetchImpl(url, {
+        headers: {
+          Accept: accept,
+          'User-Agent': this.userAgent,
+        },
+      });
+    } catch (error) {
+      throw new GitHubPublicFetchError(
+        `Failed to fetch ${url}: ${toTransportMessage(error)}`,
+        {
+          code: 'transport',
+        },
+      );
+    }
+  }
+
+  private async createFetchError(
+    response: Response,
+    url: string,
+  ): Promise<GitHubPublicFetchError> {
+    const body = await this.consumeErrorBody(response);
+    const code = this.errorCodeForResponse(response);
+    const message =
+      code === 'not_found'
+        ? `GitHub repository not found: ${url}`
+        : code === 'rate_limited'
+          ? `GitHub API rate limit exceeded for ${url}`
+          : `GitHub request failed for ${url} with status ${response.status}`;
+
+    return new GitHubPublicFetchError(message, {
+      code,
+      status: response.status,
+      ...(body.length > 0
+        ? { bodyExcerpt: body.slice(0, NON_OK_BODY_EXCERPT_CHARS) }
+        : {}),
+    });
+  }
+
+  private errorCodeForResponse(response: Response): GitHubPublicFetchErrorCode {
+    if (response.status === 404) {
+      return 'not_found';
+    }
+    if (
+      response.status === 403 &&
+      response.headers.get('x-ratelimit-remaining') === '0'
+    ) {
+      return 'rate_limited';
+    }
+    return 'unknown';
+  }
+
+  private async consumeErrorBody(response: Response): Promise<string> {
+    try {
+      return await response.text();
+    } catch {
+      try {
+        await response.body?.cancel();
+      } catch {
+        // Ignore cancellation failures after a body read failure.
+      }
+      return '';
+    }
+  }
+}

--- a/packages/harness/src/tools/github-public-review-tool-registry.test.ts
+++ b/packages/harness/src/tools/github-public-review-tool-registry.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  HarnessToolAvailabilityInput,
+  HarnessToolCall,
+  HarnessToolExecutionContext,
+} from '../types.js';
+import {
+  createGitHubPublicReviewToolRegistry,
+  GITHUB_PUBLIC_REVIEW_TOOL_NAME,
+} from './github-public-review-tool-registry.js';
+import {
+  GitHubPublicFetchError,
+  type GitHubPublicReview,
+} from './github-public-fetcher.js';
+
+const AVAILABILITY_INPUT: HarnessToolAvailabilityInput = {
+  assistantId: 'assistant-1',
+  turnId: 'turn-1',
+};
+
+const EXECUTION_CONTEXT: HarnessToolExecutionContext = {
+  assistantId: 'assistant-1',
+  turnId: 'turn-1',
+  iteration: 0,
+  toolCallIndex: 0,
+};
+
+function makeCall(input: Record<string, unknown>): HarnessToolCall {
+  return {
+    id: 'call-1',
+    name: GITHUB_PUBLIC_REVIEW_TOOL_NAME,
+    input,
+  };
+}
+
+function makeFetcher(fetchReview: ReturnType<typeof vi.fn>) {
+  return {
+    fetchReview,
+  } as unknown as {
+    fetchReview: typeof fetchReview;
+  };
+}
+
+describe('createGitHubPublicReviewToolRegistry', () => {
+  it('listAvailable returns the github_public_review tool', async () => {
+    const registry = createGitHubPublicReviewToolRegistry();
+
+    const tools = await registry.listAvailable(AVAILABILITY_INPUT);
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe(GITHUB_PUBLIC_REVIEW_TOOL_NAME);
+  });
+
+  it('returns success with structured output and a rendered heading on the happy path', async () => {
+    const review: GitHubPublicReview = {
+      owner: 'acme',
+      repo: 'widgets',
+      description: 'Public widgets',
+      license: 'MIT',
+      stargazersCount: 42,
+      defaultBranch: 'main',
+      readme: '# Widgets',
+      packageJson: { name: '@acme/widgets' },
+      topLevel: [{ path: 'src', type: 'dir' }],
+      recentCommits: [
+        {
+          sha: 'abcdef1234567890',
+          message: 'Initial release',
+          authorDate: '2026-04-28T00:00:00Z',
+        },
+      ],
+    };
+    const fetchReview = vi.fn().mockResolvedValue(review);
+    const registry = createGitHubPublicReviewToolRegistry({
+      fetcher: makeFetcher(fetchReview) as never,
+    });
+
+    const result = await registry.execute(
+      makeCall({ owner: 'acme', repo: 'widgets' }),
+      EXECUTION_CONTEXT,
+    );
+
+    expect(fetchReview).toHaveBeenCalledWith('acme', 'widgets');
+    expect(result.status).toBe('success');
+    expect(result.structuredOutput).toEqual(review as unknown as Record<string, unknown>);
+    expect(result.output).toContain('# acme/widgets');
+  });
+
+  it('maps not_found fetch errors to a non-retryable error result', async () => {
+    const registry = createGitHubPublicReviewToolRegistry({
+      fetcher: makeFetcher(
+        vi.fn().mockRejectedValue(
+          new GitHubPublicFetchError('missing repo', {
+            code: 'not_found',
+            status: 404,
+          }),
+        ),
+      ) as never,
+    });
+
+    const result = await registry.execute(
+      makeCall({ owner: 'acme', repo: 'widgets' }),
+      EXECUTION_CONTEXT,
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: {
+        code: 'not_found',
+        retryable: false,
+      },
+    });
+  });
+
+  it('maps rate_limited fetch errors to a retryable error result', async () => {
+    const registry = createGitHubPublicReviewToolRegistry({
+      fetcher: makeFetcher(
+        vi.fn().mockRejectedValue(
+          new GitHubPublicFetchError('rate limited', {
+            code: 'rate_limited',
+            status: 403,
+          }),
+        ),
+      ) as never,
+    });
+
+    const result = await registry.execute(
+      makeCall({ owner: 'acme', repo: 'widgets' }),
+      EXECUTION_CONTEXT,
+    );
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: {
+        code: 'rate_limited',
+        retryable: true,
+      },
+    });
+  });
+
+  it('returns invalid_request when owner is missing', async () => {
+    const fetchReview = vi.fn();
+    const registry = createGitHubPublicReviewToolRegistry({
+      fetcher: makeFetcher(fetchReview) as never,
+    });
+
+    const result = await registry.execute(makeCall({ repo: 'widgets' }), EXECUTION_CONTEXT);
+
+    expect(result).toMatchObject({
+      status: 'error',
+      error: {
+        code: 'invalid_request',
+        retryable: false,
+      },
+    });
+    expect(fetchReview).not.toHaveBeenCalled();
+  });
+
+  it('forwards the injected fetcher and trimmed owner/repo values', async () => {
+    const fetchReview = vi.fn().mockResolvedValue({
+      owner: 'acme',
+      repo: 'widgets',
+    } satisfies GitHubPublicReview);
+    const registry = createGitHubPublicReviewToolRegistry({
+      fetcher: makeFetcher(fetchReview) as never,
+    });
+
+    await registry.execute(
+      makeCall({ owner: '  acme  ', repo: '  widgets  ' }),
+      EXECUTION_CONTEXT,
+    );
+
+    expect(fetchReview).toHaveBeenCalledTimes(1);
+    expect(fetchReview).toHaveBeenCalledWith('acme', 'widgets');
+  });
+});

--- a/packages/harness/src/tools/github-public-review-tool-registry.ts
+++ b/packages/harness/src/tools/github-public-review-tool-registry.ts
@@ -1,0 +1,230 @@
+import type {
+  HarnessToolCall,
+  HarnessToolDefinition,
+  HarnessToolRegistry,
+  HarnessToolResult,
+} from '../types.js';
+import {
+  GitHubPublicFetcher,
+  GitHubPublicFetchError,
+  type GitHubPublicFetcherOptions,
+  type GitHubPublicReview,
+} from './github-public-fetcher.js';
+
+export interface GitHubPublicReviewToolRegistryOptions {
+  fetcher?: GitHubPublicFetcher;
+  fetcherOptions?: GitHubPublicFetcherOptions;
+}
+
+interface ValidationSuccess<T> {
+  ok: true;
+  value: T;
+}
+
+interface ValidationFailure {
+  ok: false;
+  message: string;
+}
+
+type ValidationResult<T> = ValidationSuccess<T> | ValidationFailure;
+
+type PackageJsonExcerpt = {
+  name?: string;
+  version?: string;
+  scripts?: string[];
+};
+
+export const GITHUB_PUBLIC_REVIEW_TOOL_NAME = 'github_public_review';
+
+const GITHUB_PUBLIC_REVIEW_TOOL: HarnessToolDefinition = {
+  name: GITHUB_PUBLIC_REVIEW_TOOL_NAME,
+  description:
+    'Fetch public GitHub repository metadata, README, package.json, top-level paths, and recent commits for review and summarization.',
+  inputSchema: {
+    type: 'object',
+    required: ['owner', 'repo'],
+    properties: {
+      owner: { type: 'string', minLength: 1 },
+      repo: { type: 'string', minLength: 1 },
+    },
+  },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateInput(
+  input: Record<string, unknown>,
+): ValidationResult<{ owner: string; repo: string }> {
+  const owner = input.owner;
+  const repo = input.repo;
+
+  if (typeof owner !== 'string' || owner.trim().length === 0) {
+    return { ok: false, message: 'input.owner must be a non-empty string' };
+  }
+
+  if (typeof repo !== 'string' || repo.trim().length === 0) {
+    return { ok: false, message: 'input.repo must be a non-empty string' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      owner: owner.trim(),
+      repo: repo.trim(),
+    },
+  };
+}
+
+function errorResult(
+  call: HarnessToolCall,
+  code: string,
+  message: string,
+  retryable: boolean,
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'error',
+    error: {
+      code,
+      message,
+      retryable,
+    },
+  };
+}
+
+function unknownToolResult(call: HarnessToolCall): HarnessToolResult {
+  return errorResult(call, 'unknown_tool', `Unknown tool: ${call.name}`, false);
+}
+
+function invalidRequestResult(call: HarnessToolCall, message: string): HarnessToolResult {
+  return errorResult(call, 'invalid_request', message, false);
+}
+
+function summarizeReadme(readme: string | undefined): string {
+  if (!readme) {
+    return '(none)';
+  }
+
+  const excerpt = readme.slice(0, 800).trim();
+  return excerpt.length > 0 ? excerpt : '(none)';
+}
+
+function summarizePackageJson(packageJson: unknown): string {
+  if (!isRecord(packageJson)) {
+    return '(none)';
+  }
+
+  const excerpt: PackageJsonExcerpt = {};
+  if (typeof packageJson.name === 'string' && packageJson.name.length > 0) {
+    excerpt.name = packageJson.name;
+  }
+  if (typeof packageJson.version === 'string' && packageJson.version.length > 0) {
+    excerpt.version = packageJson.version;
+  }
+  if (isRecord(packageJson.scripts)) {
+    excerpt.scripts = Object.keys(packageJson.scripts);
+  }
+
+  const parts = [
+    `name=${excerpt.name ?? '(unknown)'}`,
+    `version=${excerpt.version ?? '(unknown)'}`,
+    `scripts=${excerpt.scripts && excerpt.scripts.length > 0 ? excerpt.scripts.join(', ') : '(none)'}`,
+  ];
+  return parts.join(' | ');
+}
+
+function summarizeTopLevel(
+  topLevel: GitHubPublicReview['topLevel'],
+): string {
+  if (!topLevel || topLevel.length === 0) {
+    return '(none)';
+  }
+  return topLevel.map((entry) => entry.path).join(', ');
+}
+
+function summarizeCommits(
+  commits: GitHubPublicReview['recentCommits'],
+): string[] {
+  if (!commits || commits.length === 0) {
+    return ['(none)'];
+  }
+
+  return commits.map((commit) => {
+    const sha = commit.sha.slice(0, 7);
+    const date = commit.authorDate;
+    const message = commit.message.replace(/\s+/g, ' ').slice(0, 80);
+    return `${sha}  ${date}  ${message}`;
+  });
+}
+
+function renderOutput(review: GitHubPublicReview): string {
+  const lines = [
+    `# ${review.owner}/${review.repo}`,
+    `Description: ${review.description ?? '(none)'}`,
+    `Stars: ${review.stargazersCount ?? '(unknown)'}`,
+    `Default branch: ${review.defaultBranch ?? '(unknown)'}`,
+    `License: ${review.license ?? '(none)'}`,
+    '## README excerpt',
+    summarizeReadme(review.readme),
+    '## package.json excerpt',
+    summarizePackageJson(review.packageJson),
+    '## Top-level',
+    summarizeTopLevel(review.topLevel),
+    '## Recent commits',
+    ...summarizeCommits(review.recentCommits),
+  ];
+
+  return lines.join('\n');
+}
+
+function toStructuredOutput(review: GitHubPublicReview): Record<string, unknown> {
+  return review as unknown as Record<string, unknown>;
+}
+
+export function createGitHubPublicReviewToolRegistry(
+  options: GitHubPublicReviewToolRegistryOptions = {},
+): HarnessToolRegistry {
+  const fetcher = options.fetcher ?? new GitHubPublicFetcher(options.fetcherOptions);
+
+  return {
+    async listAvailable() {
+      return [GITHUB_PUBLIC_REVIEW_TOOL];
+    },
+
+    async execute(call) {
+      if (call.name !== GITHUB_PUBLIC_REVIEW_TOOL_NAME) {
+        return unknownToolResult(call);
+      }
+
+      const validation = validateInput(call.input);
+      if (!validation.ok) {
+        return invalidRequestResult(call, validation.message);
+      }
+
+      try {
+        const review = await fetcher.fetchReview(validation.value.owner, validation.value.repo);
+        return {
+          callId: call.id,
+          toolName: call.name,
+          status: 'success',
+          output: renderOutput(review),
+          structuredOutput: toStructuredOutput(review),
+        };
+      } catch (error) {
+        if (error instanceof GitHubPublicFetchError) {
+          return errorResult(
+            call,
+            error.code,
+            error.message,
+            error.code === 'rate_limited',
+          );
+        }
+
+        return errorResult(call, 'unknown', String(error), false);
+      }
+    },
+  };
+}

--- a/packages/harness/src/tools/prompt-fragments.test.ts
+++ b/packages/harness/src/tools/prompt-fragments.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
   CITE_SOURCE_PATHS_CLAUSE,
+  DRILL_IN_DISCIPLINE_CLAUSE,
   EMPTY_RESULT_HONESTY_CLAUSE,
+  EXTERNAL_REPO_STEER_CLAUSE,
   HALLUCINATION_PREVENTION_CLAUSES,
   SURFACE_TOOL_ERRORS_CLAUSE,
+  TOOL_DISCIPLINE_CLAUSES,
+  TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
 } from './prompt-fragments.js';
 
 describe('hallucination-prevention prompt fragments', () => {
@@ -31,5 +35,43 @@ describe('hallucination-prevention prompt fragments', () => {
   it('keeps the load-bearing tool error phrase', () => {
     expect(SURFACE_TOOL_ERRORS_CLAUSE.toLowerCase()).toContain('error');
     expect(SURFACE_TOOL_ERRORS_CLAUSE.toLowerCase()).toContain('tool');
+  });
+});
+
+describe('tool-discipline prompt fragments', () => {
+  it('exports the new clauses as non-empty strings with the expected key terms', () => {
+    expect(DRILL_IN_DISCIPLINE_CLAUSE.length).toBeGreaterThanOrEqual(80);
+    expect(DRILL_IN_DISCIPLINE_CLAUSE.toLowerCase()).toContain('drill');
+    expect(
+      DRILL_IN_DISCIPLINE_CLAUSE.toLowerCase().includes('enumeration') ||
+        DRILL_IN_DISCIPLINE_CLAUSE.toLowerCase().includes('re-issue'),
+    ).toBe(true);
+
+    expect(TOOL_INPUT_SHAPE_REMINDER_CLAUSE.length).toBeGreaterThanOrEqual(80);
+    expect(TOOL_INPUT_SHAPE_REMINDER_CLAUSE.toLowerCase()).toContain('schema');
+    expect(TOOL_INPUT_SHAPE_REMINDER_CLAUSE.toLowerCase()).toContain('description');
+
+    expect(EXTERNAL_REPO_STEER_CLAUSE.length).toBeGreaterThanOrEqual(80);
+    expect(EXTERNAL_REPO_STEER_CLAUSE).toContain('github_public_review');
+    expect(EXTERNAL_REPO_STEER_CLAUSE.match(/github_public_review/g)).toHaveLength(1);
+    expect(EXTERNAL_REPO_STEER_CLAUSE.toLowerCase()).toContain('owner');
+    expect(EXTERNAL_REPO_STEER_CLAUSE.toLowerCase()).toContain('repo');
+  });
+
+  it('exports the tool-discipline clauses in append-ready order', () => {
+    expect(TOOL_DISCIPLINE_CLAUSES).toEqual([
+      DRILL_IN_DISCIPLINE_CLAUSE,
+      TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
+      EXTERNAL_REPO_STEER_CLAUSE,
+    ]);
+    expect(TOOL_DISCIPLINE_CLAUSES).toHaveLength(3);
+  });
+
+  it('keeps tool-discipline clauses separate from hallucination-prevention clauses', () => {
+    expect(HALLUCINATION_PREVENTION_CLAUSES).not.toContain(DRILL_IN_DISCIPLINE_CLAUSE);
+    expect(HALLUCINATION_PREVENTION_CLAUSES).not.toContain(
+      TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
+    );
+    expect(HALLUCINATION_PREVENTION_CLAUSES).not.toContain(EXTERNAL_REPO_STEER_CLAUSE);
   });
 });

--- a/packages/harness/src/tools/prompt-fragments.ts
+++ b/packages/harness/src/tools/prompt-fragments.ts
@@ -12,3 +12,18 @@ export const HALLUCINATION_PREVENTION_CLAUSES = [
   EMPTY_RESULT_HONESTY_CLAUSE,
   SURFACE_TOOL_ERRORS_CLAUSE,
 ] as const;
+
+export const DRILL_IN_DISCIPLINE_CLAUSE =
+  "After a tool returns a useful hit (a path, an id, an entity), drill into THAT specific result on your next turn — read the file, fetch the entity, expand the id. Do NOT re-issue the same enumeration query hoping for different results. If the first result didn't answer the question, refine the query (different keywords, narrower scope, different tool); don't repeat it verbatim.";
+
+export const TOOL_INPUT_SHAPE_REMINDER_CLAUSE =
+  "Tool input schemas describe the SHAPE of the value you must provide; a description like 'A repository slug in owner/repo form' is not itself a valid value. Pass the actual value (e.g. 'AgentWorkforce/sage'), not the description text. If you don't have a real value, ask the user instead of submitting placeholder strings.";
+
+export const EXTERNAL_REPO_STEER_CLAUSE =
+  "When the user asks about a repository OUTSIDE their workspace (a public repo on GitHub, a competitor's project, an open-source library) use the github_public_review tool with { owner, repo } — it works against unauthenticated api.github.com and returns README + package.json + top-level layout + recent commits. Do NOT try github_specialist or workspace_search for external public repos; those only see the connected workspace.";
+
+export const TOOL_DISCIPLINE_CLAUSES = [
+  DRILL_IN_DISCIPLINE_CLAUSE,
+  TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
+  EXTERNAL_REPO_STEER_CLAUSE,
+] as const;

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -144,6 +144,13 @@ export interface HarnessInvalidOutput {
    * string matching `reason`; `reason` remains the stable human-readable field.
    */
   kind?: HarnessInvalidOutputKind;
+  /**
+   * Provider-specific error subcode. Optional; populated by adapters
+   * (e.g. OpenRouter) so consumers can switch on a stable enum instead
+   * of substring-matching the free-text `reason` field. `kind` remains
+   * the high-level transient/provider_error split.
+   */
+  code?: HarnessInvalidOutputCode;
   reason: string;
   raw?: unknown;
   httpStatus?: number;
@@ -159,6 +166,16 @@ export type HarnessInvalidOutputKind =
   | 'missing_message'
   | 'model_refused'
   | 'provider_error';
+
+export type HarnessInvalidOutputCode =
+  | 'credits_exhausted'
+  | 'rate_limited'
+  | 'timeout'
+  | 'invalid_request'
+  | 'context_length_exceeded'
+  | 'model_not_found'
+  | 'auth_failed'
+  | 'unknown';
 
 export interface HarnessToolRegistry {
   listAvailable(input: HarnessToolAvailabilityInput): Promise<HarnessToolDefinition[]>;

--- a/workflows/improve-harness-primitives/00-execute.ts
+++ b/workflows/improve-harness-primitives/00-execute.ts
@@ -1,0 +1,135 @@
+/**
+ * Master workflow for improve-harness-primitives.
+ *
+ * Lifts five primitives discovered while fixing sage's recurring
+ * Slack-bot failure modes (sage PR #155). Each currently lives sage-side
+ * but is general enough that any harness consumer would re-invent it.
+ * Pulling them upstream lets sage drop its local copies in a follow-up
+ * adoption PR (and gives future consumers a head start).
+ *
+ * The five primitives:
+ *   01 — `excludeToolNames` option on `createToolEvidenceClarificationHook`
+ *        (so consumers can exempt specific tools — e.g. memory_recall —
+ *         from the empty-result clarification path without wrapping locally)
+ *   02 — `createIdempotencyGuard(inner, options?)` — registry wrapper that
+ *        blocks the 2nd identical tool call within a turn with a structured
+ *        error pointing at drill-in alternatives
+ *   03 — `GitHubPublicFetcher` + `createGitHubPublicReviewToolRegistry` —
+ *        unauthenticated public-repo readme/package.json/top-level/commits
+ *        fetcher exposed as a `github_public_review` tool
+ *   04 — Three new prompt fragments: `DRILL_IN_DISCIPLINE_CLAUSE`,
+ *        `TOOL_INPUT_SHAPE_REMINDER_CLAUSE`, `EXTERNAL_REPO_STEER_CLAUSE`
+ *   05 — Typed `OpenRouterError.code` enum
+ *        ('credits_exhausted' | 'rate_limited' | 'timeout' |
+ *         'invalid_request' | 'unknown') so consumers can switch on a
+ *        machine-readable code instead of string-matching .message
+ *
+ * Mirrors `workflows/improve-memory-primitives/00-execute.ts`: applies
+ * `applyAgentAssistantRepoSetup` ONCE for the whole run, then runs each
+ * sub-workflow as a deterministic shell step that inherits the master's
+ * worktree. Subs do NOT need their own setup helper because they execute
+ * in the same working directory the master prepared.
+ *
+ * Per memory [agent-relay run exit code]: each sub-shell-step greps log
+ * for "Workflow status: failed" AND checks pipeline exit via PIPESTATUS,
+ * because the runner can exit 0 even when the inner workflow fails.
+ */
+
+import { workflow } from '@agent-relay/sdk/workflows';
+import { mkdirSync } from 'node:fs';
+
+import { applyAgentAssistantRepoSetup } from '../lib/agent-assistant-repo-setup.ts';
+
+const BRANCH = 'feat/improve-harness-primitives';
+const LOG_DIR = 'logs/improve-harness-primitives-master';
+
+// Wrapped in bash -c '...' (SINGLE quotes) because cloud /bin/sh is dash,
+// which doesn't support ${PIPESTATUS[0]}. Single quotes prevent sh from
+// expanding $status / ${PIPESTATUS[0]} before bash sees them.
+const SUB = (file: string) => {
+  const logPath = `${LOG_DIR}/${file}.log`;
+  const script = [
+    `set -o pipefail`,
+    `agent-relay run workflows/improve-harness-primitives/${file} 2>&1 | tee ${logPath}`,
+    `status=\${PIPESTATUS[0]}`,
+    `if [ "$status" -ne 0 ]; then echo "SUB_WORKFLOW_EXIT_NONZERO: $status"; exit $status; fi`,
+    `if grep -q "Workflow status: failed" ${logPath}; then echo "SUB_WORKFLOW_REPORTED_FAILED"; exit 1; fi`,
+    `echo "SUB_WORKFLOW_OK: ${file}"`,
+  ].join('; ');
+  return `bash -c '${script}'`;
+};
+
+async function main() {
+  mkdirSync(LOG_DIR, { recursive: true });
+
+  const baseWf = workflow('aa-improve-harness-primitives-master')
+    .description(
+      'Master — setup-branch + install-deps via shared helper, then 01 → 02 → 03 → 04 → 05 → 06 sequentially. 06 commits + opens PR.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-improve-harness-primitives-master')
+    .maxConcurrency(2)
+    .timeout(7_200_000); // 2h
+
+  // ─── Phase 0: Setup branch + deps (shared helper) ───────
+  // Per workflows/AGENTS.md, this is where setup-branch and install-deps
+  // land. Subs run as deterministic shell steps below and inherit this
+  // working directory.
+  const wf = applyAgentAssistantRepoSetup(baseWf, {
+    branch: BRANCH,
+    committerName: 'Harness Primitives Bot',
+  });
+
+  const result = await wf
+    .step('sub-01-clarification-exclude-tools', {
+      type: 'deterministic',
+      dependsOn: ['install-deps'],
+      command: SUB('01-clarification-exclude-tools.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-02-idempotency-guard', {
+      type: 'deterministic',
+      dependsOn: ['sub-01-clarification-exclude-tools'],
+      command: SUB('02-idempotency-guard.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-03-github-public-review', {
+      type: 'deterministic',
+      dependsOn: ['sub-02-idempotency-guard'],
+      command: SUB('03-github-public-review.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-04-prompt-fragments', {
+      type: 'deterministic',
+      dependsOn: ['sub-03-github-public-review'],
+      command: SUB('04-prompt-fragments.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-05-openrouter-error-codes', {
+      type: 'deterministic',
+      dependsOn: ['sub-04-prompt-fragments'],
+      command: SUB('05-openrouter-error-codes.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('sub-06-publish-pr', {
+      type: 'deterministic',
+      dependsOn: ['sub-05-openrouter-error-codes'],
+      command: SUB('06-publish-pr.ts'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/01-clarification-exclude-tools.ts
+++ b/workflows/improve-harness-primitives/01-clarification-exclude-tools.ts
@@ -1,0 +1,252 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 1 — `excludeToolNames` option on `createToolEvidenceClarificationHook`.
+ *
+ * Why this lifts upstream:
+ *   sage's slack-runner currently wraps `createToolEvidenceClarificationHook`
+ *   in a local function that filters out memory_recall (and other
+ *   read-only "expected to sometimes return empty" tools) before deciding
+ *   whether to surface a clarification. That wrapping is a sign the
+ *   upstream API is missing a join point. This sub adds it.
+ *
+ * Contract:
+ *   - Add `excludeToolNames?: readonly string[]` to
+ *     `ToolEvidenceClarificationOptions`.
+ *   - In `detectToolEvidenceClarification`, after readExplicitClarification
+ *     returns null, check `result.toolName`: if it's in the
+ *     `excludeToolNames` set, return null early (skip the
+ *     classify+question pipeline entirely).
+ *   - Both implicit (classified) and "transient_provider_error" paths are
+ *     suppressed by exclusion; explicit clarification metadata on the
+ *     result itself is NOT suppressed (consumer-set hint always wins).
+ *   - Default empty / undefined → no exclusion (zero behavior change for
+ *     existing consumers).
+ *   - Minor bump on @agent-assistant/harness (additive option = minor).
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-harness-primitives-01-clarification')
+    .description(
+      'Add excludeToolNames option to createToolEvidenceClarificationHook so consumers can exempt read-only tools (memory_recall, etc.) from the empty-result clarification path without wrapping locally.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-harness-01')
+    .maxConcurrency(2)
+    .timeout(2_400_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the clarification surface.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the clarification option + tests.',
+      retries: 2,
+    })
+
+    .step('read-clarification', {
+      type: 'deterministic',
+      command:
+        'cat packages/harness/src/tool-evidence-clarification.ts && echo --- && ' +
+        'ls packages/harness/src/*.test.ts | xargs -I{} sh -c "echo === {} ===; cat {}" | head -300',
+      captureOutput: true,
+    })
+    .step('read-existing-version', {
+      type: 'deterministic',
+      command: 'grep "\\"version\\"" packages/harness/package.json | head -1',
+      captureOutput: true,
+    })
+
+    .step('implement', {
+      agent: 'impl',
+      dependsOn: ['read-clarification', 'read-existing-version'],
+      task: `Edit packages/harness/src/tool-evidence-clarification.ts.
+
+Current source:
+{{steps.read-clarification.output}}
+
+CONTRACT:
+
+1. Extend \`ToolEvidenceClarificationOptions\`:
+   \`\`\`ts
+   export interface ToolEvidenceClarificationOptions {
+     emptyResultKeys?: readonly string[];
+     questionForReason?: Partial<Record<HarnessToolEvidenceClarificationReason, string>>;
+     /**
+      * Tool names that should NEVER trigger an evidence-based clarification.
+      * Useful for read-only / "expected to sometimes be empty" tools like
+      * memory_recall where empty results are normal, not a signal that the
+      * model needs to ask the user a clarifying question.
+      *
+      * Note: explicit clarification hints on the tool result itself
+      * (result.metadata.clarification or structuredOutput.clarification)
+      * are still respected — the exclusion only suppresses the implicit
+      * classifier path.
+      */
+     excludeToolNames?: readonly string[];
+   }
+   \`\`\`
+
+2. In \`detectToolEvidenceClarification\`:
+   - Keep readExplicitClarification first (consumer hint always wins).
+   - Before calling classifyToolEvidence, check if
+     \`options.excludeToolNames?.includes(result.toolName)\`. If yes,
+     return null. (Use a Set internally for O(1) — but accept a readonly array as input so consumers can pass literals.)
+
+3. \`createToolEvidenceClarificationHook\` signature unchanged. The hook
+   factory just passes \`options\` through to detectToolEvidenceClarification
+   as it already does.
+
+4. Bump packages/harness/package.json version: minor bump from current to
+   next minor (additive option = minor).
+
+Edit ONLY:
+- packages/harness/src/tool-evidence-clarification.ts
+- packages/harness/package.json (version bump)
+
+Do NOT touch other files.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement'],
+      command:
+        'grep -q "excludeToolNames" packages/harness/src/tool-evidence-clarification.ts && ' +
+        'grep -q "excludeToolNames" packages/harness/src/tool-evidence-clarification.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-impl'],
+      task: `Add tests to packages/harness/src/tool-evidence-clarification.test.ts (create if missing — there's already a tool-evidence-clarification.ts file in the package; check whether a test file exists with: ls packages/harness/src/tool-evidence-clarification* and cat any matching test file).
+
+Required test cases (vitest):
+
+1. Empty-result on excluded tool returns null.
+   - Build a HarnessToolResult with toolName='memory_recall', status='success', structuredOutput={results: []}.
+   - With { excludeToolNames: ['memory_recall'] }: detectToolEvidenceClarification returns null.
+   - Without excludeToolNames: detectToolEvidenceClarification returns a non-null clarification with reason='empty_results'. (Verifies exclusion is what suppresses, not some other change.)
+
+2. Transient error on excluded tool returns null.
+   - HarnessToolResult with toolName='memory_recall', status='error', error: { code: 'rate_limited' }.
+   - With { excludeToolNames: ['memory_recall'] }: returns null.
+   - Without: returns reason='transient_provider_error'.
+
+3. Ambiguous on excluded tool returns null.
+
+4. Explicit clarification hint on excluded tool STILL surfaces.
+   - HarnessToolResult with toolName='memory_recall' and metadata.clarification = { question: 'Which scope?' }.
+   - With { excludeToolNames: ['memory_recall'] }: STILL returns the explicit clarification (consumer hint wins).
+
+5. Multiple excluded names work (excludeToolNames: ['memory_recall', 'workspace_search']).
+
+6. Empty / undefined excludeToolNames is zero behavior change (regression check).
+
+Use vitest. Mirror existing test patterns in packages/harness/src/.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command:
+        'test -f packages/harness/src/tool-evidence-clarification.test.ts && ' +
+        'grep -Eq "excludeToolNames" packages/harness/src/tool-evidence-clarification.test.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests'],
+      command: 'npx vitest run packages/harness/src/tool-evidence-clarification 2>&1 | tail -60',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures from:
+{{steps.run-tests.output}}
+If green, no-op. Don't loosen assertions. Re-run: npx vitest run packages/harness/src/tool-evidence-clarification`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/src/tool-evidence-clarification 2>&1 | tail -30',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -30; echo EXIT=$?',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-typecheck', {
+      agent: 'impl',
+      dependsOn: ['typecheck'],
+      task: `If errors, fix. If EXIT=0, no-op.
+{{steps.typecheck.output}}
+Re-run: cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-typecheck'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/harness/src/tool-evidence-clarification.ts packages/harness/package.json packages/harness/src/tool-evidence-clarification.test.ts
+
+Verify:
+1. \`excludeToolNames\` is OPTIONAL — undefined means zero behavior change.
+2. Explicit clarification hints (metadata.clarification, structuredOutput.clarification) are NOT suppressed by exclusion. Excluded only suppresses the classify path.
+3. The check uses an O(1) Set lookup or short-array .includes; doesn't iterate twice.
+4. JSDoc on the new option is present and explains the "explicit hint wins" carve-out.
+5. Version bump is minor (additive option).
+6. No drive-by edits to unrelated files.
+
+Edit files directly to fix. Re-run npx vitest run packages/harness/src/tool-evidence-clarification + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/src/tool-evidence-clarification 2>&1 | tail -20 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/01-clarification-exclude-tools.ts
+++ b/workflows/improve-harness-primitives/01-clarification-exclude-tools.ts
@@ -117,8 +117,8 @@ Do NOT touch other files.`,
       type: 'deterministic',
       dependsOn: ['implement'],
       command:
-        'grep -q "excludeToolNames" packages/harness/src/tool-evidence-clarification.ts && ' +
-        'grep -q "excludeToolNames" packages/harness/src/tool-evidence-clarification.ts && echo OK',
+        'grep -Eq "excludeToolNames\\?:[[:space:]]*readonly[[:space:]]+string\\[\\]" packages/harness/src/tool-evidence-clarification.ts && ' +
+        'git diff --name-only -- packages/harness/package.json | grep -q . && echo OK',
       captureOutput: true,
       failOnError: true,
     })

--- a/workflows/improve-harness-primitives/02-idempotency-guard.ts
+++ b/workflows/improve-harness-primitives/02-idempotency-guard.ts
@@ -1,0 +1,303 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 2 — `createIdempotencyGuard(inner, options?)` registry wrapper.
+ *
+ * Why this lifts upstream:
+ *   sage observed turns where the model called workspace_search 4× with
+ *   identical input, interleaved with other tools to dodge the upstream
+ *   max-tool-calls / redundant-loop detector (which counts CONSECUTIVE
+ *   identical calls). The fix needs to be at the registry layer: any
+ *   harness consumer benefits from blocking the 2nd identical
+ *   (name + input) call within a turn.
+ *
+ *   Sage built `withRedundantCallGuard(inner)` locally. This sub lifts
+ *   that into a generic, configurable factory exported from
+ *   @agent-assistant/harness so future consumers don't reinvent it.
+ *
+ * Contract (`createIdempotencyGuard`):
+ *   - Wraps a HarnessToolRegistry; returns a HarnessToolRegistry with the
+ *     same shape (listAvailable passthrough, execute wrapped).
+ *   - Tracks calls by (turnId, name + JSON.stringify(input)) signature.
+ *     turnId comes from HarnessToolExecutionContext.
+ *   - 1st call within a turn: passes through to inner.execute, records
+ *     the result's outputChars + iteration in cache.
+ *   - 2nd identical call within the same turn: returns a HarnessToolResult
+ *     immediately (does NOT call inner.execute) with status='error',
+ *     error.code='redundant_call_blocked', error.retryable=false, message
+ *     naming the iteration of the 1st call + N drill-in alternatives the
+ *     consumer configured.
+ *   - LRU cap on number of turns retained (default 50) — eviction is
+ *     oldest-first by access time.
+ *   - Configurable: `{ alternativesFor?: (call) => string[]; maxTurns?: number }`.
+ *     `alternativesFor` is the consumer hook for "given the duplicate call,
+ *     what should the model try instead?" — defaults to a generic message.
+ *
+ * Backwards-compatible: NEW export. Existing harness behavior unchanged
+ * unless the consumer opts in by wrapping their registry.
+ *
+ * Minor bump on @agent-assistant/harness.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-harness-primitives-02-idempotency')
+    .description(
+      'Add createIdempotencyGuard(inner, options?) — registry wrapper that blocks the 2nd identical (name + input) tool call within a turn with a structured error pointing at drill-in alternatives.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-harness-02')
+    .maxConcurrency(2)
+    .timeout(2_700_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the registry-wrapping surface.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the idempotency guard + tests.',
+      retries: 2,
+    })
+
+    .step('read-types', {
+      type: 'deterministic',
+      command:
+        'cat packages/harness/src/types.ts | head -260 && echo --- && ' +
+        'cat packages/harness/src/index.ts',
+      captureOutput: true,
+    })
+
+    .step('implement', {
+      agent: 'impl',
+      dependsOn: ['read-types'],
+      task: `Create a NEW file packages/harness/src/idempotency-guard.ts.
+
+Current types + index.ts:
+{{steps.read-types.output}}
+
+CONTRACT — exported surface:
+
+\`\`\`ts
+import type {
+  HarnessToolRegistry,
+  HarnessToolCall,
+  HarnessToolResult,
+  HarnessToolExecutionContext,
+} from './types.js';
+
+export interface IdempotencyGuardOptions {
+  /**
+   * Hook the consumer uses to suggest "given this duplicate call, what
+   * should the model try instead?" Returned strings are bulleted into
+   * the error message. Default: returns a generic single-line tip.
+   */
+  alternativesFor?: (call: HarnessToolCall) => string[];
+
+  /** LRU cap on retained turns. Default 50. */
+  maxTurns?: number;
+}
+
+export function createIdempotencyGuard(
+  inner: HarnessToolRegistry,
+  options?: IdempotencyGuardOptions,
+): HarnessToolRegistry;
+\`\`\`
+
+IMPLEMENTATION:
+
+- Module-level (or closed-over) Map<turnId, Map<callSignature, { iteration: number; outputChars: number; firstCalledAt: number }>>.
+- callSignature = \`\${call.name}::\${stableStringify(call.input ?? {})}\` where stableStringify sorts object keys recursively so { a: 1, b: 2 } and { b: 2, a: 1 } produce the same key.
+- turnId comes from HarnessToolExecutionContext (check types.ts; if it's missing, fall back to context.metadata?.turnId; if still missing, skip caching for that call entirely — guarded behavior is graceful when the consumer isn't propagating turn id).
+- LRU eviction: when Map.size > maxTurns, delete the oldest by insertion order (Map insertion order is stable in JS; refresh on read by delete+re-set).
+- listAvailable: pure passthrough to inner.listAvailable.
+- execute(call, context):
+  - Compute signature.
+  - Look up turn cache. If 2nd identical signature: return:
+    \`\`\`ts
+    {
+      callId: call.callId,
+      toolName: call.name,
+      status: 'error',
+      output: \`\`,
+      error: {
+        code: 'redundant_call_blocked',
+        message: <see below>,
+        retryable: false,
+      },
+    }
+    \`\`\`
+    Message format (one string, multi-line):
+    \`The \${call.name} tool was already called this turn at iteration \${prev.iteration} with the same input (\${prev.outputChars} chars of output). Repeating the same call won't return new information. Try one of:\n  - <alt1>\n  - <alt2>\n  - <alt3>\`
+    where alts come from \`options.alternativesFor?.(call)\`. If the hook returns empty/undefined, use a single default line: "Drill into a specific result from the previous output (cite a path or id) instead of re-searching."
+  - Otherwise: call inner.execute(call, context). Record { iteration: incrementing per turn from 1, outputChars: result.output?.length ?? 0, firstCalledAt: Date.now() } and return the result unchanged.
+- Iteration counter is per-turn (resets across turns).
+- The guard MUST NOT swallow exceptions thrown by inner.execute — propagate.
+
+Also export from packages/harness/src/index.ts:
+- export { createIdempotencyGuard, type IdempotencyGuardOptions } from './idempotency-guard.js';
+
+Bump packages/harness/package.json minor version (additive export = minor).
+
+Edit ONLY:
+- packages/harness/src/idempotency-guard.ts (new)
+- packages/harness/src/index.ts (re-export)
+- packages/harness/package.json (version bump)`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement'],
+      command:
+        'test -f packages/harness/src/idempotency-guard.ts && ' +
+        'grep -q "createIdempotencyGuard" packages/harness/src/idempotency-guard.ts && ' +
+        'grep -q "createIdempotencyGuard" packages/harness/src/index.ts && ' +
+        'grep -q "redundant_call_blocked" packages/harness/src/idempotency-guard.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-impl'],
+      task: `Add packages/harness/src/idempotency-guard.test.ts (vitest).
+
+Required test cases:
+
+1. First call passes through.
+   - innerRegistry.execute = vi.fn() returning success result.
+   - guard.execute(callA, ctx) → inner called once, result returned unchanged.
+
+2. Second identical call within same turn is blocked.
+   - guard.execute(callA, ctx) — succeeds.
+   - guard.execute(callA, ctx) — returns status='error', error.code='redundant_call_blocked', retryable=false. inner.execute called only ONCE (not twice).
+
+3. Different turn id → not blocked.
+   - guard.execute(callA, ctxTurn1) — passthrough.
+   - guard.execute(callA, ctxTurn2) — passthrough (inner called twice total).
+
+4. Different input shape → not blocked.
+   - call with input {q: 'a'} then {q: 'b'} → both pass through.
+
+5. Stable stringify: input {a: 1, b: 2} and {b: 2, a: 1} are SAME signature (2nd blocked).
+
+6. listAvailable is passthrough.
+   - guard.listAvailable(input) → inner.listAvailable called with same input, return value forwarded.
+
+7. alternativesFor hook is invoked and its output appears in the blocked error message.
+   - alternativesFor: () => ['try X', 'try Y'] → message contains "try X" and "try Y".
+
+8. Empty / missing alternativesFor → default fallback line appears in message.
+
+9. LRU eviction: with maxTurns=2, after recording 3 distinct turns, the oldest turn's signatures are evicted (a repeat call from turn 1 now passes through instead of being blocked).
+
+10. Inner exception propagates: inner.execute = vi.fn().mockRejectedValue(new Error('boom')). guard.execute(...) rejects with the same error. Cache should NOT record a successful entry for that call (so a retry isn't blocked).
+
+11. Iteration counter: with multiple distinct calls then a duplicate, the blocked message reports the iteration the original was made at (iteration=1 for the first call's duplicate, iteration=2 for the second's duplicate).
+
+Use vi.fn() for inner registry. Construct a minimal HarnessToolExecutionContext per the type — inspect packages/harness/src/types.ts to learn the shape and the turnId field path.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command:
+        'test -f packages/harness/src/idempotency-guard.test.ts && ' +
+        'grep -Eq "redundant_call_blocked|maxTurns|alternativesFor" packages/harness/src/idempotency-guard.test.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests'],
+      command: 'npx vitest run packages/harness/src/idempotency-guard 2>&1 | tail -80',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures from:
+{{steps.run-tests.output}}
+If green, no-op. Don't loosen assertions. Re-run: npx vitest run packages/harness/src/idempotency-guard`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/src/idempotency-guard 2>&1 | tail -40',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -30; echo EXIT=$?',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-typecheck', {
+      agent: 'impl',
+      dependsOn: ['typecheck'],
+      task: `If errors, fix. If EXIT=0, no-op.
+{{steps.typecheck.output}}
+Re-run: cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-typecheck'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/harness/
+
+Verify:
+1. createIdempotencyGuard is purely additive — no existing harness code path is changed.
+2. Stable stringify handles nested objects and arrays (key sort applies recursively).
+3. The guard does NOT swallow inner.execute exceptions. On throw, the cache is NOT updated (so retries after a transient throw are not blocked).
+4. LRU eviction is correct — sketch out a 3-turn cycle with maxTurns=2 and confirm eviction order.
+5. listAvailable is passthrough (not memoized — listAvailable can vary across calls in some consumers).
+6. error.retryable is FALSE on the blocked path — retrying the exact same call is exactly the wrong thing to do.
+7. Default alternativesFor fallback is helpful, not just "try something else".
+8. Version bump is minor.
+
+Edit files directly to fix. Re-run npx vitest run packages/harness/src/idempotency-guard + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/src/idempotency-guard 2>&1 | tail -20 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/03-github-public-review.ts
+++ b/workflows/improve-harness-primitives/03-github-public-review.ts
@@ -1,0 +1,354 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 3 — `GitHubPublicFetcher` + `createGitHubPublicReviewToolRegistry`.
+ *
+ * Why this lifts upstream:
+ *   The prime sage use case (cross-org review of an external public repo
+ *   like "review montanaflynn/headless-terminal vs relay") fails today
+ *   because github_specialist requires authenticated access to the user's
+ *   own org. Sage's workaround is a sage-side fetcher hitting
+ *   unauthenticated api.github.com. This is exactly the kind of primitive
+ *   that belongs upstream — any harness consumer that talks to a model
+ *   about external open-source code wants this tool.
+ *
+ * Contract:
+ *
+ * - NEW file packages/harness/src/tools/github-public-fetcher.ts:
+ *
+ *   export interface GitHubPublicReview {
+ *     owner: string;
+ *     repo: string;
+ *     description?: string;
+ *     license?: string;
+ *     stargazersCount?: number;
+ *     openIssuesCount?: number;
+ *     defaultBranch?: string;
+ *     htmlUrl?: string;
+ *     readme?: string; // raw README text, truncated to ~16k chars
+ *     packageJson?: unknown; // parsed package.json, if present at repo root
+ *     topLevel?: Array<{ path: string; type: 'file' | 'dir' }>;
+ *     recentCommits?: Array<{ sha: string; message: string; authorDate: string }>;
+ *   }
+ *
+ *   export class GitHubPublicFetchError extends Error {
+ *     readonly status?: number;
+ *     readonly code: 'not_found' | 'rate_limited' | 'invalid_request' | 'transport' | 'unknown';
+ *     readonly bodyExcerpt?: string;
+ *   }
+ *
+ *   export interface GitHubPublicFetcherOptions {
+ *     fetchImpl?: typeof globalThis.fetch; // override for tests; defaults to globalThis.fetch
+ *     userAgent?: string; // default 'agent-assistant-harness'
+ *     readmeMaxChars?: number; // default 16384
+ *     commitsCount?: number; // default 5; capped at 20
+ *   }
+ *
+ *   export class GitHubPublicFetcher {
+ *     constructor(options?: GitHubPublicFetcherOptions);
+ *     fetchReview(owner: string, repo: string): Promise<GitHubPublicReview>;
+ *   }
+ *
+ *   Implementation rules:
+ *   - Use globalThis.fetch (Cloudflare Workers safe per workers-fetch rule).
+ *   - Every Response body is consumed (.text() / .json()) or .body.cancel()'d.
+ *     Never leak a Response.
+ *   - Endpoints (sequential, fail-soft for optional pieces — readme/pkg-json
+ *     missing is normal; only the /repos/{owner}/{repo} call is required):
+ *       GET https://api.github.com/repos/{owner}/{repo}
+ *       GET https://api.github.com/repos/{owner}/{repo}/readme  (Accept: application/vnd.github.raw)
+ *       GET https://api.github.com/repos/{owner}/{repo}/contents/package.json (base64-decoded)
+ *       GET https://api.github.com/repos/{owner}/{repo}/contents/  (top level)
+ *       GET https://api.github.com/repos/{owner}/{repo}/commits?per_page={commitsCount}
+ *   - 404 on /repos → throws GitHubPublicFetchError with code='not_found'.
+ *   - 403 with X-RateLimit-Remaining: 0 → code='rate_limited'.
+ *   - Owner / repo must match /^[A-Za-z0-9_.-]+$/ — invalid input throws
+ *     code='invalid_request' before any network call.
+ *   - Truncate readme to readmeMaxChars; append "\n[truncated]" marker if cut.
+ *
+ * - NEW file packages/harness/src/tools/github-public-review-tool-registry.ts:
+ *
+ *   export const GITHUB_PUBLIC_REVIEW_TOOL_NAME = 'github_public_review';
+ *
+ *   export interface GitHubPublicReviewToolRegistryOptions {
+ *     fetcher?: GitHubPublicFetcher; // optional; default = new GitHubPublicFetcher()
+ *   }
+ *
+ *   export function createGitHubPublicReviewToolRegistry(
+ *     options?: GitHubPublicReviewToolRegistryOptions,
+ *   ): HarnessToolRegistry;
+ *
+ *   The registry exposes a single tool:
+ *     github_public_review({ owner: string, repo: string })
+ *   Schema enforces both fields, both strings, regex-validated client-side.
+ *   Returns the GitHubPublicReview as structuredOutput, with a
+ *   human-readable summary in result.output.
+ *
+ * - Re-export from packages/harness/src/index.ts:
+ *     GitHubPublicFetcher, GitHubPublicFetchError, GitHubPublicReview,
+ *     GitHubPublicFetcherOptions, createGitHubPublicReviewToolRegistry,
+ *     GITHUB_PUBLIC_REVIEW_TOOL_NAME, GitHubPublicReviewToolRegistryOptions.
+ *
+ * Minor bump on @agent-assistant/harness.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-harness-primitives-03-github-public')
+    .description(
+      'Add GitHubPublicFetcher + createGitHubPublicReviewToolRegistry to @agent-assistant/harness — unauthenticated public-repo readme/package.json/top-level/commits fetcher exposed as a github_public_review tool.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-harness-03')
+    .maxConcurrency(2)
+    .timeout(3_600_000) // 1h — meatier sub
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the GitHub public review tool.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the fetcher + tool registry + tests.',
+      retries: 2,
+    })
+
+    .step('read-tools-context', {
+      type: 'deterministic',
+      command:
+        'cat packages/harness/src/tools/workspace-tool-registry.ts | head -120 && echo --- && ' +
+        'cat packages/harness/src/types.ts | sed -n "1,260p" && echo --- && ' +
+        'cat packages/harness/src/index.ts',
+      captureOutput: true,
+    })
+
+    .step('implement-fetcher', {
+      agent: 'impl',
+      dependsOn: ['read-tools-context'],
+      task: `Create packages/harness/src/tools/github-public-fetcher.ts.
+
+Reference context (workspace-tool-registry pattern + types):
+{{steps.read-tools-context.output}}
+
+Follow the exact contract in the workflow JSDoc — re-read this sub's source if needed: workflows/improve-harness-primitives/03-github-public-review.ts.
+
+Hard rules:
+1. Use globalThis.fetch (NOT a top-level imported fetch — that breaks under Cloudflare Workers).
+2. Every Response body is either fully consumed (.text() / .json()) or .body?.cancel()'d. No fire-and-forget.
+3. The /repos call is the only REQUIRED endpoint — readme / package.json / contents / commits are best-effort. If those error or 404, capture nothing and continue (the GitHubPublicReview field is left undefined).
+4. Validate owner / repo regex BEFORE the first network call.
+5. License is the SPDX id from repo.license?.spdx_id when available (string, not object).
+6. Top-level contents call may return either a single file or an array — only treat it as the directory listing when Array.isArray(json).
+7. package.json contents endpoint returns base64-encoded \`content\` — decode via Buffer.from(content, 'base64').toString('utf8') and JSON.parse, swallowing parse errors (returns undefined when malformed).
+8. Truncate readme to readmeMaxChars (default 16384). If truncated, append \`\\n[truncated]\`.
+9. recent commits map to { sha, message: commit.commit.message, authorDate: commit.commit.author.date }.
+10. UA header on every fetch.
+11. GitHubPublicFetchError extends Error, has \`status?\`, \`code\`, \`bodyExcerpt?\` — bodyExcerpt is the first 500 chars of the response body for non-OK responses.
+
+Edit ONLY:
+- packages/harness/src/tools/github-public-fetcher.ts (new)`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-fetcher', {
+      type: 'deterministic',
+      dependsOn: ['implement-fetcher'],
+      command:
+        'test -f packages/harness/src/tools/github-public-fetcher.ts && ' +
+        'grep -q "class GitHubPublicFetcher" packages/harness/src/tools/github-public-fetcher.ts && ' +
+        'grep -q "globalThis.fetch" packages/harness/src/tools/github-public-fetcher.ts && ' +
+        'grep -q "GitHubPublicFetchError" packages/harness/src/tools/github-public-fetcher.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-tool-registry', {
+      agent: 'impl',
+      dependsOn: ['verify-fetcher'],
+      task: `Create packages/harness/src/tools/github-public-review-tool-registry.ts.
+
+Imports the fetcher from ./github-public-fetcher.js. Exposes a single tool github_public_review with schema:
+
+{
+  type: 'object',
+  required: ['owner', 'repo'],
+  properties: {
+    owner: { type: 'string', minLength: 1 },
+    repo:  { type: 'string', minLength: 1 },
+  },
+}
+
+execute() flow:
+- Validate input shape (owner + repo strings present). On bad input return status='error', error.code='invalid_request', retryable=false.
+- Call fetcher.fetchReview(owner, repo).
+- On GitHubPublicFetchError: map to result with status='error', error.code from the error code, error.message from err.message, retryable: error.code === 'rate_limited'.
+- On unknown throw: status='error', error.code='unknown', message: String(err), retryable=false.
+- On success: structuredOutput = the GitHubPublicReview object; output = a 8–20 line human-readable summary (\`# {owner}/{repo}\`, description, stars, default branch, license, ## README excerpt (first 800 chars), ## package.json excerpt (name + version + main scripts keys), ## Top-level (paths joined ", "), ## Recent commits (each on one line "sha[0..7]  date  message[0..80]")).
+
+listAvailable: returns [the single tool definition] regardless of input.
+
+Re-export from packages/harness/src/index.ts:
+- GitHubPublicFetcher, GitHubPublicFetchError, GitHubPublicReview, GitHubPublicFetcherOptions
+- createGitHubPublicReviewToolRegistry, GITHUB_PUBLIC_REVIEW_TOOL_NAME, GitHubPublicReviewToolRegistryOptions
+
+Bump packages/harness/package.json minor version.
+
+Edit ONLY:
+- packages/harness/src/tools/github-public-review-tool-registry.ts (new)
+- packages/harness/src/index.ts (re-exports)
+- packages/harness/package.json (version bump)`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tool-registry', {
+      type: 'deterministic',
+      dependsOn: ['implement-tool-registry'],
+      command:
+        'test -f packages/harness/src/tools/github-public-review-tool-registry.ts && ' +
+        'grep -q "createGitHubPublicReviewToolRegistry" packages/harness/src/tools/github-public-review-tool-registry.ts && ' +
+        'grep -q "github_public_review" packages/harness/src/tools/github-public-review-tool-registry.ts && ' +
+        'grep -q "createGitHubPublicReviewToolRegistry" packages/harness/src/index.ts && ' +
+        'grep -q "GitHubPublicFetcher" packages/harness/src/index.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-tool-registry'],
+      task: `Add two test files (vitest):
+
+A. packages/harness/src/tools/github-public-fetcher.test.ts
+
+Test cases (use a fetchImpl mock — vi.fn() that returns Response-like objects):
+
+1. Happy path: /repos returns 200 with full body, /readme returns raw README, /contents/package.json returns base64 content, /contents/ returns array, /commits returns array. Resulting GitHubPublicReview has all fields populated correctly.
+2. /repos 404 → throws GitHubPublicFetchError with code='not_found', status=404.
+3. /repos 403 + X-RateLimit-Remaining: 0 → throws code='rate_limited'.
+4. Invalid owner regex (e.g. 'foo/bar') → throws code='invalid_request' with NO fetch calls.
+5. /readme 404 → readme stays undefined; review still returns successfully.
+6. /contents/package.json malformed (invalid JSON after base64 decode) → packageJson stays undefined; review still returns.
+7. /contents/ returns a single file (not array) → topLevel stays undefined.
+8. README longer than readmeMaxChars → truncated + ends with "[truncated]".
+9. recent commits respects commitsCount option.
+10. globalThis.fetch is used by default (call new GitHubPublicFetcher() with no fetchImpl, then stub globalThis.fetch via vi.stubGlobal).
+
+B. packages/harness/src/tools/github-public-review-tool-registry.test.ts
+
+Test cases:
+
+1. listAvailable returns one tool with name 'github_public_review'.
+2. execute happy path: fetcher.fetchReview resolves → result.status='success', structuredOutput is the review object, output contains "# owner/repo".
+3. execute when fetcher throws GitHubPublicFetchError code='not_found' → result.status='error', error.code='not_found', retryable=false.
+4. execute when fetcher throws code='rate_limited' → retryable=true.
+5. execute on missing owner field → result.status='error', error.code='invalid_request'.
+6. The tool registry forwards options.fetcher to receive calls (vi.fn()).
+
+Use vitest. Inject a fake fetcher via the options.fetcher path.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command:
+        'test -f packages/harness/src/tools/github-public-fetcher.test.ts && ' +
+        'test -f packages/harness/src/tools/github-public-review-tool-registry.test.ts && ' +
+        'grep -Eq "rate_limited|not_found|invalid_request" packages/harness/src/tools/github-public-fetcher.test.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['verify-tests'],
+      command: 'npx vitest run packages/harness/src/tools/github-public 2>&1 | tail -100',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures from:
+{{steps.run-tests.output}}
+If green, no-op. Don't loosen assertions. Re-run: npx vitest run packages/harness/src/tools/github-public`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/src/tools/github-public 2>&1 | tail -50',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -30; echo EXIT=$?',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-typecheck', {
+      agent: 'impl',
+      dependsOn: ['typecheck'],
+      task: `If errors, fix. If EXIT=0, no-op.
+{{steps.typecheck.output}}
+Re-run: cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-typecheck'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/harness/
+
+Verify:
+1. globalThis.fetch is used (NOT a top-level fetch import) — Cloudflare Workers requirement. Grep for "import.*fetch" should NOT match.
+2. Every Response body is consumed or cancelled. No leaked bodies.
+3. GitHubPublicFetchError extends Error and has the documented shape.
+4. /repos 404 specifically maps to code='not_found' (not 'unknown').
+5. 403 + X-RateLimit-Remaining=0 maps to 'rate_limited' (NOT 'unknown' or 'transport').
+6. owner/repo regex validation happens BEFORE any fetch call.
+7. README truncation marker is stable (always "\\n[truncated]" at the end when truncated).
+8. The tool's structuredOutput is the GitHubPublicReview as-is — no transformation.
+9. retryable=true ONLY for rate_limited; not_found / invalid_request are NOT retryable.
+10. Version bump is minor.
+11. No drive-by edits to unrelated tools.
+
+Edit files directly to fix. Re-run npx vitest run packages/harness/src/tools/github-public + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/src/tools/github-public 2>&1 | tail -30 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/04-prompt-fragments.ts
+++ b/workflows/improve-harness-primitives/04-prompt-fragments.ts
@@ -1,0 +1,211 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 4 — Three new prompt fragments.
+ *
+ * Why this lifts upstream:
+ *   sage's harness consumer authors three near-identical prompt nudges
+ *   for every system prompt to fight three failure modes seen in prod:
+ *     - looping on workspace_search instead of drilling into a hit
+ *     - using github_specialist enumerate to answer source-code questions
+ *     - passing JSON Schema descriptions as values
+ *     - asking about external repos without using the right tool
+ *
+ *   These are independent of sage's domain — they're general harness-model
+ *   discipline. Co-locating them with the existing
+ *   HALLUCINATION_PREVENTION_CLAUSES makes them a one-line import for
+ *   future consumers.
+ *
+ * Contract:
+ *
+ * Add THREE new exports to packages/harness/src/tools/prompt-fragments.ts:
+ *
+ *   export const DRILL_IN_DISCIPLINE_CLAUSE
+ *     "After a tool returns a useful hit (a path, an id, an entity), drill into THAT specific result on your next turn — read the file, fetch the entity, expand the id. Do NOT re-issue the same enumeration query hoping for different results. If the first result didn't answer the question, refine the query (different keywords, narrower scope, different tool); don't repeat it verbatim."
+ *
+ *   export const TOOL_INPUT_SHAPE_REMINDER_CLAUSE
+ *     "Tool input schemas describe the SHAPE of the value you must provide; a description like 'A repository slug in owner/repo form' is not itself a valid value. Pass the actual value (e.g. 'AgentWorkforce/sage'), not the description text. If you don't have a real value, ask the user instead of submitting placeholder strings."
+ *
+ *   export const EXTERNAL_REPO_STEER_CLAUSE
+ *     "When the user asks about a repository OUTSIDE their workspace (a public repo on GitHub, a competitor's project, an open-source library) use the github_public_review tool with { owner, repo } — it works against unauthenticated api.github.com and returns README + package.json + top-level layout + recent commits. Do NOT try github_specialist or workspace_search for external public repos; those only see the connected workspace."
+ *
+ * The exports are individual top-level constants (NOT inside an array)
+ * because consumers cherry-pick which ones they want — sage may use all
+ * three; another consumer may only want DRILL_IN_DISCIPLINE_CLAUSE.
+ *
+ * Also export a convenience array `TOOL_DISCIPLINE_CLAUSES` so the
+ * default "include all three" import is a single token.
+ *
+ * Minor bump on @agent-assistant/harness.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-harness-primitives-04-prompts')
+    .description(
+      'Add DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE to @agent-assistant/harness prompt-fragments. Plus a TOOL_DISCIPLINE_CLAUSES bundle.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-harness-04')
+    .maxConcurrency(2)
+    .timeout(1_800_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for prompt fragment phrasing.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the prompt fragments + tests.',
+      retries: 2,
+    })
+
+    .step('read-fragments', {
+      type: 'deterministic',
+      command:
+        'cat packages/harness/src/tools/prompt-fragments.ts && echo --- && ' +
+        'cat packages/harness/src/tools/prompt-fragments.test.ts && echo --- && ' +
+        'grep -n "prompt-fragments\\|HALLUCINATION_PREVENTION" packages/harness/src/index.ts',
+      captureOutput: true,
+    })
+
+    .step('implement', {
+      agent: 'impl',
+      dependsOn: ['read-fragments'],
+      task: `Edit packages/harness/src/tools/prompt-fragments.ts.
+
+Current:
+{{steps.read-fragments.output}}
+
+CONTRACT:
+
+1. Add exactly the three exports below (verbatim — these strings are the contract):
+
+   export const DRILL_IN_DISCIPLINE_CLAUSE =
+     "After a tool returns a useful hit (a path, an id, an entity), drill into THAT specific result on your next turn — read the file, fetch the entity, expand the id. Do NOT re-issue the same enumeration query hoping for different results. If the first result didn't answer the question, refine the query (different keywords, narrower scope, different tool); don't repeat it verbatim.";
+
+   export const TOOL_INPUT_SHAPE_REMINDER_CLAUSE =
+     "Tool input schemas describe the SHAPE of the value you must provide; a description like 'A repository slug in owner/repo form' is not itself a valid value. Pass the actual value (e.g. 'AgentWorkforce/sage'), not the description text. If you don't have a real value, ask the user instead of submitting placeholder strings.";
+
+   export const EXTERNAL_REPO_STEER_CLAUSE =
+     "When the user asks about a repository OUTSIDE their workspace (a public repo on GitHub, a competitor's project, an open-source library) use the github_public_review tool with { owner, repo } — it works against unauthenticated api.github.com and returns README + package.json + top-level layout + recent commits. Do NOT try github_specialist or workspace_search for external public repos; those only see the connected workspace.";
+
+2. Add a convenience bundle:
+
+   export const TOOL_DISCIPLINE_CLAUSES = [
+     DRILL_IN_DISCIPLINE_CLAUSE,
+     TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
+     EXTERNAL_REPO_STEER_CLAUSE,
+   ] as const;
+
+3. Re-export everything new from packages/harness/src/index.ts (next to wherever HALLUCINATION_PREVENTION_CLAUSES is re-exported — keep it tidy).
+
+4. Bump packages/harness/package.json version: minor bump.
+
+Edit ONLY:
+- packages/harness/src/tools/prompt-fragments.ts
+- packages/harness/src/index.ts (re-exports if not already wildcarded)
+- packages/harness/package.json (version bump)`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-impl', {
+      type: 'deterministic',
+      dependsOn: ['implement'],
+      command:
+        'grep -q "DRILL_IN_DISCIPLINE_CLAUSE" packages/harness/src/tools/prompt-fragments.ts && ' +
+        'grep -q "TOOL_INPUT_SHAPE_REMINDER_CLAUSE" packages/harness/src/tools/prompt-fragments.ts && ' +
+        'grep -q "EXTERNAL_REPO_STEER_CLAUSE" packages/harness/src/tools/prompt-fragments.ts && ' +
+        'grep -q "TOOL_DISCIPLINE_CLAUSES" packages/harness/src/tools/prompt-fragments.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-impl'],
+      task: `Extend packages/harness/src/tools/prompt-fragments.test.ts (vitest):
+
+1. Each of DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE is a non-empty string >= 80 chars.
+2. DRILL_IN_DISCIPLINE_CLAUSE mentions "drill" and "enumeration" or "re-issue" — assert key terms are present.
+3. TOOL_INPUT_SHAPE_REMINDER_CLAUSE mentions "schema" and "description" — assert key terms.
+4. EXTERNAL_REPO_STEER_CLAUSE mentions "github_public_review" exactly once and mentions "owner" and "repo".
+5. TOOL_DISCIPLINE_CLAUSES is a 3-element readonly array containing all three constants in order: DRILL_IN, INPUT_SHAPE, EXTERNAL_REPO.
+6. None of the three new clauses appear in HALLUCINATION_PREVENTION_CLAUSES (they're a separate concern: discipline vs honesty).`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command: 'npx vitest run packages/harness/src/tools/prompt-fragments 2>&1 | tail -50',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures from:
+{{steps.run-tests.output}}
+If green, no-op. Re-run: npx vitest run packages/harness/src/tools/prompt-fragments`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/src/tools/prompt-fragments 2>&1 | tail -30',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck'],
+      task: `Review via: git diff packages/harness/
+
+Verify:
+1. The three clauses match the contract phrasing in this sub's JSDoc verbatim.
+2. EXTERNAL_REPO_STEER_CLAUSE references the github_public_review tool name (the same name added in Sub 3).
+3. TOOL_DISCIPLINE_CLAUSES is readonly (\`as const\` suffix).
+4. Re-exports from index.ts are present.
+5. Version bump is minor.
+6. Existing HALLUCINATION_PREVENTION_CLAUSES export shape unchanged.
+
+Edit files directly to fix. Re-run npx vitest run packages/harness/src/tools/prompt-fragments + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/src/tools/prompt-fragments 2>&1 | tail -20 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/05-openrouter-error-codes.ts
+++ b/workflows/improve-harness-primitives/05-openrouter-error-codes.ts
@@ -1,0 +1,337 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 5 — Typed error code on OpenRouter invalid outputs.
+ *
+ * Why this lifts upstream:
+ *   sage's `getUserFacingErrorMessage` switches on substring matches
+ *   against the free-text `reason` field returned by the OpenRouter
+ *   adapter ("more credits", "rate limit", "timeout"). String matching
+ *   is fragile — provider message text shifts between releases. Every
+ *   harness consumer that surfaces user-facing errors wants a stable
+ *   machine-readable code.
+ *
+ *   The current shape is `HarnessInvalidOutput { kind: 'transient' |
+ *   'provider_error' | ...; reason: string }`. `kind` is too coarse —
+ *   "out of credits" vs "rate limited" are both 'provider_error' today.
+ *
+ * Contract:
+ *
+ * 1. Add a NEW optional field to packages/harness/src/types.ts on
+ *    HarnessInvalidOutput:
+ *
+ *      /**
+ *       * Provider-specific error subcode. Optional. When present,
+ *       * consumers should prefer this over substring-matching `reason`.
+ *       * `kind` remains the high-level class ('transient' / 'provider_error').
+ *       *\/
+ *      code?: HarnessInvalidOutputCode;
+ *
+ *    export type HarnessInvalidOutputCode =
+ *      | 'credits_exhausted'
+ *      | 'rate_limited'
+ *      | 'timeout'
+ *      | 'invalid_request'
+ *      | 'context_length_exceeded'
+ *      | 'model_not_found'
+ *      | 'auth_failed'
+ *      | 'unknown';
+ *
+ * 2. Update packages/harness/src/adapter/openrouter-model-adapter.ts so
+ *    every invalidOutput call site populates `code`:
+ *
+ *    | Trigger                                              | kind             | code                        |
+ *    |------------------------------------------------------|------------------|-----------------------------|
+ *    | AbortError after timeout                             | transient        | timeout                     |
+ *    | response.status 408/409/425/429/5xx                  | transient        | rate_limited (429)          |
+ *    |                                                      |                  | timeout (408)               |
+ *    |                                                      |                  | unknown (others)            |
+ *    | response.status 401/403                              | provider_error   | auth_failed                 |
+ *    | response.status 400                                  | provider_error   | invalid_request             |
+ *    | response.status 404                                  | provider_error   | model_not_found             |
+ *    | message includes 'credits' / 'afford' / 'insufficient' regardless of status | provider_error | credits_exhausted |
+ *    | message includes 'context length' / 'maximum context' / 'token limit' | provider_error | context_length_exceeded |
+ *    | response body !valid JSON                            | provider_error   | unknown                     |
+ *    | catch-all in the try/catch fall-through              | transient        | unknown                     |
+ *    | Unknown error in catch                               | transient        | unknown                     |
+ *
+ *    Helper: a small classifyOpenRouterError(status, message) function
+ *    that returns the code. Pure, exported as INTERNAL — not from the
+ *    public package surface — but factored so it's unit-testable from
+ *    the adapter's spec.
+ *
+ *    The credits/context-length detection happens BEFORE the status-based
+ *    fallback, so a 402 with "out of credits" body becomes
+ *    code='credits_exhausted' (not 'unknown').
+ *
+ * 3. Existing `kind` and `reason` fields keep their current values for
+ *    backwards compatibility. `code` is purely additive.
+ *
+ * 4. Re-export the `HarnessInvalidOutputCode` type from
+ *    packages/harness/src/index.ts so consumers can import it.
+ *
+ * Minor bump on @agent-assistant/harness.
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-harness-primitives-05-error-codes')
+    .description(
+      'Add HarnessInvalidOutputCode + populate it from the OpenRouter adapter — stable machine-readable subcode so consumers stop substring-matching reason.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-harness-05')
+    .maxConcurrency(2)
+    .timeout(2_700_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Architect/reviewer for the error-classification surface.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for the code field + adapter wiring + tests.',
+      retries: 2,
+    })
+
+    .step('read-context', {
+      type: 'deterministic',
+      command:
+        'sed -n "130,170p" packages/harness/src/types.ts && echo --- && ' +
+        'sed -n "420,640p" packages/harness/src/adapter/openrouter-model-adapter.ts && echo --- && ' +
+        'cat packages/harness/src/adapter/openrouter-model-adapter.test.ts | head -120',
+      captureOutput: true,
+    })
+
+    .step('implement-types', {
+      agent: 'impl',
+      dependsOn: ['read-context'],
+      task: `Edit packages/harness/src/types.ts.
+
+Current relevant slice:
+{{steps.read-context.output}}
+
+CONTRACT:
+
+1. Add type alias near HarnessInvalidOutputKind:
+   export type HarnessInvalidOutputCode =
+     | 'credits_exhausted'
+     | 'rate_limited'
+     | 'timeout'
+     | 'invalid_request'
+     | 'context_length_exceeded'
+     | 'model_not_found'
+     | 'auth_failed'
+     | 'unknown';
+
+2. Add optional field to HarnessInvalidOutput:
+   /**
+    * Provider-specific error subcode. Optional; populated by adapters
+    * (e.g. OpenRouter) so consumers can switch on a stable enum instead
+    * of substring-matching the free-text \`reason\` field. \`kind\` remains
+    * the high-level transient/provider_error split.
+    */
+   code?: HarnessInvalidOutputCode;
+
+3. Re-export HarnessInvalidOutputCode from packages/harness/src/index.ts.
+
+DO NOT change kind, reason, or any other field's type. The change is additive.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-types', {
+      type: 'deterministic',
+      dependsOn: ['implement-types'],
+      command:
+        'grep -q "HarnessInvalidOutputCode" packages/harness/src/types.ts && ' +
+        'grep -q "HarnessInvalidOutputCode" packages/harness/src/index.ts && ' +
+        'grep -q "code?: HarnessInvalidOutputCode" packages/harness/src/types.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-adapter', {
+      agent: 'impl',
+      dependsOn: ['verify-types'],
+      task: `Edit packages/harness/src/adapter/openrouter-model-adapter.ts.
+
+CONTRACT:
+
+1. Add a private helper near invalidOutput():
+
+   function classifyOpenRouterError(httpStatus: number | undefined, reason: string | undefined): HarnessInvalidOutputCode {
+     const text = (reason ?? '').toLowerCase();
+
+     // Body-content rules (run BEFORE status-based fallback)
+     if (text.includes('credits') || text.includes('afford') || text.includes('insufficient')) {
+       return 'credits_exhausted';
+     }
+     if (text.includes('context length') || text.includes('maximum context') || text.includes('token limit')) {
+       return 'context_length_exceeded';
+     }
+     if (text === 'timeout') return 'timeout';
+
+     // Status-based fallback
+     switch (httpStatus) {
+       case 400: return 'invalid_request';
+       case 401:
+       case 403: return 'auth_failed';
+       case 404: return 'model_not_found';
+       case 408: return 'timeout';
+       case 429: return 'rate_limited';
+       default:
+         if (httpStatus !== undefined && httpStatus >= 500) return 'unknown';
+         return 'unknown';
+     }
+   }
+
+2. Wherever invalidOutput(...) is called, attach a code via the options bag:
+   - HTTP non-OK: code = classifyOpenRouterError(response.status, body?.error?.message)
+   - JSON-parse fail (response.ok but body undefined): code = 'unknown'
+   - AbortError catch: code = 'timeout'
+   - Generic catch fall-through: code = classifyOpenRouterError(undefined, error.message) (lets credits/context-length matches in thrown errors still classify)
+
+   To keep changes minimal: extend invalidOutput's options-bag-merging to forward code, OR pass code in the options object that already gets spread into the return.
+
+3. Do NOT change kind values (transient vs provider_error). Only add code.
+
+4. Bump packages/harness/package.json minor version.
+
+Re-read this sub's source for the exact mapping table:
+workflows/improve-harness-primitives/05-openrouter-error-codes.ts
+
+Edit ONLY:
+- packages/harness/src/adapter/openrouter-model-adapter.ts
+- packages/harness/package.json (version bump)`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('verify-adapter', {
+      type: 'deterministic',
+      dependsOn: ['implement-adapter'],
+      command:
+        'grep -q "classifyOpenRouterError" packages/harness/src/adapter/openrouter-model-adapter.ts && ' +
+        'grep -q "credits_exhausted" packages/harness/src/adapter/openrouter-model-adapter.ts && echo OK',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-tests', {
+      agent: 'impl',
+      dependsOn: ['verify-adapter'],
+      task: `Add packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts (vitest).
+
+Required test cases (use a fetchImpl mock returning Response-like objects):
+
+1. 402 with body.error.message containing "more credits" → output.kind='provider_error', output.code='credits_exhausted'.
+2. 429 status → output.kind='transient', output.code='rate_limited'.
+3. 408 → output.kind='transient', output.code='timeout'.
+4. 401 → output.kind='provider_error', output.code='auth_failed'.
+5. 403 → output.kind='provider_error', output.code='auth_failed'.
+6. 400 → output.kind='provider_error', output.code='invalid_request'.
+7. 404 → output.kind='provider_error', output.code='model_not_found'.
+8. 500 → output.kind='transient', output.code='unknown'.
+9. Body-message containing "context length" → code='context_length_exceeded' regardless of status.
+10. Body-message containing "insufficient" → code='credits_exhausted'.
+11. AbortError (simulated by signal abort) → code='timeout'.
+12. Generic thrown error with message "openrouter says you need more credits" → code='credits_exhausted'.
+13. response.ok but malformed JSON → code='unknown'.
+14. Existing kind values are unchanged: 429 still kind='transient', 402 with credits text still kind='provider_error'.
+15. The classify helper itself is exercised: a unit test pasted in-line that calls classifyOpenRouterError(429, 'too many requests') → 'rate_limited'.
+
+Look at packages/harness/src/adapter/openrouter-model-adapter.test.ts for the existing test scaffold (request mocking pattern). Add the new cases there OR in a sibling file — your call, but tests must exercise the public OpenRouterModelAdapter.nextStep(...) path, not just call classifyOpenRouterError directly (the classify-only test in #15 is fine to also include).`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+
+    .step('run-tests', {
+      type: 'deterministic',
+      dependsOn: ['write-tests'],
+      command: 'npx vitest run packages/harness/src/adapter/openrouter-model-adapter 2>&1 | tail -100',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-tests', {
+      agent: 'impl',
+      dependsOn: ['run-tests'],
+      task: `Fix any failures from:
+{{steps.run-tests.output}}
+If green, no-op. Don't loosen assertions. Re-run: npx vitest run packages/harness/src/adapter/openrouter-model-adapter`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 2,
+    })
+    .step('run-tests-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-tests'],
+      command: 'npx vitest run packages/harness/src/adapter/openrouter-model-adapter 2>&1 | tail -50',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('typecheck', {
+      type: 'deterministic',
+      dependsOn: ['run-tests-final'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -30; echo EXIT=$?',
+      captureOutput: true,
+      failOnError: false,
+    })
+    .step('fix-typecheck', {
+      agent: 'impl',
+      dependsOn: ['typecheck'],
+      task: `If errors, fix. If EXIT=0, no-op.
+{{steps.typecheck.output}}
+Re-run: cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('typecheck-final', {
+      type: 'deterministic',
+      dependsOn: ['fix-typecheck'],
+      command: 'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['typecheck-final'],
+      task: `Review via: git diff packages/harness/src/types.ts packages/harness/src/index.ts packages/harness/src/adapter/openrouter-model-adapter.ts
+
+Verify:
+1. \`code\` is OPTIONAL on HarnessInvalidOutput. Existing consumers that don't read it are unaffected.
+2. \`kind\` values are unchanged. The OpenRouter adapter still returns 'transient' for 429 and 'provider_error' for 4xx like 401/403/400/404. Only \`code\` is new.
+3. Body-message classification (credits / context-length) runs BEFORE status fallback so a 402 with "out of credits" message classifies as credits_exhausted, not 'invalid_request' / 'unknown'.
+4. AbortError → timeout (not 'unknown').
+5. Generic catch fall-through still classifies via message text — a thrown Error("more credits") becomes credits_exhausted.
+6. The adapter's existing public API (createOpenRouterModelAdapter, OpenRouterModelAdapter, OpenRouterModelAdapterConfig) is unchanged.
+7. classifyOpenRouterError is internal — NOT re-exported from packages/harness/src/index.ts.
+8. Version bump is minor.
+
+Edit files directly to fix. Re-run npx vitest run packages/harness/src/adapter + cd packages/harness && npx tsc --noEmit.`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+    .step('post-review-final', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/src/adapter/openrouter-model-adapter 2>&1 | tail -30 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/06-publish-pr.ts
+++ b/workflows/improve-harness-primitives/06-publish-pr.ts
@@ -136,16 +136,19 @@ If anything is wrong, fix directly. Then re-run:
     .step('commit', {
       type: 'deterministic',
       dependsOn: ['post-review-tests'],
-      // git add -u catches modifications. -- new files explicitly listed
-      // and `|| true` on each guards against the file not existing for any
-      // sub that the impl agent collapsed into a sibling file.
+      // git add -u catches modifications. New files added via subshells so
+      // `|| true` only catches the individual `git add` failure, not the
+      // preceding `git add -u`. Per Devin review on PR #69: bash treats
+      // `&& ... || true` as left-associative `(A && B) || true`, which
+      // would silently swallow a failure of `git add -u` and produce an
+      // incomplete commit missing all modifications.
       command:
         'git add -u packages/harness/ && ' +
-        'git add packages/harness/src/idempotency-guard.ts packages/harness/src/idempotency-guard.test.ts || true; ' +
-        'git add packages/harness/src/tools/github-public-fetcher.ts packages/harness/src/tools/github-public-fetcher.test.ts || true; ' +
-        'git add packages/harness/src/tools/github-public-review-tool-registry.ts packages/harness/src/tools/github-public-review-tool-registry.test.ts || true; ' +
-        'git add packages/harness/src/tool-evidence-clarification.test.ts || true; ' +
-        'git add packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts || true; ' +
+        '(git add packages/harness/src/idempotency-guard.ts packages/harness/src/idempotency-guard.test.ts || true) && ' +
+        '(git add packages/harness/src/tools/github-public-fetcher.ts packages/harness/src/tools/github-public-fetcher.test.ts || true) && ' +
+        '(git add packages/harness/src/tools/github-public-review-tool-registry.ts packages/harness/src/tools/github-public-review-tool-registry.test.ts || true) && ' +
+        '(git add packages/harness/src/tool-evidence-clarification.test.ts || true) && ' +
+        '(git add packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts || true) && ' +
         'git status --short && ' +
         "git commit -m 'feat(harness): clarification exclude-tools, idempotency guard, github-public-review tool, tool-discipline prompt fragments, openrouter error codes' " +
         "           -m 'Five primitives lifted from sage Slack-bot failure-mode fixes (sage PR #155). Each is general harness-runtime concern that any consumer benefits from. excludeToolNames on createToolEvidenceClarificationHook so read-only tools (memory_recall) skip the empty-result clarification path. createIdempotencyGuard registry wrapper blocks the 2nd identical (name + input) tool call within a turn with a structured redundant_call_blocked error pointing at consumer-supplied drill-in alternatives. GitHubPublicFetcher + createGitHubPublicReviewToolRegistry expose unauthenticated public-repo readme/package.json/top-level/recent-commits via a github_public_review tool — closes the cross-org external-repo review use case. Three new prompt fragments (DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE) plus a TOOL_DISCIPLINE_CLAUSES bundle co-located with HALLUCINATION_PREVENTION_CLAUSES. HarnessInvalidOutputCode adds a stable subcode (credits_exhausted / rate_limited / timeout / invalid_request / context_length_exceeded / model_not_found / auth_failed / unknown) populated by the OpenRouter adapter so consumers can switch on a machine-readable code instead of substring-matching reason. All additive; existing signatures and field shapes unchanged. Single minor bump on @agent-assistant/harness.'",

--- a/workflows/improve-harness-primitives/06-publish-pr.ts
+++ b/workflows/improve-harness-primitives/06-publish-pr.ts
@@ -136,22 +136,49 @@ If anything is wrong, fix directly. Then re-run:
     .step('commit', {
       type: 'deterministic',
       dependsOn: ['post-review-tests'],
+      // Idempotent: if a prior run already committed (resume scenario, or
+      // a sub already committed its own work), staging produces nothing
+      // and we skip the commit + log "already committed". Only fails when
+      // there's truly nothing to ship — no staged changes AND no commits
+      // ahead of origin/main.
+      //
       // git add -u catches modifications. New files added via subshells so
       // `|| true` only catches the individual `git add` failure, not the
       // preceding `git add -u`. Per Devin review on PR #69: bash treats
       // `&& ... || true` as left-associative `(A && B) || true`, which
       // would silently swallow a failure of `git add -u` and produce an
       // incomplete commit missing all modifications.
-      command:
-        'git add -u packages/harness/ && ' +
-        '(git add packages/harness/src/idempotency-guard.ts packages/harness/src/idempotency-guard.test.ts || true) && ' +
-        '(git add packages/harness/src/tools/github-public-fetcher.ts packages/harness/src/tools/github-public-fetcher.test.ts || true) && ' +
-        '(git add packages/harness/src/tools/github-public-review-tool-registry.ts packages/harness/src/tools/github-public-review-tool-registry.test.ts || true) && ' +
-        '(git add packages/harness/src/tool-evidence-clarification.test.ts || true) && ' +
-        '(git add packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts || true) && ' +
-        'git status --short && ' +
-        "git commit -m 'feat(harness): clarification exclude-tools, idempotency guard, github-public-review tool, tool-discipline prompt fragments, openrouter error codes' " +
-        "           -m 'Five primitives lifted from sage Slack-bot failure-mode fixes (sage PR #155). Each is general harness-runtime concern that any consumer benefits from. excludeToolNames on createToolEvidenceClarificationHook so read-only tools (memory_recall) skip the empty-result clarification path. createIdempotencyGuard registry wrapper blocks the 2nd identical (name + input) tool call within a turn with a structured redundant_call_blocked error pointing at consumer-supplied drill-in alternatives. GitHubPublicFetcher + createGitHubPublicReviewToolRegistry expose unauthenticated public-repo readme/package.json/top-level/recent-commits via a github_public_review tool — closes the cross-org external-repo review use case. Three new prompt fragments (DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE) plus a TOOL_DISCIPLINE_CLAUSES bundle co-located with HALLUCINATION_PREVENTION_CLAUSES. HarnessInvalidOutputCode adds a stable subcode (credits_exhausted / rate_limited / timeout / invalid_request / context_length_exceeded / model_not_found / auth_failed / unknown) populated by the OpenRouter adapter so consumers can switch on a machine-readable code instead of substring-matching reason. All additive; existing signatures and field shapes unchanged. Single minor bump on @agent-assistant/harness.'",
+      command: [
+        'set -e',
+        'mkdir -p tmp',
+        // Write the commit message to a file so we don't have to fight
+        // shell-quoting with single quotes inside the workflow string.
+        "cat > tmp/aa-harness-commit-msg.txt <<'COMMITMSG'",
+        'feat(harness): clarification exclude-tools, idempotency guard, github-public-review tool, tool-discipline prompt fragments, openrouter error codes',
+        '',
+        'Five primitives lifted from sage Slack-bot failure-mode fixes (sage PR #155). Each is general harness-runtime concern that any consumer benefits from. excludeToolNames on createToolEvidenceClarificationHook so read-only tools (memory_recall) skip the empty-result clarification path. createIdempotencyGuard registry wrapper blocks the 2nd identical (name + input) tool call within a turn with a structured redundant_call_blocked error pointing at consumer-supplied drill-in alternatives. GitHubPublicFetcher + createGitHubPublicReviewToolRegistry expose unauthenticated public-repo readme/package.json/top-level/recent-commits via a github_public_review tool — closes the cross-org external-repo review use case. Three new prompt fragments (DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE) plus a TOOL_DISCIPLINE_CLAUSES bundle co-located with HALLUCINATION_PREVENTION_CLAUSES. HarnessInvalidOutputCode adds a stable subcode (credits_exhausted / rate_limited / timeout / invalid_request / context_length_exceeded / model_not_found / auth_failed / unknown) populated by the OpenRouter adapter so consumers can switch on a machine-readable code instead of substring-matching reason. All additive; existing signatures and field shapes unchanged. Single minor bump on @agent-assistant/harness.',
+        'COMMITMSG',
+        // Stage modifications and any new files.
+        'git add -u packages/harness/',
+        '(git add packages/harness/src/idempotency-guard.ts packages/harness/src/idempotency-guard.test.ts || true)',
+        '(git add packages/harness/src/tools/github-public-fetcher.ts packages/harness/src/tools/github-public-fetcher.test.ts || true)',
+        '(git add packages/harness/src/tools/github-public-review-tool-registry.ts packages/harness/src/tools/github-public-review-tool-registry.test.ts || true)',
+        '(git add packages/harness/src/tool-evidence-clarification.test.ts || true)',
+        '(git add packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts || true)',
+        'git status --short',
+        // Decide: commit, skip, or fail.
+        'if git diff --cached --quiet; then',
+        '  ahead=$(git rev-list --count origin/main..HEAD)',
+        '  if [ "$ahead" -gt 0 ]; then',
+        '    echo "[commit] nothing to stage; HEAD is $ahead commit(s) ahead of origin/main — assuming prior run already committed. Skipping commit."',
+        '  else',
+        '    echo "[commit] FATAL: nothing staged AND no commits ahead of origin/main. The workflow produced no changes — failing loudly."',
+        '    exit 1',
+        '  fi',
+        'else',
+        '  git commit -F tmp/aa-harness-commit-msg.txt',
+        'fi',
+      ].join('\n'),
       captureOutput: true,
       failOnError: true,
     })
@@ -262,8 +289,22 @@ wc -l tmp/aa-harness-pr-body.md`,
     .step('open-pr', {
       type: 'deterministic',
       dependsOn: ['write-pr-body'],
-      command:
-        'PR_URL=$(gh pr create --title "feat(harness): clarification exclude-tools, idempotency guard, github-public-review, prompt fragments, openrouter error codes" --body-file tmp/aa-harness-pr-body.md) && echo "PR: $PR_URL"',
+      // Idempotent against re-runs / resumes: if a PR already exists for
+      // the current branch, print its URL and update the body instead of
+      // failing with "a pull request for branch X already exists".
+      command: [
+        'set -e',
+        'branch=$(git rev-parse --abbrev-ref HEAD)',
+        'existing=$(gh pr list --head "$branch" --json url --jq ".[0].url" 2>/dev/null || true)',
+        'if [ -n "$existing" ] && [ "$existing" != "null" ]; then',
+        '  echo "[open-pr] PR already exists for $branch — updating body."',
+        '  gh pr edit "$existing" --body-file tmp/aa-harness-pr-body.md > /dev/null',
+        '  echo "PR: $existing"',
+        'else',
+        '  PR_URL=$(gh pr create --title "feat(harness): clarification exclude-tools, idempotency guard, github-public-review, prompt fragments, openrouter error codes" --body-file tmp/aa-harness-pr-body.md)',
+        '  echo "PR: $PR_URL"',
+        'fi',
+      ].join('\n'),
       captureOutput: true,
       failOnError: true,
     })

--- a/workflows/improve-harness-primitives/06-publish-pr.ts
+++ b/workflows/improve-harness-primitives/06-publish-pr.ts
@@ -1,0 +1,278 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+/**
+ * Sub 6 — Holistic review, commit, push, open PR.
+ *
+ * Does NOT publish to npm — that's the existing release workflow's job
+ * once the PR merges. This sub gets the change set into a single
+ * reviewable PR with the cross-cutting message.
+ *
+ * Per memory [Sage Slack→harness migration] commit lessons: do NOT
+ * hardcode a path list. Use `git add -u` for modifications + explicit
+ * NEW files only. The new files added by 01-05:
+ *   - packages/harness/src/idempotency-guard.ts (+ test)
+ *   - packages/harness/src/tools/github-public-fetcher.ts (+ test)
+ *   - packages/harness/src/tools/github-public-review-tool-registry.ts (+ test)
+ *   - packages/harness/src/tool-evidence-clarification.test.ts (if newly created)
+ *   - packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts
+ */
+
+async function runWorkflow() {
+  const result = await workflow('improve-harness-primitives-06-publish-pr')
+    .description(
+      'Final cross-cutting lead review of @agent-assistant/harness primitives, single commit, push, open PR.',
+    )
+    .pattern('dag')
+    .channel('wf-aa-harness-06')
+    .maxConcurrency(2)
+    .timeout(1_800_000)
+
+    .agent('lead', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      role: 'Senior reviewer with authority to send work back.',
+      retries: 1,
+    })
+    .agent('impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      role: 'Implementer for any final review-driven fixes.',
+      retries: 2,
+    })
+
+    .step('check-branch', {
+      type: 'deterministic',
+      command:
+        'branch=$(git rev-parse --abbrev-ref HEAD); ' +
+        'echo "Current branch: $branch"; ' +
+        'if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then ' +
+        '  echo "REFUSE: not on a feature branch — master executor should have created one"; exit 1; ' +
+        'fi; ' +
+        'git status --short',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('show-diff-stat', {
+      type: 'deterministic',
+      dependsOn: ['check-branch'],
+      command: 'git diff --stat HEAD; echo ---; git log --oneline origin/main..HEAD || true',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('full-test-suite', {
+      type: 'deterministic',
+      dependsOn: ['show-diff-stat'],
+      command:
+        'npx vitest run packages/harness/ 2>&1 | tail -50 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('lead-review', {
+      agent: 'lead',
+      dependsOn: ['full-test-suite'],
+      task: `Review the FULL diff via: git diff origin/main...HEAD -- packages/harness/
+
+Required pass criteria for the consolidated change set:
+
+1. excludeToolNames option:
+   - ToolEvidenceClarificationOptions.excludeToolNames is OPTIONAL.
+   - Excluded tool with empty result returns null. With explicit clarification metadata still surfaces.
+
+2. createIdempotencyGuard:
+   - listAvailable is passthrough.
+   - 2nd identical call within a turn returns code='redundant_call_blocked', retryable=false.
+   - Different turn id is NOT blocked.
+   - inner.execute exceptions propagate (not swallowed); cache not poisoned by exceptions.
+   - Stable stringify handles nested object key ordering.
+
+3. GitHubPublicFetcher + createGitHubPublicReviewToolRegistry:
+   - Uses globalThis.fetch (NOT a top-level fetch import). Grep: \`grep -n "import.*fetch" packages/harness/src/tools/github-public-fetcher.ts\` should not match.
+   - Every Response body is consumed or cancelled.
+   - 404 → code='not_found', 403+ratelimit → code='rate_limited'.
+   - owner/repo regex validation BEFORE any fetch.
+   - README truncation with stable marker.
+   - retryable=true ONLY for rate_limited.
+
+4. Three prompt fragments:
+   - DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE exported.
+   - TOOL_DISCIPLINE_CLAUSES is a 3-element readonly array.
+   - HALLUCINATION_PREVENTION_CLAUSES untouched.
+
+5. HarnessInvalidOutputCode:
+   - Type added to types.ts and re-exported from index.ts.
+   - Existing kind values unchanged.
+   - OpenRouter adapter populates code at every invalidOutput call site.
+   - Body-text classification (credits / context-length) runs before status fallback.
+
+6. Cross-cutting:
+   - All five primitives exported from packages/harness/src/index.ts.
+   - One minor version bump on packages/harness/package.json (cumulative across all five — final version is one minor above the version on origin/main).
+   - No drive-by edits to memory package, vfs package, or unrelated harness files.
+   - No leftover console.log / .skip / .only.
+   - Tests cover happy + edge + failure paths.
+
+If anything is wrong, fix directly. Then re-run:
+  npx vitest run packages/harness/
+  cd packages/harness && npx tsc --noEmit`,
+      verification: { type: 'exit_code', value: '0' },
+      retries: 1,
+    })
+
+    .step('post-review-tests', {
+      type: 'deterministic',
+      dependsOn: ['lead-review'],
+      command:
+        'npx vitest run packages/harness/ 2>&1 | tail -50 && echo --- && ' +
+        'cd packages/harness && npx tsc --noEmit 2>&1 | tail -10',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('commit', {
+      type: 'deterministic',
+      dependsOn: ['post-review-tests'],
+      // git add -u catches modifications. -- new files explicitly listed
+      // and `|| true` on each guards against the file not existing for any
+      // sub that the impl agent collapsed into a sibling file.
+      command:
+        'git add -u packages/harness/ && ' +
+        'git add packages/harness/src/idempotency-guard.ts packages/harness/src/idempotency-guard.test.ts || true; ' +
+        'git add packages/harness/src/tools/github-public-fetcher.ts packages/harness/src/tools/github-public-fetcher.test.ts || true; ' +
+        'git add packages/harness/src/tools/github-public-review-tool-registry.ts packages/harness/src/tools/github-public-review-tool-registry.test.ts || true; ' +
+        'git add packages/harness/src/tool-evidence-clarification.test.ts || true; ' +
+        'git add packages/harness/src/adapter/openrouter-model-adapter.error-codes.test.ts || true; ' +
+        'git status --short && ' +
+        "git commit -m 'feat(harness): clarification exclude-tools, idempotency guard, github-public-review tool, tool-discipline prompt fragments, openrouter error codes' " +
+        "           -m 'Five primitives lifted from sage Slack-bot failure-mode fixes (sage PR #155). Each is general harness-runtime concern that any consumer benefits from. excludeToolNames on createToolEvidenceClarificationHook so read-only tools (memory_recall) skip the empty-result clarification path. createIdempotencyGuard registry wrapper blocks the 2nd identical (name + input) tool call within a turn with a structured redundant_call_blocked error pointing at consumer-supplied drill-in alternatives. GitHubPublicFetcher + createGitHubPublicReviewToolRegistry expose unauthenticated public-repo readme/package.json/top-level/recent-commits via a github_public_review tool — closes the cross-org external-repo review use case. Three new prompt fragments (DRILL_IN_DISCIPLINE_CLAUSE, TOOL_INPUT_SHAPE_REMINDER_CLAUSE, EXTERNAL_REPO_STEER_CLAUSE) plus a TOOL_DISCIPLINE_CLAUSES bundle co-located with HALLUCINATION_PREVENTION_CLAUSES. HarnessInvalidOutputCode adds a stable subcode (credits_exhausted / rate_limited / timeout / invalid_request / context_length_exceeded / model_not_found / auth_failed / unknown) populated by the OpenRouter adapter so consumers can switch on a machine-readable code instead of substring-matching reason. All additive; existing signatures and field shapes unchanged. Single minor bump on @agent-assistant/harness.'",
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('push', {
+      type: 'deterministic',
+      dependsOn: ['commit'],
+      command:
+        'branch=$(git rev-parse --abbrev-ref HEAD) && git push -u origin "$branch"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('write-pr-body', {
+      type: 'deterministic',
+      dependsOn: ['push'],
+      command: `mkdir -p tmp && cat > tmp/aa-harness-pr-body.md <<'PRBODY'
+## Summary
+
+Five primitives lifted upstream from sage's Slack-bot failure-mode fixes (sage PR #155). Each was a sage-side workaround for something general enough that any \`@agent-assistant/harness\` consumer would re-invent. Pulling them upstream lets sage drop its local copies in a follow-up adoption PR.
+
+## Primitives
+
+### 1. \`excludeToolNames\` on \`createToolEvidenceClarificationHook\`
+
+Adds an opt-out list of tool names that should NEVER trigger the implicit empty-result / ambiguous / transient-error clarification path. Useful for read-only tools (\`memory_recall\`, \`workspace_list\`) where empty results are normal.
+
+Explicit clarification hints on the tool result itself (\`result.metadata.clarification\`) are still respected — exclusion only suppresses the implicit classifier path.
+
+### 2. \`createIdempotencyGuard(inner, options?)\`
+
+Registry wrapper that blocks the 2nd identical \`(name + JSON.stringify(input))\` tool call within a turn. Returns a structured \`redundant_call_blocked\` error with consumer-configured drill-in alternatives. Catches the pattern where models interleave identical \`workspace_search\` calls between other tools to dodge consecutive-loop detectors.
+
+\`\`\`ts
+const wrapped = createIdempotencyGuard(myRegistry, {
+  alternativesFor: (call) => [
+    'Drill into the top result with workspace_read',
+    'Refine the query with a path filter',
+  ],
+  maxTurns: 50,
+});
+\`\`\`
+
+### 3. \`GitHubPublicFetcher\` + \`createGitHubPublicReviewToolRegistry\`
+
+Unauthenticated \`api.github.com\` fetcher. Pulls README + \`package.json\` + top-level layout + recent commits for any public repo. Exposed as a single \`github_public_review({ owner, repo })\` tool.
+
+Closes the cross-org external-repo review use case — "review montanaflynn/headless-terminal vs ours" — which authenticated tools (\`github_specialist\`, \`workspace_search\`) can't answer.
+
+Cloudflare Workers safe (\`globalThis.fetch\`, every Response consumed or cancelled).
+
+### 4. Tool-discipline prompt fragments
+
+Three new exports next to \`HALLUCINATION_PREVENTION_CLAUSES\`:
+
+- \`DRILL_IN_DISCIPLINE_CLAUSE\` — drill into the result you got, don't re-issue the same enumeration query.
+- \`TOOL_INPUT_SHAPE_REMINDER_CLAUSE\` — tool input schemas describe SHAPE, not VALUE; don't pass schema descriptions as values.
+- \`EXTERNAL_REPO_STEER_CLAUSE\` — for external public repos, use \`github_public_review\`, not \`github_specialist\` / \`workspace_search\`.
+
+Plus a \`TOOL_DISCIPLINE_CLAUSES\` bundle for "include all three".
+
+### 5. \`HarnessInvalidOutputCode\` + OpenRouter adapter wiring
+
+New optional \`code\` field on \`HarnessInvalidOutput\` populated by the OpenRouter adapter:
+
+\`\`\`ts
+type HarnessInvalidOutputCode =
+  | 'credits_exhausted'
+  | 'rate_limited'
+  | 'timeout'
+  | 'invalid_request'
+  | 'context_length_exceeded'
+  | 'model_not_found'
+  | 'auth_failed'
+  | 'unknown';
+\`\`\`
+
+Lets consumers \`switch (output.code)\` instead of substring-matching the free-text \`reason\`. Body-text classification (e.g. "out of credits", "context length") wins over status-based fallback so the credits-exhausted case classifies correctly regardless of HTTP code.
+
+\`kind\` (transient / provider_error) and \`reason\` are unchanged.
+
+## Backwards compatibility
+
+- All five changes are additive: new optional fields, new opt-in factories, new exports.
+- Existing function signatures unchanged. Existing field shapes unchanged. Existing prompt fragments unchanged.
+- Single minor bump on \`@agent-assistant/harness\`.
+
+## Test plan
+
+- [x] \`npx vitest run packages/harness/\` — green.
+- [x] \`cd packages/harness && npx tsc --noEmit\` — clean.
+- [x] Each primitive has happy / edge / failure-path tests.
+- [x] OpenRouter adapter classification covers 401/403/404/408/429/500 + body-text overrides for credits & context-length.
+- [x] \`grep "import.*fetch" packages/harness/src/tools/github-public-fetcher.ts\` returns nothing (Cloudflare Workers safe).
+
+## Followups
+
+- Sage adoption (separate PR in the sage repo) — drops the local \`withRedundantCallGuard\`, the local clarification wrapper that filters memory_recall, the local \`GitHubPublicFetcher\`, the inlined prompt-extension strings, and the substring-matching \`getUserFacingErrorMessage\` in favor of these upstream exports.
+- Consider per-call-id (vs name+input) keying as a future option on \`createIdempotencyGuard\` for tools that have side effects.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+PRBODY
+wc -l tmp/aa-harness-pr-body.md`,
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('open-pr', {
+      type: 'deterministic',
+      dependsOn: ['write-pr-body'],
+      command:
+        'PR_URL=$(gh pr create --title "feat(harness): clarification exclude-tools, idempotency guard, github-public-review, prompt fragments, openrouter error codes" --body-file tmp/aa-harness-pr-body.md) && echo "PR: $PR_URL"',
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+    .run({ cwd: process.cwd() });
+
+  console.log('Workflow status:', result.status);
+  if (result.status === 'failed') process.exit(1);
+}
+
+runWorkflow().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/improve-harness-primitives/README.md
+++ b/workflows/improve-harness-primitives/README.md
@@ -1,0 +1,61 @@
+# improve-harness-primitives
+
+Five primitives lifted upstream from sage's Slack-bot failure-mode fixes
+(sage PR #155). Each was a sage-side workaround for something general
+enough that any `@agent-assistant/harness` consumer would re-invent.
+Pulling them upstream lets sage drop its local copies in a follow-up
+adoption PR — and gives future consumers a head start.
+
+## Primitives
+
+| # | Sub | Primitive | Why |
+|---|---|---|---|
+| 1 | `01-clarification-exclude-tools.ts` | `excludeToolNames` option on `createToolEvidenceClarificationHook` | Read-only tools (memory_recall) shouldn't trigger empty-result clarifications. Today sage wraps locally; this lifts the join point upstream. |
+| 2 | `02-idempotency-guard.ts` | `createIdempotencyGuard(inner, options?)` | Block 2nd identical (name + input) tool call within a turn. Catches the "interleave to dodge the consecutive-loop detector" pattern. |
+| 3 | `03-github-public-review.ts` | `GitHubPublicFetcher` + `createGitHubPublicReviewToolRegistry` | Closes the cross-org external public-repo review use case. Unauthenticated `api.github.com`, Workers-safe. |
+| 4 | `04-prompt-fragments.ts` | `DRILL_IN_DISCIPLINE_CLAUSE`, `TOOL_INPUT_SHAPE_REMINDER_CLAUSE`, `EXTERNAL_REPO_STEER_CLAUSE` (+ `TOOL_DISCIPLINE_CLAUSES` bundle) | Three near-identical nudges every harness consumer authors locally — co-locate with `HALLUCINATION_PREVENTION_CLAUSES`. |
+| 5 | `05-openrouter-error-codes.ts` | `HarnessInvalidOutputCode` + OpenRouter adapter wiring | Stable machine-readable subcode (credits_exhausted / rate_limited / timeout / …) so consumers stop substring-matching `reason`. |
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `00-execute.ts` | Master — applies `applyAgentAssistantRepoSetup` once, then runs subs sequentially as deterministic shell steps |
+| `01-clarification-exclude-tools.ts` | Sub 1 — additive option on existing clarification factory |
+| `02-idempotency-guard.ts` | Sub 2 — new registry wrapper module |
+| `03-github-public-review.ts` | Sub 3 — new fetcher + tool registry |
+| `04-prompt-fragments.ts` | Sub 4 — three new exports + bundle |
+| `05-openrouter-error-codes.ts` | Sub 5 — type extension + adapter wiring |
+| `06-publish-pr.ts` | Holistic lead review + commit + push + PR |
+
+## Run
+
+```bash
+agent-relay run workflows/improve-harness-primitives/00-execute.ts
+```
+
+Each sub fails fast with `process.exit(1)` if its tests / tsc don't
+pass. Master also greps stdout for `Workflow status: failed` as a second
+guard (per memory: agent-relay run can exit 0 even when the inner
+workflow fails). Branch left at `feat/improve-harness-primitives` on
+failure for inspection.
+
+## Backwards compatibility
+
+All changes are additive:
+
+- New optional `excludeToolNames` field on existing options interface.
+- New `createIdempotencyGuard` factory — opt-in via wrapping.
+- New `GitHubPublicFetcher` + tool registry — separate module.
+- New prompt fragment exports next to existing ones.
+- New optional `code` field on `HarnessInvalidOutput`. `kind` and `reason` unchanged.
+
+Single minor bump on `@agent-assistant/harness`.
+
+## Followup (not in this workflow)
+
+Sage adoption PR drops sage's local `withRedundantCallGuard`, the local
+clarification wrapper filtering `memory_recall`, sage's
+`GitHubPublicFetcher`, the inlined prompt-extension strings, and the
+substring-matching `getUserFacingErrorMessage` in favor of these
+upstream exports.


### PR DESCRIPTION
## Summary

Five primitives lifted upstream from sage's Slack-bot failure-mode fixes (sage PR #155). Each was a sage-side workaround for something general enough that any `@agent-assistant/harness` consumer would re-invent. Pulling them upstream lets sage drop its local copies in a follow-up adoption PR.

## Primitives

### 1. `excludeToolNames` on `createToolEvidenceClarificationHook`

Adds an opt-out list of tool names that should NEVER trigger the implicit empty-result / ambiguous / transient-error clarification path. Useful for read-only tools (`memory_recall`, `workspace_list`) where empty results are normal.

Explicit clarification hints on the tool result itself (`result.metadata.clarification`) are still respected — exclusion only suppresses the implicit classifier path.

### 2. `createIdempotencyGuard(inner, options?)`

Registry wrapper that blocks the 2nd identical `(name + JSON.stringify(input))` tool call within a turn. Returns a structured `redundant_call_blocked` error with consumer-configured drill-in alternatives. Catches the pattern where models interleave identical `workspace_search` calls between other tools to dodge consecutive-loop detectors.

```ts
const wrapped = createIdempotencyGuard(myRegistry, {
  alternativesFor: (call) => [
    'Drill into the top result with workspace_read',
    'Refine the query with a path filter',
  ],
  maxTurns: 50,
});
```

### 3. `GitHubPublicFetcher` + `createGitHubPublicReviewToolRegistry`

Unauthenticated `api.github.com` fetcher. Pulls README + `package.json` + top-level layout + recent commits for any public repo. Exposed as a single `github_public_review({ owner, repo })` tool.

Closes the cross-org external-repo review use case — "review montanaflynn/headless-terminal vs ours" — which authenticated tools (`github_specialist`, `workspace_search`) can't answer.

Cloudflare Workers safe (`globalThis.fetch`, every Response consumed or cancelled).

### 4. Tool-discipline prompt fragments

Three new exports next to `HALLUCINATION_PREVENTION_CLAUSES`:

- `DRILL_IN_DISCIPLINE_CLAUSE` — drill into the result you got, don't re-issue the same enumeration query.
- `TOOL_INPUT_SHAPE_REMINDER_CLAUSE` — tool input schemas describe SHAPE, not VALUE; don't pass schema descriptions as values.
- `EXTERNAL_REPO_STEER_CLAUSE` — for external public repos, use `github_public_review`, not `github_specialist` / `workspace_search`.

Plus a `TOOL_DISCIPLINE_CLAUSES` bundle for "include all three".

### 5. `HarnessInvalidOutputCode` + OpenRouter adapter wiring

New optional `code` field on `HarnessInvalidOutput` populated by the OpenRouter adapter:

```ts
type HarnessInvalidOutputCode =
  | 'credits_exhausted'
  | 'rate_limited'
  | 'timeout'
  | 'invalid_request'
  | 'context_length_exceeded'
  | 'model_not_found'
  | 'auth_failed'
  | 'unknown';
```

Lets consumers `switch (output.code)` instead of substring-matching the free-text `reason`. Body-text classification (e.g. "out of credits", "context length") wins over status-based fallback so the credits-exhausted case classifies correctly regardless of HTTP code.

`kind` (transient / provider_error) and `reason` are unchanged.

## Backwards compatibility

- All five changes are additive: new optional fields, new opt-in factories, new exports.
- Existing function signatures unchanged. Existing field shapes unchanged. Existing prompt fragments unchanged.
- Single minor bump on `@agent-assistant/harness`.

## Test plan

- [x] `npx vitest run packages/harness/` — green.
- [x] `cd packages/harness && npx tsc --noEmit` — clean.
- [x] Each primitive has happy / edge / failure-path tests.
- [x] OpenRouter adapter classification covers 401/403/404/408/429/500 + body-text overrides for credits & context-length.
- [x] `grep "import.*fetch" packages/harness/src/tools/github-public-fetcher.ts` returns nothing (Cloudflare Workers safe).

## Followups

- Sage adoption (separate PR in the sage repo) — drops the local `withRedundantCallGuard`, the local clarification wrapper that filters memory_recall, the local `GitHubPublicFetcher`, the inlined prompt-extension strings, and the substring-matching `getUserFacingErrorMessage` in favor of these upstream exports.
- Consider per-call-id (vs name+input) keying as a future option on `createIdempotencyGuard` for tools that have side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
