### PR TITLE
feat(harness): idempotency guard escalation (0.9.0)

### DIFF
--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/idempotency-guard.test.ts
+++ b/packages/harness/src/idempotency-guard.test.ts
@@ -120,6 +120,8 @@ describe('createIdempotencyGuard', () => {
     expect(second.metadata?.idempotencyGuard).toMatchObject({
       blocked: true,
       code: 'redundant_call_blocked',
+      tier: 1,
+      duplicateCount: 1,
       previousIteration: 1,
     });
     expect(inner.execute).toHaveBeenCalledTimes(1);
@@ -339,5 +341,135 @@ describe('createIdempotencyGuard', () => {
       blocked: true,
       previousIteration: 2,
     });
+  });
+
+  it('tier 2: second duplicate returns a directive that inlines the prior output', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const priorOutput = 'project-list:\n- relaycast (12 files)\n- agent-assistant (47 files)\n- sage (203 files)';
+    const inner = makeInnerRegistry({
+      executeImpl: vi.fn(async () => makeResult(call, { output: priorOutput })),
+    });
+    const guard = createIdempotencyGuard(inner, {
+      alternativesFor: () => ['Read a specific file', 'Stop and answer the user'],
+    });
+
+    await guard.execute(call, context); // tier 0 — populates cache
+    const tierOne = await guard.execute(call, context); // tier 1 — soft teaching
+    const tierTwo = await guard.execute(call, context); // tier 2 — directive
+
+    expect(tierOne.status).toBe('success');
+    expect(tierOne.output).toContain("Repeating the same call won't return new information");
+
+    expect(tierTwo.status).toBe('success');
+    expect(tierTwo.error).toBeUndefined();
+    expect(tierTwo.output).toContain('STOP.');
+    expect(tierTwo.output).toContain('--- DATA FROM PRIOR CALL ---');
+    expect(tierTwo.output).toContain('--- END DATA ---');
+    expect(tierTwo.output).toContain('relaycast (12 files)');
+    expect(tierTwo.output).toContain('Read a specific file');
+    expect(tierTwo.metadata?.idempotencyGuard).toMatchObject({
+      blocked: true,
+      code: 'redundant_call_blocked',
+      tier: 2,
+      duplicateCount: 2,
+      previousIteration: 1,
+    });
+    // Inner tool was only invoked the first time.
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('tier 3: third duplicate returns a non-retryable error so the harness fails fast', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+
+    await guard.execute(call, context); // tier 0
+    await guard.execute(call, context); // tier 1
+    await guard.execute(call, context); // tier 2
+    const tierThree = await guard.execute(call, context); // tier 3 — abort
+
+    expect(tierThree.status).toBe('error');
+    expect(tierThree.error).toBeDefined();
+    expect(tierThree.error?.code).toBe('redundant_call_loop_aborted');
+    expect(tierThree.error?.retryable).toBe(false);
+    expect(tierThree.metadata?.idempotencyGuard).toMatchObject({
+      tier: 3,
+      code: 'redundant_call_loop_aborted',
+    });
+    // Inner tool only invoked once across all four guard calls.
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+
+    // A fifth identical call still aborts (tier stays at 3+).
+    const tierFour = await guard.execute(call, context);
+    expect(tierFour.status).toBe('error');
+    expect(tierFour.error?.code).toBe('redundant_call_loop_aborted');
+  });
+
+  it('tier 2: truncates a large prior output to ~1200 chars in the directive body', async () => {
+    const call = makeCall('call-1');
+    const context = makeContext('turn-1');
+    const bigOutput = 'X'.repeat(5000);
+    const inner = makeInnerRegistry({
+      executeImpl: vi.fn(async () => makeResult(call, { output: bigOutput })),
+    });
+    const guard = createIdempotencyGuard(inner);
+
+    await guard.execute(call, context);
+    await guard.execute(call, context);
+    const tierTwo = await guard.execute(call, context);
+
+    expect(tierTwo.status).toBe('success');
+    expect(tierTwo.output).toBeDefined();
+    expect(tierTwo.output).toContain('--- DATA FROM PRIOR CALL ---');
+    expect(tierTwo.output).toContain('[truncated]');
+
+    // The inlined data section should contain at most ~1200 chars of the
+    // 'X' payload (plus the truncation marker), not the full 5000.
+    const xCount = (tierTwo.output ?? '').match(/X/g)?.length ?? 0;
+    expect(xCount).toBeLessThanOrEqual(1200);
+    // Sanity: it should still contain a healthy chunk.
+    expect(xCount).toBeGreaterThanOrEqual(1000);
+  });
+
+  it('different signatures escalate independently', async () => {
+    const callA = makeCall('call-a', { q: 'a' });
+    const callA2 = makeCall('call-a-2', { q: 'a' });
+    const callB = makeCall('call-b', { q: 'b' });
+    const context = makeContext('turn-1');
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+
+    await guard.execute(callA, context); // A: tier 0
+    const aDup = await guard.execute(callA2, context); // A: tier 1 (soft)
+    const bFirst = await guard.execute(callB, context); // B: tier 0 (passes through)
+
+    expect(aDup.metadata?.idempotencyGuard).toMatchObject({ tier: 1, duplicateCount: 1 });
+    expect(bFirst.metadata?.idempotencyGuard).toBeUndefined();
+    expect(bFirst.status).toBe('success');
+    // A: 1 inner call. B: 1 inner call. Total: 2.
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('per-turn isolation: duplicate count resets when turnId changes', async () => {
+    const call = makeCall('call-1');
+    const inner = makeInnerRegistry();
+    const guard = createIdempotencyGuard(inner);
+
+    // Turn 1: tier 0, 1, 2
+    await guard.execute(call, makeContext('turn-1'));
+    await guard.execute(call, makeContext('turn-1'));
+    const turn1Tier2 = await guard.execute(call, makeContext('turn-1'));
+    expect(turn1Tier2.metadata?.idempotencyGuard).toMatchObject({ tier: 2 });
+
+    // Turn 2: should restart from tier 0 — first call passes through.
+    const turn2First = await guard.execute(call, makeContext('turn-2'));
+    expect(turn2First.metadata?.idempotencyGuard).toBeUndefined();
+    expect(turn2First.status).toBe('success');
+
+    // Turn 2: second call is tier 1, not tier 2.
+    const turn2Second = await guard.execute(call, makeContext('turn-2'));
+    expect(turn2Second.metadata?.idempotencyGuard).toMatchObject({ tier: 1, duplicateCount: 1 });
   });
 });

