### PR TITLE
Bump Relay dependency ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "packages/webhook-runtime"
       ],
       "dependencies": {
-        "@agent-relay/sdk": "^6.0.6"
+        "@agent-relay/sdk": "^6.0.7"
       },
       "devDependencies": {
         "@agentworkforce/workload-router": "^0.5.1"
@@ -127,9 +127,9 @@
       "link": true
     },
     "node_modules/@agent-relay/broker-darwin-arm64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.6.tgz",
-      "integrity": "sha512-o3JdeDefhYcRmUSRE0BkOaaLuK+3nMwDJ6JBsJ92+2o9FHwyfXBezXFVtDaL956OdFGzxUilY/0cPxdGiWM52Q==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.7.tgz",
+      "integrity": "sha512-IEkeo2w7StDpsn19Ot2Aueq2xTo+iXcB30LUV2I4TWIOkd46cA0LOJL41UVHJDKraNBCl8Cq/o7G7mRAd/rSLg==",
       "cpu": [
         "arm64"
       ],
@@ -140,9 +140,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-darwin-x64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.6.tgz",
-      "integrity": "sha512-opi0j+4tWpWUmgzGig4fwNU1cvUXP/Gru1NNKJYxUT8hr7MgWPenOsgpVzLgrtJFYDwLHgIWole4TVnVP9BinA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.7.tgz",
+      "integrity": "sha512-XT2RvMlVc+vh+wa+ofd5vc9c8JM0y4D6EavWZS2ngLkKGVPLVRwOdj2Jc3tX8mCTllzbObjTB1/0PcnXqqeDtw==",
       "cpu": [
         "x64"
       ],
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-linux-arm64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.6.tgz",
-      "integrity": "sha512-EtjW+4+bt+jdb6mNC6gHV0CWVe7euIAPTBiW+kCf2/Ilm9/8PQWJaJIydaAmhJTYDUsB5tp+Zali7Au0EfS+LA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.7.tgz",
+      "integrity": "sha512-dNH6DTWldSittRGN4mkH8fgGbk6zsIZA++7T+vOznS0GY7Kb8BWTso+uBmytsIfvaTEP0vQwXDL8cjjUlffJWA==",
       "cpu": [
         "arm64"
       ],
@@ -166,9 +166,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-linux-x64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.6.tgz",
-      "integrity": "sha512-XnGED/5MXeElW0VRFCFjBFHW7zPupTJ1uT0F69znbBzs9zHMYmMc3o+KYCCA4vQYYCaNDDBvpm+xEGt9P6WKAQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.7.tgz",
+      "integrity": "sha512-SI9qAK4+n5kyiM4diKZ8F+juScM6JeqeIIqEeBtszDnN1o4CRTCx3DLWLFa1S+P8fk9jUwOEEXeUrwAh5re70w==",
       "cpu": [
         "x64"
       ],
@@ -179,9 +179,9 @@
       ]
     },
     "node_modules/@agent-relay/broker-win32-x64": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.6.tgz",
-      "integrity": "sha512-Lu4UZJTBMJz+1EhXxqn1RQU4Ta0i8u9Hcpwt0RzOLSh3Cc+QVyRrI93gbaTgrpMgDtjRBxJ66zRhvEjyNA8bow==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.7.tgz",
+      "integrity": "sha512-/AzuMsKCVggyTLsdsOOVEVI7luEruR1+Tdx0F0JfXQGq5G+w+DK8KM02zq0DQSVvfgHFLPnz2UQG63z/ryLkmQ==",
       "cpu": [
         "x64"
       ],
@@ -191,22 +191,49 @@
         "win32"
       ]
     },
