### PR TITLE
fix(harness): createIdempotencyGuard returns successful tool result, not unrecoverable error (0.8.4)

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/idempotency-guard.test.ts
+++ b/packages/harness/src/idempotency-guard.test.ts
@@ -251,6 +251,69 @@ describe('createIdempotencyGuard', () => {
     expect(inner.execute).toHaveBeenCalledTimes(2);
   });
 
+  it('does not cache a retryable error result, so retry attempts reach the inner tool', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const errorResult: HarnessToolResult = {
+      callId: call.id,
+      toolName: call.name,
+      status: 'error',
+      error: {
+        code: 'transient',
+        message: 'transient failure',
+        retryable: true,
+      },
+    };
+    const successResult = makeResult(call, { output: 'recovered-output' });
+    const execute = vi
+      .fn<HarnessToolRegistry['execute']>()
+      .mockResolvedValueOnce(errorResult)
+      .mockResolvedValueOnce(successResult);
+    const inner = makeInnerRegistry({ executeImpl: execute });
+    const guard = createIdempotencyGuard(inner);
+
+    const first = await guard.execute(call, context);
+    const second = await guard.execute(call, context);
+
+    expect(first).toEqual(errorResult);
+    // Without the success-only cache rule, the second call would hit the
+    // guard's cache and return a fake "duplicate call" success — silently
+    // exiting executeToolWithRetry without ever re-invoking the tool.
+    expect(second).toEqual(successResult);
+    expect(second.metadata?.idempotencyGuard).toBeUndefined();
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a non-retryable error result either', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const errorResult: HarnessToolResult = {
+      callId: call.id,
+      toolName: call.name,
+      status: 'error',
+      error: {
+        code: 'permanent',
+        message: 'permanent failure',
+        retryable: false,
+      },
+    };
+    const successResult = makeResult(call, { output: 'recovered-output' });
+    const execute = vi
+      .fn<HarnessToolRegistry['execute']>()
+      .mockResolvedValueOnce(errorResult)
+      .mockResolvedValueOnce(successResult);
+    const inner = makeInnerRegistry({ executeImpl: execute });
+    const guard = createIdempotencyGuard(inner);
+
+    const first = await guard.execute(call, context);
+    const second = await guard.execute(call, context);
+
+    expect(first).toEqual(errorResult);
+    expect(second).toEqual(successResult);
+    expect(second.metadata?.idempotencyGuard).toBeUndefined();
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
   it('reports the original per-turn iteration number in duplicate results', async () => {
     const inner = makeInnerRegistry();
     const guard = createIdempotencyGuard(inner);

--- a/packages/harness/src/idempotency-guard.test.ts
+++ b/packages/harness/src/idempotency-guard.test.ts
@@ -97,7 +97,7 @@ describe('createIdempotencyGuard', () => {
     expect(inner.execute).toHaveBeenCalledWith(call, context);
   });
 
-  it('blocks a second identical call within the same turn', async () => {
+  it('blocks a second identical call within the same turn as a successful tool result', async () => {
     const call = makeCall('call-1');
     const context = makeContext('turn-1');
     const inner = makeInnerRegistry();
@@ -106,10 +106,22 @@ describe('createIdempotencyGuard', () => {
     const first = await guard.execute(call, context);
     const second = await guard.execute(call, context);
 
+    // The blocked duplicate is reported as a successful tool result so
+    // the harness keeps the turn alive — otherwise a `retryable !==
+    // true` tool error gets classified as `tool_error_unrecoverable`
+    // and the model never sees the alternatives. Integration-test gap:
+    // we don't run the full harness loop here; `harness.tool-retry.test.ts`
+    // exercises the classifier path separately.
     expect(first.status).toBe('success');
-    expect(second.status).toBe('error');
-    expect(second.error?.code).toBe('redundant_call_blocked');
-    expect(second.error?.retryable).toBe(false);
+    expect(second.status).toBe('success');
+    expect(second.error).toBeUndefined();
+    expect(second.output).toContain('was already called this turn at iteration 1');
+    expect(second.output).toContain("Repeating the same call won't return new information");
+    expect(second.metadata?.idempotencyGuard).toMatchObject({
+      blocked: true,
+      code: 'redundant_call_blocked',
+      previousIteration: 1,
+    });
     expect(inner.execute).toHaveBeenCalledTimes(1);
   });
 
@@ -148,8 +160,8 @@ describe('createIdempotencyGuard', () => {
     const second = await guard.execute(makeCall('call-2', { b: 2, a: 1 }), context);
 
     expect(first.status).toBe('success');
-    expect(second.status).toBe('error');
-    expect(second.error?.code).toBe('redundant_call_blocked');
+    expect(second.status).toBe('success');
+    expect(second.metadata?.idempotencyGuard).toMatchObject({ blocked: true });
     expect(inner.execute).toHaveBeenCalledTimes(1);
   });
 
@@ -169,7 +181,7 @@ describe('createIdempotencyGuard', () => {
     expect(inner.listAvailable).toHaveBeenCalledWith(input);
   });
 
-  it('includes alternativesFor output in the blocked error message', async () => {
+  it('includes alternativesFor output in the blocked tool result body', async () => {
     const call = makeCall('call-1');
     const context = makeContext('turn-1');
     const inner = makeInnerRegistry();
@@ -181,8 +193,9 @@ describe('createIdempotencyGuard', () => {
 
     expect(alternativesFor).toHaveBeenCalledTimes(1);
     expect(alternativesFor).toHaveBeenCalledWith(call);
-    expect(result.error?.message).toContain('try X');
-    expect(result.error?.message).toContain('try Y');
+    expect(result.status).toBe('success');
+    expect(result.output).toContain('try X');
+    expect(result.output).toContain('try Y');
   });
 
   it('uses the default fallback line when alternativesFor is missing or empty', async () => {
@@ -201,8 +214,8 @@ describe('createIdempotencyGuard', () => {
     await emptyHook.execute(call, context);
     const emptyAlternatives = await emptyHook.execute(call, context);
 
-    expect(withoutHook.error?.message).toContain(defaultTip);
-    expect(emptyAlternatives.error?.message).toContain(defaultTip);
+    expect(withoutHook.output).toContain(defaultTip);
+    expect(emptyAlternatives.output).toContain(defaultTip);
   });
 
   it('evicts the oldest turn when maxTurns is exceeded', async () => {
@@ -238,7 +251,7 @@ describe('createIdempotencyGuard', () => {
     expect(inner.execute).toHaveBeenCalledTimes(2);
   });
 
-  it('reports the original per-turn iteration number in duplicate errors', async () => {
+  it('reports the original per-turn iteration number in duplicate results', async () => {
     const inner = makeInnerRegistry();
     const guard = createIdempotencyGuard(inner);
     const context = makeContext('turn-1');
@@ -251,7 +264,17 @@ describe('createIdempotencyGuard', () => {
     const duplicateFirst = await guard.execute(makeCall('call-3', { q: 'a' }), context);
     const duplicateSecond = await guard.execute(makeCall('call-4', { q: 'b' }), context);
 
-    expect(duplicateFirst.error?.message).toContain('iteration 1');
-    expect(duplicateSecond.error?.message).toContain('iteration 2');
+    expect(duplicateFirst.status).toBe('success');
+    expect(duplicateSecond.status).toBe('success');
+    expect(duplicateFirst.output).toContain('iteration 1');
+    expect(duplicateSecond.output).toContain('iteration 2');
+    expect(duplicateFirst.metadata?.idempotencyGuard).toMatchObject({
+      blocked: true,
+      previousIteration: 1,
+    });
+    expect(duplicateSecond.metadata?.idempotencyGuard).toMatchObject({
+      blocked: true,
+      previousIteration: 2,
+    });
   });
 });

--- a/packages/harness/src/idempotency-guard.ts
+++ b/packages/harness/src/idempotency-guard.ts
@@ -178,13 +178,21 @@ export function createIdempotencyGuard(
       }
 
       const result = await inner.execute(call, context);
-      const iteration = nextIterations.get(turnId) ?? 1;
-      turnCache.set(signature, {
-        iteration,
-        outputChars: result.output?.length ?? 0,
-        firstCalledAt: Date.now(),
-      });
-      nextIterations.set(turnId, iteration + 1);
+      // Only cache successful results. Caching errors would let a retryable
+      // failure mask a subsequent retry as a "duplicate call" success — see
+      // executeToolWithRetry: it re-invokes the same (name, input), and a
+      // cache hit here returns status:'success' so the retry loop exits
+      // without ever re-running the inner tool. Skipping the cache on
+      // non-success keeps the retry path live.
+      if (result.status === 'success') {
+        const iteration = nextIterations.get(turnId) ?? 1;
+        turnCache.set(signature, {
+          iteration,
+          outputChars: result.output?.length ?? 0,
+          firstCalledAt: Date.now(),
+        });
+        nextIterations.set(turnId, iteration + 1);
+      }
       return result;
     },
   };

--- a/packages/harness/src/idempotency-guard.ts
+++ b/packages/harness/src/idempotency-guard.ts
@@ -95,15 +95,25 @@ function duplicateResult(
     ...buildAlternatives(call, options).map((item) => `- ${item}`),
   ].join('\n');
 
+  // Return a successful tool result, not an error. The whole point of
+  // surfacing alternatives is for the model to read them and pick a
+  // different tool — but the harness classifies any tool error with
+  // `retryable !== true` as `tool_error_unrecoverable` and terminates
+  // the turn, which means the model never sees this message. By
+  // delivering the teaching message as the tool's `output` we keep the
+  // turn alive so the model can adapt.
   return {
     callId: call.id,
     toolName: call.name,
-    status: 'error',
-    output: '',
-    error: {
-      code: 'redundant_call_blocked',
-      message,
-      retryable: false,
+    status: 'success',
+    output: message,
+    metadata: {
+      idempotencyGuard: {
+        blocked: true,
+        code: 'redundant_call_blocked',
+        previousIteration: previous.iteration,
+        previousOutputChars: previous.outputChars,
+      },
     },
   };
 }


### PR DESCRIPTION
## Summary
Fixes a real prod bug in 0.8.3's `createIdempotencyGuard`: when a duplicate call is detected, the guard returned a tool error with `errorCode: "redundant_call_blocked"` + `retryable: false`, which the harness classified as `tool_error_unrecoverable` and **terminated the turn**. The model never got to read the alternatives message and adapt.

Now: the guard returns a **successful** tool result whose `output` body is the existing teaching message + `alternativesFor` strings. The model sees the output, picks a different tool, and the turn continues. The blocked-duplicate signal is still preserved on `result.metadata.idempotencyGuard` (`{ blocked: true, code: 'redundant_call_blocked', previousIteration, previousOutputChars }`) for telemetry / observability consumers.

This is Option A from the brief — local to the guard, no harness-classifier changes.

## Repro from sage prod (2026-04-29)
```
iter 1: workspace_list /github/repos/X → success (501 chars)
iter 2: workspace_list /github/repos/X → tool_failed
        errorCode: "redundant_call_blocked", retryable: false
turn_finished: outcome=failed, stopReason=tool_error_unrecoverable
slack user saw: "I could not complete that request right now."
```

## What changed
- `packages/harness/src/idempotency-guard.ts` — `duplicateResult()` now returns `{ status: 'success', output: <teaching message + alternatives>, metadata: { idempotencyGuard: { blocked: true, code, previousIteration, previousOutputChars } } }` instead of `{ status: 'error', error: { code, message, retryable: false } }`.
- `packages/harness/src/idempotency-guard.test.ts` — updated 5 existing assertions and added new metadata assertions to match the new shape.
- `packages/harness/package.json` — `0.8.3` → `0.8.4`.

## Tests
- [x] Duplicate call returns successful result, not error (`idempotency-guard.test.ts:100`)
- [x] Output body contains alternatives message (`idempotency-guard.test.ts:184`)
- [x] Default fallback line surfaced via `output` (`idempotency-guard.test.ts:202`)
- [x] Per-turn iteration number reported in `output` and `metadata` (`idempotency-guard.test.ts:253`)
- [x] `metadata.idempotencyGuard.blocked === true` carries the redundant-call signal for consumers
- [ ] Integration-test gap: we don't drive the full harness loop in this unit suite. The classifier path is exercised by `harness.tool-retry.test.ts` and unaffected — what changed is upstream: the guard never produces a `retryable !== true` tool error anymore, so it can't trigger `tool_error_unrecoverable` from this path.

`npm test --workspace=@agent-assistant/harness` → 250 / 250 pass.
`npx tsc --noEmit` (in `packages/harness`) → clean.

## Version
Bumps `@agent-assistant/harness` 0.8.3 → 0.8.4.

## Migration notes for consumers
If a consumer was previously matching `result.status === 'error' && result.error?.code === 'redundant_call_blocked'` for telemetry, switch to checking `result.metadata?.idempotencyGuard?.blocked === true` (or `result.metadata?.idempotencyGuard?.code === 'redundant_call_blocked'`). The `output` body remains the same teaching message; only the envelope shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