--- a/packages/harness/src/idempotency-guard.ts
+++ b/packages/harness/src/idempotency-guard.ts
@@ -21,11 +21,32 @@ interface CachedCallRecord {
   iteration: number;
   outputChars: number;
   firstCalledAt: number;
+  /**
+   * Number of duplicate hits observed for this signature in the current
+   * turn. Starts at 0 at cache-set time; incremented every time the
+   * guard short-circuits on a subsequent identical call. Drives the
+   * three-tier escalation (soft teaching → directive + inlined output →
+   * fail-fast error).
+   */
+  duplicateCount: number;
+  /**
+   * A truncated copy of the prior successful output body, used by the
+   * tier-2 directive message so the model gets the data inlined into
+   * the new tool result instead of just being told to "use the prior
+   * output." Capped at PRIOR_OUTPUT_CACHE_CAP at cache-set time so the
+   * per-turn cache stays bounded.
+   */
+  priorOutput: string;
 }
 
 const DEFAULT_MAX_TURNS = 50;
 const DEFAULT_ALTERNATIVE =
   'Drill into a specific result from the previous output (cite a path or id) instead of re-searching.';
+
+/** Hard cap on stored prior output (bytes of UTF-16). 4KB per entry. */
+const PRIOR_OUTPUT_CACHE_CAP = 4096;
+/** How much of the prior output we inline into the tier-2 directive. */
+const DIRECTIVE_INLINE_CAP = 1200;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -85,7 +106,19 @@ function buildAlternatives(
     : [DEFAULT_ALTERNATIVE];
 }
 