-    "node_modules/@agent-relay/github-primitive": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.6.tgz",
-      "integrity": "sha512-2t5W3vdjsaIrKhxHN/ilQKtmQuE5sq8GnetquECJGbC9fxSVRYhwe2xCiDaYh1R0u7xCEFrcmFjEdLd8ju0mvA==",
+    "node_modules/@agent-relay/config": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.7.tgz",
+      "integrity": "sha512-IvN5ktTbVlks5wpBv2KnbKNiQjvEtaWvrhPJh+XfDyyPV7l4UVdmYa02pLSIlfVrSe9/HVBlQUzKZXkGk8EreA==",
       "dependencies": {
-        "@agent-relay/workflow-types": "6.0.6"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
+      }
+    },
+    "node_modules/@agent-relay/github-primitive": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.7.tgz",
+      "integrity": "sha512-cv8epc8dtU6EuBY46japGO0TXRg9Fpb+t9kFpDIX3Xquv9QVD3GKn9ZtQ0en6OGBkDBMn+U4hE3dTAH8b6Se/Q==",
+      "dependencies": {
+        "@agent-relay/workflow-types": "6.0.7"
+      }
+    },
+    "node_modules/@agent-relay/hooks": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-6.0.7.tgz",
+      "integrity": "sha512-z8t9JuvazOEtGpIYOipI3IQ07qz2E+3/GcyM4ZmDQks8jav49QoW1O9CvJg8eRiVDZF8KQ84Adc4xe2rDDV5kA==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.7",
+        "@agent-relay/sdk": "6.0.7",
+        "@agent-relay/trajectory": "6.0.7"
+      }
+    },
+    "node_modules/@agent-relay/memory": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-6.0.7.tgz",
+      "integrity": "sha512-oOzkkRIOb/ZOhQJw9+77oMO4NsVuEKBqXY+v6PTZiCfx+zPIocRpBqtnCfA8Cy1yAkFvTD+YBKZ/cesqA15Dag==",
+      "dependencies": {
+        "@agent-relay/hooks": "6.0.7"
       }
     },
     "node_modules/@agent-relay/sdk": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.6.tgz",
-      "integrity": "sha512-B/FjRCDG/RBWeLZQmHYE2bcG7C4S9DJDnNTBfCAuzQiKbHBB4IebwvrOky0UIuSVjpGRVObAXf8KoiiYqbhBRg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.7.tgz",
+      "integrity": "sha512-SgqmPYE1nToicYRM0g9CnGyqeDoH5cfAmpENCgF7N4pR36JErPX0qUqM48IVFzNWE0ALKmzRAEbcPQet2yzUfg==",
       "dependencies": {
-        "@agent-relay/config": "6.0.6",
-        "@agent-relay/github-primitive": "6.0.6",
-        "@agent-relay/workflow-types": "6.0.6",
+        "@agent-relay/config": "6.0.7",
+        "@agent-relay/github-primitive": "6.0.7",
+        "@agent-relay/workflow-types": "6.0.7",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -219,14 +246,14 @@
         "yaml": "^2.7.0"
       },
       "optionalDependencies": {
-        "@agent-relay/broker-darwin-arm64": "6.0.6",
-        "@agent-relay/broker-darwin-x64": "6.0.6",
-        "@agent-relay/broker-linux-arm64": "6.0.6",
-        "@agent-relay/broker-linux-x64": "6.0.6",
-        "@agent-relay/broker-win32-x64": "6.0.6"
+        "@agent-relay/broker-darwin-arm64": "6.0.7",
+        "@agent-relay/broker-darwin-x64": "6.0.7",
+        "@agent-relay/broker-linux-arm64": "6.0.7",
+        "@agent-relay/broker-linux-x64": "6.0.7",
+        "@agent-relay/broker-win32-x64": "6.0.7"
       },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "6.0.6",
+        "@agent-relay/credential-proxy": "6.0.7",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -262,19 +289,18 @@
         }
       }
     },
-    "node_modules/@agent-relay/sdk/node_modules/@agent-relay/config": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.6.tgz",
-      "integrity": "sha512-gQe6eHGdh5lG3lCHEPUs2J9E5QUHy5O5CkXfSZgO0rAd2QWE55H0dRKwJ1CFnkYBcgYr4+3QtIPPZBKpkqnfGA==",
+    "node_modules/@agent-relay/trajectory": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-6.0.7.tgz",
+      "integrity": "sha512-vDbA8p6iLMKjRzkpJ6w4YFZYOg5ZRH40E7iYV4/M04vpAS2ppOH1wI8maCHHvvQGo++Ky4wAs775RdJQAfyz3g==",
       "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.1"
