### PR TITLE
fix(harness): clarification hook skips on retry-exhausted failures (0.9.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -251,7 +251,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/tool-evidence-clarification.test.ts
+++ b/packages/harness/src/tool-evidence-clarification.test.ts
@@ -140,7 +140,8 @@ describe('detectToolEvidenceClarification', () => {
   it('still honors explicit clarification hints on a failed tool result', () => {
     // The failed-tool short-circuit only suppresses the implicit
     // classifier path. Explicit hints (set deliberately by the tool
-    // author) still pass through.
+    // author) still pass through — provided the error is NOT a
+    // retry-exhausted transient failure (see retry-exhausted case below).
     const result = makeToolResult({
       status: 'error',
       metadata: { clarification: { question: 'Which org should I use?' } },
@@ -152,6 +153,58 @@ describe('detectToolEvidenceClarification', () => {
       reason: 'custom',
       metadata: { toolName: 'memory_recall' },
     });
+  });
+
+  it('skips explicit clarification when a retryable failure exhausted its retries', () => {
+    // Captured live in sage prod (2026-04-30): `github_specialist`
+    // exhausted 3 retry attempts, sage's tool-registry attached an
+    // explicit `transient_provider_error` clarification hint
+    // ("What exact repo owner/name should I retry with?") to the FINAL
+    // error result — but the user had already given a fully-specified
+    // repo. The harness's in-turn retry loop has already given up by the
+    // time the hook sees this; `retryable: true` describes IN-TURN
+    // retry potential which is moot post-retry-loop. We must skip
+    // clarification rather than mislead the user.
+    const result = makeToolResult({
+      toolName: 'github_specialist',
+      status: 'error',
+      metadata: {
+        clarification: {
+          question:
+            'The GitHub lookup hit a temporary provider error. What exact repo owner/name should I retry with?',
+          reason: 'transient_provider_error',
+        },
+      },
+      error: {
+        code: 'delegation_failed',
+        message: 'specialist timed out',
+        retryable: true,
+      },
+    });
+
+    expect(detectToolEvidenceClarification(result)).toBeNull();
+  });
+
+  it('skips structuredOutput clarification hints on retryable-exhausted failures too', () => {
+    // Same retry-exhausted gate covers structuredOutput clarification
+    // hints (some adapters attach via that channel rather than metadata).
+    const result = makeToolResult({
+      toolName: 'linear_specialist',
+      status: 'error',
+      structuredOutput: {
+        clarification: {
+          question: 'What exact issue key should I retry with?',
+          reason: 'transient_provider_error',
+        },
+      },
+      error: {
+        code: 'delegation_failed',
+        message: 'rate limited',
+        retryable: true,
+      },
+    });
+
+    expect(detectToolEvidenceClarification(result)).toBeNull();
   });
 
   it('treats empty or undefined excludeToolNames as no behavior change', () => {

--- a/packages/harness/src/tool-evidence-clarification.ts
+++ b/packages/harness/src/tool-evidence-clarification.ts
@@ -43,16 +43,38 @@ export function detectToolEvidenceClarification(
   result: HarnessToolResult,
   options: ToolEvidenceClarificationOptions = {},
 ): HarnessToolEvidenceClarification | null {
+  // Retry-exhausted short-circuit. When a tool returns
+  // `status: 'error'` with `retryable: true`, the harness has already run
+  // its in-turn retry loop (`executeToolWithRetry`) and given up — the
+  // final `lastResult` is what we see here. The `retryable` flag describes
+  // IN-TURN retry potential, which is moot post-retry-loop. Asking the
+  // user "what should I retry with?" misleads them: it implies the model
+  // can change the input and recover, but the call already failed N times
+  // with the same input the user gave. This MUST run before the explicit
+  // clarification path because tool authors sometimes attach a
+  // `transient_provider_error` clarification hint to retryable failures
+  // (e.g. sage's `buildTransientClarification`) which produces exactly
+  // the misleading "retry with what?" UX.
+  //
+  // Non-retryable explicit hints (e.g. `auth_failed` with no `retryable`
+  // flag, where the hint asks a real question like "which org?") are
+  // still honored below — those are deliberate clarifications, not
+  // retry-loop fallout.
+  if (result.status === 'error' && result.error?.retryable === true) {
+    return null;
+  }
+
   const explicit = readExplicitClarification(result);
   if (explicit) {
     return explicit;
   }
 
-  // Failed-tool short-circuit. Implicit clarification classifiers (empty
-  // results / ambiguous identifiers) inspect tool result *content* — but a
-  // failed tool's result frequently looks empty or thin, which would fire
-  // these classifiers even though the right action is to surface the
-  // failure or retry, not ask the user a clarifying question.
+  // Failed-tool short-circuit (non-retryable case). Implicit clarification
+  // classifiers (empty results / ambiguous identifiers) inspect tool
+  // result *content* — but a failed tool's result frequently looks empty
+  // or thin, which would fire these classifiers even though the right
+  // action is to surface the failure, not ask the user a clarifying
+  // question.
   //
   // This is independent of `excludeToolNames`: that option excludes a
   // specific tool by name; this short-circuit excludes ANY tool that


### PR DESCRIPTION
## Summary
Extends the clarification-skip hook (PR #70) to skip the EXPLICIT clarification path when a retryable tool failure exhausted its retries. Previously the explicit-hint reader ran before the failed-tool short-circuit, so tool authors that attached a `transient_provider_error` clarification hint to retryable failures still produced misleading "retry with what?" UX after the harness's in-turn retry loop gave up.

## Repro from sage prod (2026-04-30)
`@Sage what's in AgentWorkforce/relaycast?` ->
- iter 1: `github_specialist enumerate` -> 3 retry attempts, all `delegation_failed: timeout`
- final result: `status: error, retryable: true` with sage's `buildTransientClarification` hint attached on `metadata.clarification`
- harness: `stopReason: clarification_required`
- user reply: "What exact repo owner/name should I retry with?" — wrong; repo was already fully specified

## Fix
`detectToolEvidenceClarification` now short-circuits on `status === 'error' && error.retryable === true` BEFORE reading explicit clarification hints. The `retryable` flag describes IN-TURN retry potential (consumed by `executeToolWithRetry`); once we're past the retry loop, it is moot.

Non-retryable explicit hints (e.g. `auth_failed` carrying a real "which org?" question) still pass through — they are deliberate clarifications, not retry-loop fallout.

## Version
0.9.1 -> 0.9.2 (patch).

## Test plan
- [x] Retryable + exhausted explicit hint -> clarification skipped (new test)
- [x] Retryable + exhausted via structuredOutput.clarification -> skipped (new test)
- [x] Non-retryable failed tool with explicit hint (`auth_failed` "which org?") -> clarification fires (regression preserved)
- [x] Failed tool with empty-looking output -> clarification skipped (regression preserved)
- [x] No tool failures + genuine clarification need -> clarification fires (regression preserved via `harness.test.ts`)
- [x] `npm test --workspace=@agent-assistant/harness` -> 259/259 passing
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/agent-assistant/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