-function duplicateResult(
+function truncate(value: string, cap: number): string {
+  if (value.length <= cap) {
+    return value;
+  }
+  return `${value.slice(0, cap)}…[truncated]`;
+}
+
+/**
+ * Tier 1 (first duplicate). Gentle teaching message — the original 0.8.5
+ * behavior. Returns a successful tool result so the harness keeps the
+ * turn alive and the model gets a chance to read the alternatives.
+ */
+function softDuplicateResult(
   call: HarnessToolCall,
   previous: CachedCallRecord,
   options: IdempotencyGuardOptions | undefined,
@@ -95,13 +128,6 @@ function duplicateResult(
     ...buildAlternatives(call, options).map((item) => `- ${item}`),
   ].join('\n');
 
-  // Return a successful tool result, not an error. The whole point of
-  // surfacing alternatives is for the model to read them and pick a
-  // different tool — but the harness classifies any tool error with
-  // `retryable !== true` as `tool_error_unrecoverable` and terminates
-  // the turn, which means the model never sees this message. By
-  // delivering the teaching message as the tool's `output` we keep the
-  // turn alive so the model can adapt.
   return {
     callId: call.id,
     toolName: call.name,
@@ -111,6 +137,84 @@ function duplicateResult(
       idempotencyGuard: {
         blocked: true,
         code: 'redundant_call_blocked',
+        tier: 1,
+        duplicateCount: previous.duplicateCount,
+        previousIteration: previous.iteration,
+        previousOutputChars: previous.outputChars,
+      },
+    },
+  };
+}
+
+/**
+ * Tier 2 (second duplicate). Directive message with the prior output
+ * inlined directly into the new tool result. The model has the data
+ * right there — no excuse to re-call.
+ */
+function directiveDuplicateResult(
+  call: HarnessToolCall,
+  previous: CachedCallRecord,
+  options: IdempotencyGuardOptions | undefined,
+): HarnessToolResult {
+  const inlined = truncate(previous.priorOutput, DIRECTIVE_INLINE_CAP);
+  const alternatives = buildAlternatives(call, options).map((item) => `- ${item}`);
+
+  const message = [
+    `STOP. You already called ${call.name} with these exact arguments TWICE this turn (iteration ${previous.iteration} and again since). The data is below — use it instead of calling again.`,
+    '',
+    '--- DATA FROM PRIOR CALL ---',
+    inlined,
+    '--- END DATA ---',
+    '',
+    `Do NOT call ${call.name} with these arguments a fourth time. Either:`,
+    ...alternatives,
+    '',
+    'If none apply, summarize what you have for the user and stop.',
+  ].join('\n');
+
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'success',
+    output: message,
+    metadata: {
+      idempotencyGuard: {
+        blocked: true,
+        code: 'redundant_call_blocked',
+        tier: 2,
+        duplicateCount: previous.duplicateCount,
+        previousIteration: previous.iteration,
+        previousOutputChars: previous.outputChars,
+      },
+    },
+  };
+}
+
+/**
+ * Tier 3+ (third+ duplicate). Fail-fast. Returns a non-retryable error
+ * that the harness's existing classifier maps to
+ * `tool_error_unrecoverable`, terminating the turn instead of letting
+ * the model grind through more identical no-ops.
+ */
+function abortDuplicateResult(
+  call: HarnessToolCall,
+  previous: CachedCallRecord,
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'error',
+    error: {
+      code: 'redundant_call_loop_aborted',
+      message: `Aborting turn: ${call.name} was called ${previous.duplicateCount + 1} times this turn with identical arguments after two escalating warnings. Original output (${previous.outputChars} chars) is in the transcript at iteration ${previous.iteration}.`,
+      retryable: false,
+    },
+    metadata: {
+      idempotencyGuard: {
+        blocked: true,
+        code: 'redundant_call_loop_aborted',
+        tier: 3,
+        duplicateCount: previous.duplicateCount,
         previousIteration: previous.iteration,
         previousOutputChars: previous.outputChars,
       },
@@ -174,7 +278,17 @@ export function createIdempotencyGuard(
 
       const previous = turnCache.get(signature);
       if (previous) {
-        return duplicateResult(call, previous, options);
+        previous.duplicateCount += 1;
+        // Tier ladder. duplicateCount==1 is the first duplicate (the second
+        // identical call overall). We escalate every subsequent duplicate
+        // until tier 3, which fails fast.
+        if (previous.duplicateCount === 1) {
+          return softDuplicateResult(call, previous, options);
+        }
+        if (previous.duplicateCount === 2) {
+          return directiveDuplicateResult(call, previous, options);
+        }
+        return abortDuplicateResult(call, previous);
       }
 
       const result = await inner.execute(call, context);
@@ -186,10 +300,13 @@ export function createIdempotencyGuard(
       // non-success keeps the retry path live.
       if (result.status === 'success') {
         const iteration = nextIterations.get(turnId) ?? 1;
+        const output = result.output ?? '';
         turnCache.set(signature, {
           iteration,
-          outputChars: result.output?.length ?? 0,
+          outputChars: output.length,
           firstCalledAt: Date.now(),
+          duplicateCount: 0,
+          priorOutput: truncate(output, PRIOR_OUTPUT_CACHE_CAP),
         });
         nextIterations.set(turnId, iteration + 1);
       }


### PR DESCRIPTION
## Summary
Escalating response in `createIdempotencyGuard`:
- 1st duplicate → soft teaching (existing)
- 2nd duplicate → directive message with **inlined truncated prior output** (model gets the data, not just an instruction to re-derive it)
- 3rd duplicate → retryable:false error `redundant_call_loop_aborted` → harness terminates turn immediately

## Repro from sage prod (2026-04-29)
`@Sage what's in AgentWorkforce/relaycast?`
- iter 1: workspace_list → success (12,804 chars)
- iter 2,3,5,6,7: workspace_list **same args** → 266-char teaching message ignored
- iter 7: `redundant_tool_loop` detector trips → turn failed → user gets generic reply

After: tier-2 directive at iter 3 inlines the listing data; tier-3 at iter 4 fails fast.

## Storage cost
Each cache entry now stores up to 4KB of the prior output (`priorOutput`, truncated at cache-set). Bounded by the existing `maxTurns` LRU cap (default 50).

## Tests
- [x] tier 1, 2, 3 escalation behavior
- [x] truncation on large prior outputs (5KB → 1200 inlined + `[truncated]`)
- [x] different signatures don't share counts
- [x] per-turn isolation (new turn restarts from tier 0)
- [x] 0.8.5 retryable-error pass-through still works
- [x] 18/18 idempotency-guard tests pass; 257/257 harness suite tests pass

## Version
`@agent-assistant/harness` 0.8.5 → 0.9.0 (minor bump for behavior change). No central error classifier changes were needed — `retryable:false` already maps to `tool_error_unrecoverable` in `harness.ts`.

## Coordination
A parallel sage PR adds a salvage path: when a turn fails with a tool-loop stop reason, sage synthesizes a final answer from the gathered tool outputs instead of just showing an error. Together these eliminate the prod failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