+        "@agent-relay/config": "6.0.7"
       }
     },
     "node_modules/@agent-relay/workflow-types": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.6.tgz",
-      "integrity": "sha512-Fu2GJWkIiSUxXawhk9SW+btDz5WDzI6RGKyugG12+wm4CDJ4rnDY9Xg8FGDugzOHL8EasWFvtF6pztZTzjJOSQ=="
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.7.tgz",
+      "integrity": "sha512-j3DiPRDe8BthIXvE7y+EWA60fEnPkxx7pv08PXhj8u2p6BPawPbD6g5tDMZvPo+68vltsr0KOv83AaA8IVUjGQ=="
     },
     "node_modules/@agentworkforce/workload-router": {
       "version": "0.5.1",
@@ -3637,7 +3663,7 @@
         "@agent-assistant/traits": "^0.2.0",
         "@agent-assistant/turn-context": "^0.3.4",
         "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^6.0.6",
+        "@agent-relay/sdk": "^6.0.7",
         "zod": "^3.25.0"
       },
       "devDependencies": {
@@ -4478,46 +4504,11 @@
       "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
-        "@agent-relay/memory": "^6.0.6"
+        "@agent-relay/memory": "^6.0.7"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/memory/node_modules/@agent-relay/config": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.6.tgz",
-      "integrity": "sha512-gQe6eHGdh5lG3lCHEPUs2J9E5QUHy5O5CkXfSZgO0rAd2QWE55H0dRKwJ1CFnkYBcgYr4+3QtIPPZBKpkqnfGA==",
-      "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.1"
-      }
-    },
-    "packages/memory/node_modules/@agent-relay/hooks": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-6.0.6.tgz",
-      "integrity": "sha512-kvreQJmxT0k9CzPNm9gI0jCLZGb5N3aWfry5hsD/+1BecwRnrwrF4VWfjXtfCYjdDYpqlP37x3kbmfPoylTztQ==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.6",
-        "@agent-relay/sdk": "6.0.6",
-        "@agent-relay/trajectory": "6.0.6"
-      }
-    },
-    "packages/memory/node_modules/@agent-relay/memory": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-6.0.6.tgz",
-      "integrity": "sha512-LPsh11/w6lRZU8e7jKa7JRQGuGjU9maBfGIrlmUXb6sh8L3Rly5s2ZcWrt0z7wuE7H7nfZm7S/B49GyYApp6RA==",
-      "dependencies": {
-        "@agent-relay/hooks": "6.0.6"
-      }
-    },
-    "packages/memory/node_modules/@agent-relay/trajectory": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-6.0.6.tgz",
-      "integrity": "sha512-GbiMzXuATiTZTL2Jho1+Mncf2Qc2jWarf0UccXL78xSr7jhgY/MLuYuI1wX/y0U44x5gHZzbQ3SuIf1gQTqS0g==",
-      "dependencies": {
-        "@agent-relay/config": "6.0.6"
       }
     },
     "packages/policy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,10 @@
         "packages/webhook-runtime"
       ],
       "dependencies": {
-        "@agent-relay/sdk": "^4.0.22"
+        "@agent-relay/sdk": "^6.0.6"
       },
       "devDependencies": {
-        "@agentworkforce/workload-router": "^0.2.0"
+        "@agentworkforce/workload-router": "^0.5.1"
       }
     },
     "node_modules/@agent-assistant/cloudflare-runtime": {
@@ -126,39 +126,87 @@
       "resolved": "packages/webhook-runtime",
       "link": true
     },
-    "node_modules/@agent-relay/config": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-4.0.40.tgz",
-      "integrity": "sha512-SEXTOTlxkC2kss17YzvAR9bmwMIBclurjI0O2k5xbxxqK/dH3iMM4sJpXXqat1iug95Lrp2Vp/hQJt6xOGeI9g==",
-      "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.1"
-      }
+    "node_modules/@agent-relay/broker-darwin-arm64": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-arm64/-/broker-darwin-arm64-6.0.6.tgz",
+      "integrity": "sha512-o3JdeDefhYcRmUSRE0BkOaaLuK+3nMwDJ6JBsJ92+2o9FHwyfXBezXFVtDaL956OdFGzxUilY/0cPxdGiWM52Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
-    "node_modules/@agent-relay/hooks": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-4.0.40.tgz",
-      "integrity": "sha512-WVbmXtJV3dHsKXs7zVOMpjeuEGBBWt0DCkqLuANKQMAaR2FkrhUbK0XZWL3lz2IHDlByM3tu9y4KgzbSoKu5hA==",
-      "dependencies": {
-        "@agent-relay/config": "4.0.40",
-        "@agent-relay/sdk": "4.0.40",
-        "@agent-relay/trajectory": "4.0.40"
-      }
+    "node_modules/@agent-relay/broker-darwin-x64": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-darwin-x64/-/broker-darwin-x64-6.0.6.tgz",
+      "integrity": "sha512-opi0j+4tWpWUmgzGig4fwNU1cvUXP/Gru1NNKJYxUT8hr7MgWPenOsgpVzLgrtJFYDwLHgIWole4TVnVP9BinA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
-    "node_modules/@agent-relay/memory": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-4.0.40.tgz",
-      "integrity": "sha512-W/pUIMq4FrxmVqn73mUoEz4mEyBrmrqrkW2uNWf/cxRQZoMki4D9dNCO6QiTVNHUNxFdXhMuS8fxLP8Ht3NEdg==",
+    "node_modules/@agent-relay/broker-linux-arm64": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-arm64/-/broker-linux-arm64-6.0.6.tgz",
+      "integrity": "sha512-EtjW+4+bt+jdb6mNC6gHV0CWVe7euIAPTBiW+kCf2/Ilm9/8PQWJaJIydaAmhJTYDUsB5tp+Zali7Au0EfS+LA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@agent-relay/broker-linux-x64": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-linux-x64/-/broker-linux-x64-6.0.6.tgz",
+      "integrity": "sha512-XnGED/5MXeElW0VRFCFjBFHW7zPupTJ1uT0F69znbBzs9zHMYmMc3o+KYCCA4vQYYCaNDDBvpm+xEGt9P6WKAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@agent-relay/broker-win32-x64": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/broker-win32-x64/-/broker-win32-x64-6.0.6.tgz",
+      "integrity": "sha512-Lu4UZJTBMJz+1EhXxqn1RQU4Ta0i8u9Hcpwt0RzOLSh3Cc+QVyRrI93gbaTgrpMgDtjRBxJ66zRhvEjyNA8bow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@agent-relay/github-primitive": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.6.tgz",
+      "integrity": "sha512-2t5W3vdjsaIrKhxHN/ilQKtmQuE5sq8GnetquECJGbC9fxSVRYhwe2xCiDaYh1R0u7xCEFrcmFjEdLd8ju0mvA==",
       "dependencies": {
-        "@agent-relay/hooks": "4.0.40"
+        "@agent-relay/workflow-types": "6.0.6"
       }
     },
     "node_modules/@agent-relay/sdk": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-4.0.40.tgz",
-      "integrity": "sha512-/65zrEALDUOPU96SBMBl462r6J5w/vQyshR0OV9KnLfzp5eRBhgv9p3beeFDgq6WuLto/A28U5zgnTyST3/n4g==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-6.0.6.tgz",
+      "integrity": "sha512-B/FjRCDG/RBWeLZQmHYE2bcG7C4S9DJDnNTBfCAuzQiKbHBB4IebwvrOky0UIuSVjpGRVObAXf8KoiiYqbhBRg==",
       "dependencies": {
-        "@agent-relay/config": "4.0.40",
+        "@agent-relay/config": "6.0.6",
+        "@agent-relay/github-primitive": "6.0.6",
+        "@agent-relay/workflow-types": "6.0.6",
         "@relaycast/sdk": "^1.1.0",
         "@relayfile/sdk": ">=0.1.2 <1",
         "@sinclair/typebox": "^0.34.48",
@@ -170,8 +218,15 @@
         "ws": "^8.18.3",
         "yaml": "^2.7.0"
       },
+      "optionalDependencies": {
+        "@agent-relay/broker-darwin-arm64": "6.0.6",
+        "@agent-relay/broker-darwin-x64": "6.0.6",
+        "@agent-relay/broker-linux-arm64": "6.0.6",
+        "@agent-relay/broker-linux-x64": "6.0.6",
+        "@agent-relay/broker-win32-x64": "6.0.6"
+      },
       "peerDependencies": {
-        "@agent-relay/credential-proxy": "4.0.40",
+        "@agent-relay/credential-proxy": "6.0.6",
         "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
         "@google/adk": ">=0.5.0",
         "@langchain/langgraph": ">=1.2.0",
@@ -207,22 +262,25 @@
         }
       }
     },
-    "node_modules/@agent-relay/trajectory": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-4.0.40.tgz",
-      "integrity": "sha512-+h0aRuT1Gmp6iTXACN+qcdh2ntIbZq6Bk55vTa7GGtyVUldLS5O2XSKDHUWn/gSiThUAlySApr4ZsG9lX1Jbkg==",
+    "node_modules/@agent-relay/sdk/node_modules/@agent-relay/config": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.6.tgz",
+      "integrity": "sha512-gQe6eHGdh5lG3lCHEPUs2J9E5QUHy5O5CkXfSZgO0rAd2QWE55H0dRKwJ1CFnkYBcgYr4+3QtIPPZBKpkqnfGA==",
       "dependencies": {
-        "@agent-relay/config": "4.0.40"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
       }
     },
+    "node_modules/@agent-relay/workflow-types": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/workflow-types/-/workflow-types-6.0.6.tgz",
+      "integrity": "sha512-Fu2GJWkIiSUxXawhk9SW+btDz5WDzI6RGKyugG12+wm4CDJ4rnDY9Xg8FGDugzOHL8EasWFvtF6pztZTzjJOSQ=="
+    },
     "node_modules/@agentworkforce/workload-router": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.2.0.tgz",
-      "integrity": "sha512-f4mHXkKL4C/JGwdntVQ0Kjvh92Ier+EXHpw7AFBuBK17NiqyP1FcC+LaKFc4lx54n/GzbtHZcHN/Z+hfZPkZLg==",
-      "dev": true,
-      "dependencies": {
-        "@agent-relay/sdk": "^4.0.5"
-      }
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.5.1.tgz",
+      "integrity": "sha512-6YyDSIna32G5J7qNI0rPlqvg6jelZGHLUkiqR4Hcm6YXVLvOQEUOJavNQ48tMA9EgHtsHPPy4PJHGj0UyCurVw==",
+      "dev": true
     },
     "node_modules/@clack/core": {
       "version": "0.3.5",
@@ -818,9 +876,9 @@
       }
     },
     "node_modules/@relayfile/adapter-github": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@relayfile/adapter-github/-/adapter-github-0.1.8.tgz",
-      "integrity": "sha512-o5o66ZUYRWS7aKZDWylv4xhzo7JQ3s/mRpx62KO63UsoZzL9wdIkBh6KkXD3QA2E+vOjMsfSBLDpAIa5n0NH3A==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-github/-/adapter-github-0.1.9.tgz",
+      "integrity": "sha512-FEqABg32iPGlmQGlEV+bKpsHxG5zdFI64/RPLB4SnbCW6+B7ZBQy4KEE/XVWeHQSjwH/mcREAto4WE59CUli6Q==",
       "license": "MIT",
       "dependencies": {
         "@relayfile/adapter-core": "^0.1.1"
@@ -833,9 +891,9 @@
       }
     },
     "node_modules/@relayfile/adapter-linear": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@relayfile/adapter-linear/-/adapter-linear-0.1.9.tgz",
-      "integrity": "sha512-5oIQqZnlshBlZnxy2TuENG+1HOlMzi2gI+n5Kgxdjfvjy2xmtLUTh/8Yoo6bot8yn6DiWYF2dylq6eph0yS0fw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-linear/-/adapter-linear-0.1.11.tgz",
+      "integrity": "sha512-mo68B9MNt15AxYm4iiSwrvN3SE7fD3JRsqfJZW9+Yh78tzPZkKiabP67gyWzXSfDH5rk2LJbD0RHv22YInu1kQ==",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/sdk": "^3.2.22"
@@ -3476,7 +3534,7 @@
     },
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
-      "version": "0.1.14",
+      "version": "0.1.16",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -3491,7 +3549,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3503,71 +3561,18 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.3.16",
+      "version": "0.3.18",
       "dependencies": {
-        "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
+        "@agent-assistant/harness": "^0.10.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
     },
-    "packages/continuation/node_modules/@agent-assistant/connectivity": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
-      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^5.1.6"
-      }
-    },
-    "packages/continuation/node_modules/@agent-assistant/coordination": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
-      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "nanoid": "^5.1.6"
-      }
-    },
-    "packages/continuation/node_modules/@agent-assistant/core": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
-      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/continuation/node_modules/@agent-assistant/harness": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
-      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "@agent-assistant/coordination": "^0.2.6",
-        "@agent-assistant/core": "^0.2.0",
-        "@agent-assistant/traits": "^0.2.0",
-        "@agent-assistant/turn-context": "^0.3.4",
-        "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^4.0.22"
-      }
-    },
-    "packages/continuation/node_modules/@agent-assistant/traits": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
-      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
-      "license": "MIT"
-    },
-    "packages/continuation/node_modules/@agent-assistant/vfs": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
-      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
-      "license": "MIT"
-    },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3590,7 +3595,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3623,7 +3628,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3632,7 +3637,7 @@
         "@agent-assistant/traits": "^0.2.0",
         "@agent-assistant/turn-context": "^0.3.4",
         "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^4.0.22",
+        "@agent-relay/sdk": "^6.0.6",
         "zod": "^3.25.0"
       },
       "devDependencies": {
@@ -3682,7 +3687,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4470,19 +4475,54 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "license": "MIT",
       "dependencies": {
-        "@agent-relay/memory": "^4.0.23"
+        "@agent-relay/memory": "^6.0.6"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       }
     },
+    "packages/memory/node_modules/@agent-relay/config": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-6.0.6.tgz",
+      "integrity": "sha512-gQe6eHGdh5lG3lCHEPUs2J9E5QUHy5O5CkXfSZgO0rAd2QWE55H0dRKwJ1CFnkYBcgYr4+3QtIPPZBKpkqnfGA==",
+      "dependencies": {
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
+      }
+    },
+    "packages/memory/node_modules/@agent-relay/hooks": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-6.0.6.tgz",
+      "integrity": "sha512-kvreQJmxT0k9CzPNm9gI0jCLZGb5N3aWfry5hsD/+1BecwRnrwrF4VWfjXtfCYjdDYpqlP37x3kbmfPoylTztQ==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.6",
+        "@agent-relay/sdk": "6.0.6",
+        "@agent-relay/trajectory": "6.0.6"
+      }
+    },
+    "packages/memory/node_modules/@agent-relay/memory": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-6.0.6.tgz",
+      "integrity": "sha512-LPsh11/w6lRZU8e7jKa7JRQGuGjU9maBfGIrlmUXb6sh8L3Rly5s2ZcWrt0z7wuE7H7nfZm7S/B49GyYApp6RA==",
+      "dependencies": {
+        "@agent-relay/hooks": "6.0.6"
+      }
+    },
+    "packages/memory/node_modules/@agent-relay/trajectory": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-6.0.6.tgz",
+      "integrity": "sha512-GbiMzXuATiTZTL2Jho1+Mncf2Qc2jWarf0UccXL78xSr7jhgY/MLuYuI1wX/y0U44x5gHZzbQ3SuIf1gQTqS0g==",
+      "dependencies": {
+        "@agent-relay/config": "6.0.6"
+      }
+    },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4494,7 +4534,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4516,7 +4556,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4533,7 +4573,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4541,12 +4581,12 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.4.15",
+      "version": "0.4.17",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
-        "@relayfile/adapter-github": "^0.1.6",
-        "@relayfile/adapter-linear": "^0.1.7"
+        "@relayfile/adapter-github": "^0.1.9",
+        "@relayfile/adapter-linear": "^0.1.11"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4580,7 +4620,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4588,9 +4628,9 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.2.16",
+      "version": "0.2.18",
       "dependencies": {
-        "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
+        "@agent-assistant/harness": "^0.10.1"
       },
       "devDependencies": {
         "@types/node": "^24.6.0",
@@ -4598,62 +4638,9 @@
         "vitest": "^3.2.4"
       }
     },
-    "packages/telemetry/node_modules/@agent-assistant/connectivity": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
-      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^5.1.6"
-      }
-    },
-    "packages/telemetry/node_modules/@agent-assistant/coordination": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
-      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "nanoid": "^5.1.6"
-      }
-    },
-    "packages/telemetry/node_modules/@agent-assistant/core": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
-      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/telemetry/node_modules/@agent-assistant/harness": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
-      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "@agent-assistant/coordination": "^0.2.6",
-        "@agent-assistant/core": "^0.2.0",
-        "@agent-assistant/traits": "^0.2.0",
-        "@agent-assistant/turn-context": "^0.3.4",
-        "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^4.0.22"
-      }
-    },
-    "packages/telemetry/node_modules/@agent-assistant/traits": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
-      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
-      "license": "MIT"
-    },
-    "packages/telemetry/node_modules/@agent-assistant/vfs": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
-      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
-      "license": "MIT"
-    },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4662,66 +4649,16 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.3.16",
+      "version": "0.3.18",
       "license": "MIT",
       "dependencies": {
-        "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
-        "@agent-assistant/memory": "^0.2.0",
+        "@agent-assistant/harness": "^0.10.1",
+        "@agent-assistant/memory": "^0.4.7",
         "@agent-assistant/traits": "^0.2.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/connectivity": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
-      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^5.1.6"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/coordination": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
-      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "nanoid": "^5.1.6"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/core": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
-      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/harness": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
-      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "@agent-assistant/coordination": "^0.2.6",
-        "@agent-assistant/core": "^0.2.0",
-        "@agent-assistant/traits": "^0.2.0",
-        "@agent-assistant/turn-context": "^0.3.4",
-        "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^4.0.22"
-      }
-    },
-    "packages/turn-context/node_modules/@agent-assistant/memory": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
-      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@agent-relay/memory": "^4.0.23"
       }
     },
     "packages/turn-context/node_modules/@agent-assistant/traits": {
@@ -4730,15 +4667,9 @@
       "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
       "license": "MIT"
     },
-    "packages/turn-context/node_modules/@agent-assistant/vfs": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
-      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
-      "license": "MIT"
-    },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.3.15",
+      "version": "0.3.17",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4765,7 +4696,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.2.17",
+      "version": "0.2.19",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -4773,14 +4704,14 @@
         "hono": "^4"
       },
       "devDependencies": {
-        "@agent-assistant/harness": "^0.6.4",
+        "@agent-assistant/harness": "^0.10.1",
         "@types/node": "^24.6.0",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       },
       "peerDependencies": {
-        "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
+        "@agent-assistant/harness": "^0.10.1"
       },
       "peerDependenciesMeta": {
         "@agent-assistant/harness": {
@@ -4807,30 +4738,6 @@
         "nanoid": "^5.1.6"
       }
     },
-    "packages/webhook-runtime/node_modules/@agent-assistant/core": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
-      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
-      "dev": true,
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/webhook-runtime/node_modules/@agent-assistant/harness": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
-      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
-      "dev": true,
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "@agent-assistant/coordination": "^0.2.6",
-        "@agent-assistant/core": "^0.2.0",
-        "@agent-assistant/traits": "^0.2.0",
-        "@agent-assistant/turn-context": "^0.3.4",
-        "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^4.0.22"
-      }
-    },
     "packages/webhook-runtime/node_modules/@agent-assistant/specialists": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@agent-assistant/specialists/-/specialists-0.3.12.tgz",
@@ -4841,13 +4748,6 @@
         "@relayfile/adapter-github": "^0.1.6",
         "@relayfile/adapter-linear": "^0.1.7"
       }
-    },
-    "packages/webhook-runtime/node_modules/@agent-assistant/traits": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
-      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/webhook-runtime/node_modules/@agent-assistant/vfs": {
       "version": "0.2.24",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "worker": "npm run worker -w @agent-assistant/webhook-runtime --"
   },
   "devDependencies": {
-    "@agentworkforce/workload-router": "^0.2.0"
+    "@agentworkforce/workload-router": "^0.5.1"
   },
   "dependencies": {
-    "@agent-relay/sdk": "^4.0.22"
+    "@agent-relay/sdk": "^6.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "@agentworkforce/workload-router": "^0.5.1"
   },
   "dependencies": {
-    "@agent-relay/sdk": "^6.0.6"
+    "@agent-relay/sdk": "^6.0.7"
   }
 }

--- a/packages/continuation/package.json
+++ b/packages/continuation/package.json
@@ -21,7 +21,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
+    "@agent-assistant/harness": "^0.10.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -43,7 +43,7 @@
     "@agent-assistant/traits": "^0.2.0",
     "@agent-assistant/turn-context": "^0.3.4",
     "@agent-assistant/vfs": "^0.2.23",
-    "@agent-relay/sdk": "^6.0.6",
+    "@agent-relay/sdk": "^6.0.7",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -43,7 +43,7 @@
     "@agent-assistant/traits": "^0.2.0",
     "@agent-assistant/turn-context": "^0.3.4",
     "@agent-assistant/vfs": "^0.2.23",
-    "@agent-relay/sdk": "^4.0.22",
+    "@agent-relay/sdk": "^6.0.6",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@agent-relay/memory": "^6.0.6"
+    "@agent-relay/memory": "^6.0.7"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@agent-relay/memory": "^4.0.23"
+    "@agent-relay/memory": "^6.0.6"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@agent-assistant/coordination": "^0.2.6",
     "@agent-assistant/vfs": "^0.2.6",
-    "@relayfile/adapter-github": "^0.1.6",
-    "@relayfile/adapter-linear": "^0.1.7"
+    "@relayfile/adapter-github": "^0.1.9",
+    "@relayfile/adapter-linear": "^0.1.11"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -37,7 +37,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
+    "@agent-assistant/harness": "^0.10.1"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/packages/turn-context/package.json
+++ b/packages/turn-context/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@agent-assistant/traits": "^0.2.0",
-    "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
-    "@agent-assistant/memory": "^0.2.0"
+    "@agent-assistant/harness": "^0.10.1",
+    "@agent-assistant/memory": "^0.4.7"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -41,7 +41,7 @@
     "hono": "^4"
   },
   "peerDependencies": {
-    "@agent-assistant/harness": "^0.4.0 || ^0.6.0"
+    "@agent-assistant/harness": "^0.10.1"
   },
   "peerDependenciesMeta": {
     "@agent-assistant/harness": {
@@ -49,7 +49,7 @@
     }
   },
   "devDependencies": {
-    "@agent-assistant/harness": "^0.6.4",
+    "@agent-assistant/harness": "^0.10.1",
     "@types/node": "^24.6.0",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary
- bump @agent-assistant/harness and @agent-assistant/memory onto the published Relay 6.0.7 package line
- tighten internal Agent Assistant package ranges so continuation, telemetry, turn-context, and webhook-runtime do not pull older harness/memory releases
- bump specialist adapter ranges to the current Relayfile adapter line

## Verification
- npm run build -w @agent-assistant/memory
- npm run build -w @agent-assistant/harness
- npm run build -w @agent-assistant/continuation
- npm run build -w @agent-assistant/telemetry
- npm run build -w @agent-assistant/turn-context
- npm run build -w @agent-assistant/specialists
- npm run build -w @agent-assistant/webhook-runtime
- npm ls @agent-relay/sdk @agent-relay/memory @relayfile/sdk --userconfig=/dev/null

## Notes
Relay publish is complete at 6.0.7. The remaining older adapter transitive edge is handled by the companion relayfile-adapters PR once it is published.