### PR TITLE
feat: anti-fabrication primitives (harness, specialists, vfs, proactive)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -307,9 +307,14 @@ jobs:
       matrix:
         package: ${{ fromJson(needs.resolve-packages.outputs.matrix) }}
     steps:
+      # Checkout the SAME ref the build job ran on (`github.ref_name` is the
+      # branch the workflow_dispatch was triggered against). Hardcoding `main`
+      # caused stale-dist publishes when running this workflow from a feature
+      # branch: the artifact-restored dist was overwritten by `npm publish`'s
+      # prepack hook, which ran `tsc` against main's source. Fixes PR #76.
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,7 +335,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3560,7 +3559,7 @@
     },
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
-      "version": "0.1.16",
+      "version": "0.1.18",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -3575,7 +3574,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3587,7 +3586,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.3.18",
+      "version": "0.3.20",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -3598,7 +3597,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -3621,7 +3620,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -3654,7 +3653,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -3713,7 +3712,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -4501,7 +4500,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.4.7",
+      "version": "0.4.9",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^6.0.7"
@@ -4513,7 +4512,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -4525,7 +4524,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/surfaces": ">=0.2.19",
@@ -4547,7 +4546,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -4564,7 +4563,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4572,7 +4571,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.4.17",
+      "version": "0.4.19",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -4611,7 +4610,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -4619,7 +4618,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.2.18",
+      "version": "0.2.20",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -4631,7 +4630,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -4640,16 +4639,66 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.3.18",
+      "version": "0.3.20",
       "license": "MIT",
       "dependencies": {
-        "@agent-assistant/harness": "^0.10.1",
-        "@agent-assistant/memory": "^0.4.7",
+        "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
+        "@agent-assistant/memory": "^0.2.0",
         "@agent-assistant/traits": "^0.2.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/harness": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.6.12.tgz",
+      "integrity": "sha512-ZcsWTrs3JBT5U+PkdueZYAmzaCEq7z4Tv8wqsWTbddhr5m6UPk8KH4fLe+q8xwmTXe7B8n9vEBlnxfpVZZzTZw==",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.3.4",
+        "@agent-assistant/vfs": "^0.2.23",
+        "@agent-relay/sdk": "^4.0.22"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
       }
     },
     "packages/turn-context/node_modules/@agent-assistant/traits": {
@@ -4658,9 +4707,104 @@
       "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
       "license": "MIT"
     },
+    "packages/turn-context/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
+    "packages/turn-context/node_modules/@agent-relay/config": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-4.0.40.tgz",
+      "integrity": "sha512-SEXTOTlxkC2kss17YzvAR9bmwMIBclurjI0O2k5xbxxqK/dH3iMM4sJpXXqat1iug95Lrp2Vp/hQJt6xOGeI9g==",
+      "dependencies": {
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-relay/hooks": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-4.0.40.tgz",
+      "integrity": "sha512-WVbmXtJV3dHsKXs7zVOMpjeuEGBBWt0DCkqLuANKQMAaR2FkrhUbK0XZWL3lz2IHDlByM3tu9y4KgzbSoKu5hA==",
+      "dependencies": {
+        "@agent-relay/config": "4.0.40",
+        "@agent-relay/sdk": "4.0.40",
+        "@agent-relay/trajectory": "4.0.40"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-relay/memory": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-4.0.40.tgz",
+      "integrity": "sha512-W/pUIMq4FrxmVqn73mUoEz4mEyBrmrqrkW2uNWf/cxRQZoMki4D9dNCO6QiTVNHUNxFdXhMuS8fxLP8Ht3NEdg==",
+      "dependencies": {
+        "@agent-relay/hooks": "4.0.40"
+      }
+    },
+    "packages/turn-context/node_modules/@agent-relay/sdk": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-4.0.40.tgz",
+      "integrity": "sha512-/65zrEALDUOPU96SBMBl462r6J5w/vQyshR0OV9KnLfzp5eRBhgv9p3beeFDgq6WuLto/A28U5zgnTyST3/n4g==",
+      "dependencies": {
+        "@agent-relay/config": "4.0.40",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "4.0.40",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
+      }
+    },
+    "packages/turn-context/node_modules/@agent-relay/trajectory": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-4.0.40.tgz",
+      "integrity": "sha512-+h0aRuT1Gmp6iTXACN+qcdh2ntIbZq6Bk55vTa7GGtyVUldLS5O2XSKDHUWn/gSiThUAlySApr4ZsG9lX1Jbkg==",
+      "dependencies": {
+        "@agent-relay/config": "4.0.40"
+      }
+    },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.3.17",
+      "version": "0.3.19",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4687,7 +4831,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.2.19",
+      "version": "0.2.21",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@agent-assistant/surfaces": "^0.3.0",

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/cloudflare-runtime",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/cloudflare-runtime",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@agent-assistant/continuation": "^0.3.4",
-    "@agent-assistant/webhook-runtime": "^0.2.5",
-    "@agent-assistant/surfaces": "^0.3.0"
+    "@agent-assistant/surfaces": "^0.3.0",
+    "@agent-assistant/webhook-runtime": "^0.2.5"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260417.1",

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/connectivity",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Typed in-process connectivity signals for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/connectivity",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Typed in-process connectivity signals for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/continuation/package.json
+++ b/packages/continuation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/continuation",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Bounded continuation primitive — turns resumable harness outcomes into explicit state, validated resume triggers, and real follow-up delivery",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/continuation/package.json
+++ b/packages/continuation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/continuation",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Bounded continuation primitive — turns resumable harness outcomes into explicit state, validated resume triggers, and real follow-up delivery",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/coordination/package.json
+++ b/packages/coordination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/coordination",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Minimal coordinator, specialist registry, delegation, and synthesis runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/coordination/package.json
+++ b/packages/coordination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/coordination",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Minimal coordinator, specialist registry, delegation, and synthesis runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/core",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Assistant definition, lifecycle, and runtime composition for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/core",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Assistant definition, lifecycle, and runtime composition for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@agent-assistant/connectivity": "^0.2.6",
-    "@agent-assistant/core": "^0.2.0",
     "@agent-assistant/coordination": "^0.2.6",
+    "@agent-assistant/core": "^0.2.0",
     "@agent-assistant/memory": "^0.4.0",
     "@agent-assistant/traits": "^0.2.0",
     "@agent-assistant/turn-context": "^0.3.4",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/harness",
-  "version": "0.11.0",
+  "version": "0.10.2",
   "description": "Bounded iterative assistant-turn runtime for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/harness/src/claim-density.test.ts
+++ b/packages/harness/src/claim-density.test.ts
@@ -1,0 +1,97 @@
+import { assert, describe, it } from 'vitest';
+
+import { exceedsEvidenceBudget } from './claim-density.js';
+
+const sparseWorkspaceListToolCalls = [
+  { name: 'workspace_list', outputChars: 513 },
+] as const;
+
+const fiveRowMarkdownTable = [
+  '| Commit | Repo | Note |',
+  '| --- | --- | --- |',
+  '| b5c1e2f | agent-assistant | Added harness retry telemetry |',
+  '| a3d7890 | sage | Tightened worker bridge logging |',
+  '| c4f8ab1 | burn | Updated local command adapter docs |',
+  '| d91aa73 | ai-hist | Fixed trajectory export formatting |',
+  '| ef02bc4 | relayfile | Reworked VFS hydration path |',
+].join('\n');
+
+describe('exceedsEvidenceBudget', () => {
+  it('turn bepqzr — fabricated commits table from sparse evidence', () => {
+    // Captured turn id: bepqzr
+    const verdict = exceedsEvidenceBudget({
+      toolCalls: sparseWorkspaceListToolCalls,
+      assistantText: [
+        'Here is the commit summary I found:',
+        '',
+        fiveRowMarkdownTable,
+      ].join('\n'),
+    });
+
+    assert.equal(verdict.exceeds, true);
+    assert.equal(verdict.reason, 'sparse_tool_evidence_with_structured_claims');
+  });
+
+  it('turn bepqzr variant — numbered list with SHA refs', () => {
+    // Captured turn id: bepqzr
+    const verdict = exceedsEvidenceBudget({
+      toolCalls: sparseWorkspaceListToolCalls,
+      assistantText: [
+        '1. b5c1e2f - Added harness retry telemetry',
+        '2. a3d7890 - Tightened worker bridge logging',
+        '3. c4f8ab1 - Updated local command adapter docs',
+      ].join('\n'),
+    });
+
+    assert.equal(verdict.exceeds, true);
+    assert.equal(verdict.reason, 'sparse_tool_evidence_with_structured_claims');
+  });
+
+  it('legitimate 5-call investigation — table allowed', () => {
+    // Captured turn id: legitimate-5-call-investigation
+    const verdict = exceedsEvidenceBudget({
+      toolCalls: [
+        { name: 'workspace_list', outputChars: 1600 },
+        { name: 'workspace_list', outputChars: 1600 },
+        { name: 'workspace_list', outputChars: 1600 },
+        { name: 'workspace_list', outputChars: 1600 },
+        { name: 'workspace_list', outputChars: 1600 },
+      ],
+      assistantText: fiveRowMarkdownTable,
+    });
+
+    assert.equal(verdict.exceeds, false);
+  });
+
+  it('legitimate 1-call summary — no structured claims', () => {
+    // Captured turn id: legitimate-1-call-summary
+    const verdict = exceedsEvidenceBudget({
+      toolCalls: [{ name: 'workspace_list', outputChars: 200 }],
+      assistantText:
+        "There are 22 repos including agent-assistant, ai-hist, burn — but I don't see relayfile.",
+    });
+
+    assert.equal(verdict.exceeds, false);
+  });
+
+  it('workspace_search single call with table', () => {
+    // Captured turn id: workspace-search-single-call
+    const verdict = exceedsEvidenceBudget({
+      toolCalls: [{ name: 'workspace_search', outputChars: 900 }],
+      assistantText: fiveRowMarkdownTable,
+    });
+
+    assert.equal(verdict.exceeds, true);
+    assert.equal(verdict.reason, 'sparse_tool_evidence_with_structured_claims');
+  });
+
+  it('rich evidence boundary — outputChars=1024 exactly', () => {
+    // Captured turn id: rich-evidence-boundary-1024
+    const verdict = exceedsEvidenceBudget({
+      toolCalls: [{ name: 'workspace_list', outputChars: 1024 }],
+      assistantText: fiveRowMarkdownTable,
+    });
+
+    assert.equal(verdict.exceeds, false);
+  });
+});

--- a/packages/harness/src/claim-density.ts
+++ b/packages/harness/src/claim-density.ts
@@ -1,0 +1,169 @@
+export interface EvidenceBudgetInput {
+  toolCalls: ReadonlyArray<{
+    name: string;
+    outputChars: number;
+  }>;
+  assistantText: string;
+}
+
+export interface EvidenceBudgetVerdict {
+  exceeds: boolean;
+  reason?: 'sparse_tool_evidence_with_structured_claims';
+  detail?: { toolCallCount: number; outputChars: number; claimMarkers: string[] };
+}
+
+const EVIDENCE_BUDGET_REASON = 'sparse_tool_evidence_with_structured_claims' as const;
+const SPARSE_OUTPUT_CHAR_LIMIT = 1024;
+const MIN_STRUCTURED_LIST_ITEMS = 3;
+
+const WORKSPACE_ENUMERATION_TOOL_RE = /^(workspace_list|workspace_search)$/;
+const SHA_LIKE_RE = /\b[a-f0-9]{6,40}\b/;
+const SHORT_OR_ISO_DATE_RE = /\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}(?:\/\d{2,4})?)\b/;
+const OWNER_REPO_RE = /\b[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\b/;
+const NUMBERED_ITEM_RE = /^\s*\d+\.\s+/;
+const PIPE_PREFIX_RE = /^\s*\|/;
+const TABLE_SEPARATOR_RE = /^\s*\|(?:\s*:?-{3,}:?\s*\|)+\s*$/;
+const CLAIM_MARKER_ORDER = ['markdown_table', 'numbered_list', 'sha_like', 'date', 'owner_repo'] as const;
+
+export function exceedsEvidenceBudget(input: EvidenceBudgetInput): EvidenceBudgetVerdict {
+  if (input.toolCalls.length !== 1) {
+    return { exceeds: false };
+  }
+
+  const toolCall = input.toolCalls[0];
+  if (!toolCall) {
+    return { exceeds: false };
+  }
+
+  if (
+    !WORKSPACE_ENUMERATION_TOOL_RE.test(toolCall.name)
+    || toolCall.outputChars >= SPARSE_OUTPUT_CHAR_LIMIT
+  ) {
+    return { exceeds: false };
+  }
+
+  const claimMarkers = collectClaimMarkers(input.assistantText);
+  if (claimMarkers.length === 0) {
+    return { exceeds: false };
+  }
+
+  return {
+    exceeds: true,
+    reason: EVIDENCE_BUDGET_REASON,
+    detail: {
+      toolCallCount: input.toolCalls.length,
+      outputChars: toolCall.outputChars,
+      claimMarkers,
+    },
+  };
+}
+
+function collectClaimMarkers(text: string): string[] {
+  const present = new Set<string>();
+
+  if (containsMarkdownTable(text)) {
+    present.add('markdown_table');
+  }
+
+  const listMarkers = findStructuredNumberedListMarkers(text);
+  for (const marker of listMarkers) {
+    present.add(marker);
+  }
+
+  return CLAIM_MARKER_ORDER.filter((marker) => present.has(marker));
+}
+
+function containsMarkdownTable(text: string): boolean {
+  const lines = text.split(/\r?\n/);
+  let currentRun: string[] = [];
+
+  for (const line of lines) {
+    if (PIPE_PREFIX_RE.test(line)) {
+      currentRun.push(line);
+      continue;
+    }
+
+    if (isMarkdownTableRun(currentRun)) {
+      return true;
+    }
+    currentRun = [];
+  }
+
+  return isMarkdownTableRun(currentRun);
+}
+
+function isMarkdownTableRun(lines: readonly string[]): boolean {
+  return lines.length >= 2 && lines.some((line) => TABLE_SEPARATOR_RE.test(line));
+}
+
+function findStructuredNumberedListMarkers(text: string): string[] {
+  const lines = text.split(/\r?\n/);
+  let currentGroup: string[] = [];
+
+  for (const line of lines) {
+    if (NUMBERED_ITEM_RE.test(line)) {
+      currentGroup.push(line);
+      continue;
+    }
+
+    const markers = markersForQualifiedNumberedGroup(currentGroup);
+    if (markers.length > 0) {
+      return markers;
+    }
+    currentGroup = [];
+  }
+
+  return markersForQualifiedNumberedGroup(currentGroup);
+}
+
+function markersForQualifiedNumberedGroup(lines: readonly string[]): string[] {
+  if (lines.length < MIN_STRUCTURED_LIST_ITEMS) {
+    return [];
+  }
+
+  let hasShaLike = false;
+  let hasDate = false;
+  let hasOwnerRepo = false;
+
+  for (const line of lines) {
+    const itemMarkers = structuredFieldPresence(line.replace(NUMBERED_ITEM_RE, ''));
+    if (!itemMarkers.hasStructuredField) {
+      return [];
+    }
+
+    hasShaLike ||= itemMarkers.hasShaLike;
+    hasDate ||= itemMarkers.hasDate;
+    hasOwnerRepo ||= itemMarkers.hasOwnerRepo;
+  }
+
+  const markers = ['numbered_list'];
+  if (hasShaLike) {
+    markers.push('sha_like');
+  }
+  if (hasDate) {
+    markers.push('date');
+  }
+  if (hasOwnerRepo) {
+    markers.push('owner_repo');
+  }
+
+  return markers;
+}
+
+function structuredFieldPresence(text: string): {
+  hasStructuredField: boolean;
+  hasShaLike: boolean;
+  hasDate: boolean;
+  hasOwnerRepo: boolean;
+} {
+  const hasShaLike = SHA_LIKE_RE.test(text);
+  const hasDate = SHORT_OR_ISO_DATE_RE.test(text);
+  const hasOwnerRepo = OWNER_REPO_RE.test(text);
+
+  return {
+    hasStructuredField: hasShaLike || hasDate || hasOwnerRepo,
+    hasShaLike,
+    hasDate,
+    hasOwnerRepo,
+  };
+}

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -1,8 +1,12 @@
 export { createHarness } from './harness.js';
 export { USING_RELAYFILE_VFS_SKILL } from './skills/using-relayfile-vfs.js';
 export { HarnessConfigError } from './types.js';
+export { exceedsEvidenceBudget } from './claim-density.js';
+export type { EvidenceBudgetInput, EvidenceBudgetVerdict } from './claim-density.js';
 export { stopReasonToUserMessage } from './stop-reason-message.js';
+export { truthfulFailureReply } from './stop-reason-message.js';
 export type { StopReasonMessageOptions } from './stop-reason-message.js';
+export type { TruthfulFailureReplyOptions } from './stop-reason-message.js';
 export * from './adapter/index.js';
 
 export { OpenRouterModelAdapter, createOpenRouterModelAdapter } from './adapter/openrouter-model-adapter.js';
@@ -29,6 +33,8 @@ export {
   TOOL_DISCIPLINE_CLAUSES,
   TOOL_INPUT_SHAPE_REMINDER_CLAUSE,
 } from './tools/prompt-fragments.js';
+export { buildIntegrationsLayer } from './prompt/integrations-layer.js';
+export type { IntegrationContextInput, IntegrationLayerOptions } from './prompt/integrations-layer.js';
 export {
   createWorkspaceToolRegistry,
   WORKSPACE_LIST_TOOL_NAME,

--- a/packages/harness/src/prompt/integrations-layer.test.ts
+++ b/packages/harness/src/prompt/integrations-layer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildIntegrationsLayer } from './integrations-layer.js';
+
+const EIGHT_REPOS = [
+  'agent-assistant',
+  'relayfile',
+  'sage',
+  'trail',
+  'coordination',
+  'connectivity',
+  'turn-context',
+  'workforce',
+];
+
+const TWENTY_TWO_REPOS = [
+  'agent-assistant',
+  'relayfile',
+  'sage',
+  'trail',
+  'coordination',
+  'connectivity',
+  'turn-context',
+  'workforce',
+  'broker-sdk',
+  'relay-cli',
+  'workload-router',
+  'persona-catalog',
+  'runtime-core',
+  'memory-store',
+  'prompt-kit',
+  'notion-sync',
+  'slack-bridge',
+  'github-bridge',
+  'docs-site',
+  'ops-console',
+  'evidence-store',
+  'tool-registry',
+];
+
+const SLACK_CHANNELS = ['general', 'eng-builds', 'launches'];
+
+function getContent(result: ReturnType<typeof buildIntegrationsLayer>): string {
+  expect(result).not.toBeNull();
+  return result?.content ?? '';
+}
+
+function getSampleLine(content: string): string {
+  const sampleLine = content
+    .split('\n')
+    .find((line) => line.startsWith('  Sample: '));
+
+  expect(sampleLine).toBeDefined();
+  return sampleLine ?? '';
+}
+
+function getSampleNames(content: string): string[] {
+  return getSampleLine(content)
+    .replace('  Sample: ', '')
+    .replace(/\.$/, '')
+    .split(', ');
+}
+
+describe('buildIntegrationsLayer', () => {
+  it('<= maxInlineItems renders full list', () => {
+    const content = getContent(
+      buildIntegrationsLayer({
+        github: {
+          orgs: ['agent-workforce'],
+          repoNames: EIGHT_REPOS,
+        },
+      }),
+    );
+
+    for (const repoName of EIGHT_REPOS) {
+      expect(content).toContain(repoName);
+    }
+    expect(content).not.toContain('NOT exhaustive');
+  });
+
+  it('> maxInlineItems renders non-exhaustive marker', () => {
+    const content = getContent(
+      buildIntegrationsLayer({
+        github: {
+          orgs: ['agent-workforce'],
+          repoNames: TWENTY_TWO_REPOS,
+        },
+      }),
+    );
+
+    expect(content).toContain(
+      'NOT exhaustive — to enumerate, call workspace_list /github/repos',
+    );
+    expect(content).toContain('Workspace contains 22 repos.');
+
+    const sampleNames = getSampleNames(content);
+    expect(sampleNames).toHaveLength(5);
+    expect(sampleNames.every((repoName) => TWENTY_TWO_REPOS.includes(repoName))).toBe(true);
+  });
+
+  it('stable sample is deterministic across calls', () => {
+    const input = {
+      github: {
+        orgs: ['agent-workforce'],
+        repoNames: TWENTY_TWO_REPOS,
+      },
+    };
+
+    const firstContent = getContent(buildIntegrationsLayer(input));
+    const secondContent = getContent(buildIntegrationsLayer(input));
+
+    expect(getSampleLine(firstContent)).toBe(getSampleLine(secondContent));
+  });
+
+  it('empty items omits the line', () => {
+    const result = buildIntegrationsLayer({
+      github: { orgs: ['x'], repoNames: [] },
+    });
+
+    expect(result?.content ?? '').not.toContain('GitHub:');
+  });
+
+  it('mix of github + slack rendering', () => {
+    const content = getContent(
+      buildIntegrationsLayer({
+        github: {
+          orgs: ['agent-workforce'],
+          repoNames: TWENTY_TWO_REPOS,
+        },
+        slack: {
+          channels: SLACK_CHANNELS,
+        },
+      }),
+    );
+
+    expect(content).toContain('Workspace contains 22 repos.');
+    expect(content).toContain(
+      'NOT exhaustive — to enumerate, call workspace_list /github/repos',
+    );
+    expect(content).toContain(
+      'Slack: Connected to the Slack workspace. Workspace contains channels: general, eng-builds, launches.',
+    );
+  });
+});

--- a/packages/harness/src/prompt/integrations-layer.ts
+++ b/packages/harness/src/prompt/integrations-layer.ts
@@ -1,0 +1,193 @@
+import { createHash } from 'node:crypto';
+
+const DEFAULT_MAX_INLINE_ITEMS = 8;
+const DEFAULT_MAX_SAMPLE_ITEMS = 5;
+const DEFAULT_SAMPLE_STRATEGY = 'stable-hash';
+
+const GITHUB_ROOT = '/github/repos';
+const SLACK_ROOT = '/slack/channels';
+const NOTION_ROOT = '/notion/databases';
+
+const MAX_GITHUB_ORG_SUMMARY_ITEMS = 3;
+
+export interface IntegrationContextInput {
+  github?: { orgs: string[]; repoNames: string[] };
+  slack?: { channels: string[] };
+  notion?: { databases: string[] };
+}
+
+export interface IntegrationLayerOptions {
+  maxInlineItems?: number;
+  maxSampleItems?: number;
+  sampleStrategy?: 'first' | 'stable-hash';
+}
+
+export function buildIntegrationsLayer(
+  input: IntegrationContextInput,
+  opts?: IntegrationLayerOptions,
+): { content: string } | null {
+  const options = normalizeOptions(opts);
+  const lines = [
+    buildGitHubLine(input.github, options),
+    buildSurfaceLine(
+      'Slack',
+      'the Slack workspace',
+      input.slack?.channels ?? [],
+      SLACK_ROOT,
+      { pluralLabel: 'channels' },
+      options,
+    ),
+    buildSurfaceLine(
+      'Notion',
+      'the Notion workspace',
+      input.notion?.databases ?? [],
+      NOTION_ROOT,
+      { pluralLabel: 'databases' },
+      options,
+    ),
+  ].filter((line): line is string => line !== null);
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  return { content: lines.join('\n') };
+}
+
+interface NormalizedOptions {
+  maxInlineItems: number;
+  maxSampleItems: number;
+  sampleStrategy: 'first' | 'stable-hash';
+}
+
+interface SurfaceDescriptor {
+  pluralLabel: string;
+}
+
+function buildGitHubLine(
+  github: IntegrationContextInput['github'],
+  options: NormalizedOptions,
+): string | null {
+  const repoNames = normalizeItems(github?.repoNames ?? []);
+  if (repoNames.length === 0) {
+    return null;
+  }
+
+  return buildSurfaceLine(
+    'GitHub',
+    summarizeGitHubOrgs(github?.orgs ?? []),
+    repoNames,
+    GITHUB_ROOT,
+    { pluralLabel: 'repos' },
+    options,
+  );
+}
+
+function buildSurfaceLine(
+  label: string,
+  connectionSummary: string,
+  items: string[],
+  root: string,
+  descriptor: SurfaceDescriptor,
+  options: NormalizedOptions,
+): string | null {
+  const normalizedItems = normalizeItems(items);
+  if (normalizedItems.length === 0) {
+    return null;
+  }
+
+  if (normalizedItems.length <= options.maxInlineItems) {
+    return `${label}: Connected to ${connectionSummary}. Workspace contains ${descriptor.pluralLabel}: ${normalizedItems.join(', ')}.`;
+  }
+
+  const sample = selectSample(normalizedItems, options);
+
+  return [
+    `${label}: Connected to ${connectionSummary}. Workspace contains ${normalizedItems.length} ${descriptor.pluralLabel}.`,
+    `  This list is NOT exhaustive — to enumerate, call workspace_list ${root}.`,
+    `  Sample: ${sample.length > 0 ? sample.join(', ') : 'none'}.`,
+  ].join('\n');
+}
+
+function summarizeGitHubOrgs(orgs: string[]): string {
+  const normalizedOrgs = normalizeItems(orgs);
+  if (normalizedOrgs.length === 0) {
+    return 'the GitHub workspace';
+  }
+
+  if (normalizedOrgs.length === 1) {
+    return `GitHub org ${normalizedOrgs[0]}`;
+  }
+
+  const visibleOrgs = normalizedOrgs.slice(0, MAX_GITHUB_ORG_SUMMARY_ITEMS);
+  if (normalizedOrgs.length <= MAX_GITHUB_ORG_SUMMARY_ITEMS) {
+    return `GitHub orgs ${visibleOrgs.join(', ')}`;
+  }
+
+  return `${normalizedOrgs.length} GitHub orgs including ${visibleOrgs.join(', ')}`;
+}
+
+function selectSample(items: string[], options: NormalizedOptions): string[] {
+  if (options.maxSampleItems === 0) {
+    return [];
+  }
+
+  if (options.sampleStrategy === 'first') {
+    return items.slice(0, options.maxSampleItems);
+  }
+
+  return [...items]
+    .sort((left, right) => compareStableHashes(left, right) || left.localeCompare(right))
+    .slice(0, options.maxSampleItems);
+}
+
+function compareStableHashes(left: string, right: string): number {
+  return stableHashPrefix(left).localeCompare(stableHashPrefix(right));
+}
+
+function stableHashPrefix(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 8);
+}
+
+function normalizeItems(items: string[]): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    const trimmed = item.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+function normalizeOptions(opts?: IntegrationLayerOptions): NormalizedOptions {
+  return {
+    maxInlineItems: normalizeCount(opts?.maxInlineItems, DEFAULT_MAX_INLINE_ITEMS),
+    maxSampleItems: normalizeCount(opts?.maxSampleItems, DEFAULT_MAX_SAMPLE_ITEMS),
+    sampleStrategy: normalizeSampleStrategy(opts?.sampleStrategy),
+  };
+}
+
+function normalizeSampleStrategy(
+  strategy: IntegrationLayerOptions['sampleStrategy'] | undefined,
+): 'first' | 'stable-hash' {
+  if (strategy === 'first' || strategy === 'stable-hash') {
+    return strategy;
+  }
+
+  return DEFAULT_SAMPLE_STRATEGY;
+}
+
+function normalizeCount(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return Math.floor(value);
+}

--- a/packages/harness/src/stop-reason-message.ts
+++ b/packages/harness/src/stop-reason-message.ts
@@ -9,6 +9,13 @@ export interface StopReasonMessageOptions {
   canRetry?: boolean;
 }
 
+export interface TruthfulFailureReplyOptions {
+  /** Optional product-specific suffix appended to the reply text. */
+  suffix?: string;
+  /** When true, the stop reason is included as backticked text for log triage. */
+  includeStopReason?: boolean;
+}
+
 /**
  * Maps a harness stop reason to a one-line, end-user-facing message.
  *
@@ -58,6 +65,8 @@ export function stopReasonToUserMessage(
       return canRetry
         ? "I had trouble with my primary reply path. Retrying with a fallback."
         : "I had trouble producing a usable reply. Try rephrasing the request.";
+    case 'evidence_density_violation':
+      return "I couldn't answer that reliably this turn — the evidence I gathered was too sparse to support a confident answer. Could you re-ask with more specifics (repo/file/ticket)?";
     case 'runtime_error':
       return 'Something went wrong while processing that. Try again in a moment.';
     case 'cancelled':
@@ -65,4 +74,21 @@ export function stopReasonToUserMessage(
     default:
       return "I couldn't complete that request.";
   }
+}
+
+export function truthfulFailureReply(
+  stopReason: HarnessStopReason,
+  opts: TruthfulFailureReplyOptions = {},
+): string {
+  let reply = stopReasonToUserMessage(stopReason);
+
+  if (opts.suffix) {
+    reply += ` ${opts.suffix}`;
+  }
+
+  if (opts.includeStopReason) {
+    reply += ` [\`${stopReason}\`]`;
+  }
+
+  return reply;
 }

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -376,6 +376,11 @@ export type HarnessStopReason =
   | 'tool_error_unrecoverable'
   | 'model_refused'
   | 'model_invalid_response'
+  /**
+   * Emitted when post-turn claim-density check (exceedsEvidenceBudget) trips —
+   * the model produced structured factual content from sparse tool evidence.
+   */
+  | 'evidence_density_violation'
   | 'runtime_error'
   | 'cancelled';
 

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/inbox",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Bounded inbox primitives for trusted external inputs",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/inbox",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Bounded inbox primitives for trusted external inputs",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/memory",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Assistant-scoped memory composition layer over @agent-relay/memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/memory",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Assistant-scoped memory composition layer over @agent-relay/memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/policy",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Action classification, gating, and audit contracts for agent assistants",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/policy",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Action classification, gating, and audit contracts for agent assistants",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/proactive/package.json
+++ b/packages/proactive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/proactive",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Proactive decision engine for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/proactive/package.json
+++ b/packages/proactive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/proactive",
-  "version": "0.4.0",
+  "version": "0.3.18",
   "description": "Proactive decision engine for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/proactive/package.json
+++ b/packages/proactive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/proactive",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "description": "Proactive decision engine for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/proactive/src/evidence-egress.test.ts
+++ b/packages/proactive/src/evidence-egress.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { postWithEvidence } from './evidence-egress.js';
+import type { ClaimEvidence, ProactiveEgress } from './evidence-egress.js';
+
+type PostedCall = {
+  channel: string;
+  text: string;
+  threadTs?: string;
+};
+
+class FakeProactiveEgress implements ProactiveEgress {
+  readonly calls: PostedCall[] = [];
+
+  constructor(private readonly error?: Error) {}
+
+  async postMessageChunked(
+    channel: string,
+    text: string,
+    threadTs?: string,
+  ): Promise<unknown> {
+    this.calls.push({ channel, text, threadTs });
+
+    if (this.error) {
+      throw this.error;
+    }
+
+    return { ok: true };
+  }
+}
+
+function makeEvidence(): ClaimEvidence[] {
+  return [{ id: 'spec-req-1', kind: 'github_investigate' }];
+}
+
+describe('postWithEvidence', () => {
+  it('plain text post — no markers, no evidence required', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'hi team, standup in 5',
+        evidence: [],
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(true);
+    expect(egress.calls).toHaveLength(1);
+    expect(egress.calls[0]).toEqual({
+      channel: 'team-updates',
+      text: 'hi team, standup in 5',
+      threadTs: undefined,
+    });
+  });
+
+  it('PR ref + empty evidence — BLOCKED', async () => {
+    const egress = new FakeProactiveEgress();
+    const onEvent = vi.fn();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'PR AgentWorkforce/sage#173 looks ready',
+        evidence: [],
+      },
+      { egress, onEvent },
+    );
+
+    expect(result.posted).toBe(false);
+    expect(result.blockedReason).toBe('no_evidence');
+    expect(result.detectedMarkers).toContain('pr_ref');
+    expect(egress.calls).toHaveLength(0);
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'proactive_post_blocked_no_evidence',
+        channel: 'team-updates',
+      }),
+    );
+  });
+
+  it('PR ref + non-empty evidence — POSTED', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'PR AgentWorkforce/sage#173 looks ready',
+        evidence: makeEvidence(),
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(true);
+    expect(egress.calls).toHaveLength(1);
+  });
+
+  it('SHA reference + empty evidence — BLOCKED', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'b5c1e2f reverts commit aaa',
+        evidence: [],
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(false);
+    expect(result.blockedReason).toBe('no_evidence');
+    expect(egress.calls).toHaveLength(0);
+  });
+
+  it('Linear ticket + empty evidence — BLOCKED', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'ENG-456 needs your input',
+        evidence: [],
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(false);
+    expect(result.blockedReason).toBe('no_evidence');
+    expect(egress.calls).toHaveLength(0);
+  });
+
+  it("is-synced negation + empty evidence — BLOCKED", async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: "relayfile isn't synced in this workspace",
+        evidence: [],
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(false);
+    expect(result.blockedReason).toBe('no_evidence');
+    expect(egress.calls).toHaveLength(0);
+  });
+
+  it('merged-at phrasing + empty evidence — BLOCKED', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'The PR was merged at 14:32',
+        evidence: [],
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(false);
+    expect(result.blockedReason).toBe('no_evidence');
+    expect(egress.calls).toHaveLength(0);
+  });
+
+  it('github.com URL + empty evidence — BLOCKED', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'see https://github.com/AgentWorkforce/sage/pull/173',
+        evidence: [],
+      },
+      { egress },
+    );
+
+    expect(result.posted).toBe(false);
+    expect(result.blockedReason).toBe('no_evidence');
+    expect(egress.calls).toHaveLength(0);
+  });
+
+  it('bypassEvidenceCheck=true bypasses — POSTED with markers but no evidence', async () => {
+    const egress = new FakeProactiveEgress();
+
+    const result = await postWithEvidence(
+      {
+        channel: 'team-updates',
+        text: 'PR AgentWorkforce/sage#173 looks ready',
+        evidence: [],
+      },
+      { egress, bypassEvidenceCheck: true },
+    );
+
+    expect(result.posted).toBe(true);
+    expect(result.detectedMarkers?.length ?? 0).toBeGreaterThan(0);
+    expect(egress.calls).toHaveLength(1);
+  });
+
+  it('egress throws → blocked with egress_failed, no rethrow', async () => {
+    const egress = new FakeProactiveEgress(new Error('egress unavailable'));
+
+    await expect(
+      postWithEvidence(
+        {
+          channel: 'team-updates',
+          text: 'hi team, standup in 5',
+          evidence: [],
+        },
+        { egress },
+      ),
+    ).resolves.toMatchObject({
+      posted: false,
+      blockedReason: 'egress_failed',
+    });
+  });
+});

--- a/packages/proactive/src/evidence-egress.ts
+++ b/packages/proactive/src/evidence-egress.ts
@@ -1,0 +1,176 @@
+export interface ClaimEvidence {
+  /** Specialist requestId or any opaque-but-unique evidence id. */
+  id: string;
+  /** Optional kind for telemetry. */
+  kind?: string;
+  /** Optional source url / vfs path. */
+  source?: string;
+}
+
+export interface PostWithEvidenceInput {
+  channel: string;
+  threadTs?: string;
+  text: string;
+  evidence: ReadonlyArray<ClaimEvidence>;
+}
+
+export interface PostWithEvidenceResult {
+  posted: boolean;
+  blockedReason?: 'no_evidence' | 'egress_failed';
+  /** When posted, the underlying egress's return value. */
+  egressResult?: unknown;
+  /** Detected claim markers (for telemetry). */
+  detectedMarkers?: string[];
+}
+
+export interface ProactiveEgress {
+  postMessageChunked(
+    channel: string,
+    text: string,
+    threadTs?: string,
+  ): Promise<unknown>;
+}
+
+export interface PostWithEvidenceOptions {
+  egress: ProactiveEgress;
+  onEvent?: (event: {
+    event: string;
+    channel: string;
+    reason?: string;
+    markers?: string[];
+  }) => void;
+  /**
+   * Default false. When true, the evidence precondition is skipped and the
+   * post is forwarded to `egress` even if claim markers were detected with no
+   * evidence attached.
+   *
+   * Reserved for two callers ONLY:
+   *   1. Tests in this package (and downstream packages) that need to
+   *      exercise the success path without constructing real evidence.
+   *   2. A deliberate operator override at a known-safe call site where the
+   *      caller has independently verified that the text contains no
+   *      external-fact claims (e.g. a hand-authored ops broadcast). The
+   *      override MUST be accompanied by a code comment explaining why the
+   *      precondition is safe to skip at that site.
+   *
+   * Do not flip this on globally to "fix" false positives — false positives
+   * are by design (spec §6: missing a pattern lets fabrications through,
+   * blocking a benign post is recoverable).
+   */
+  bypassEvidenceCheck?: boolean;
+}
+
+const CLAIM_MARKER_PATTERNS: ReadonlyArray<{
+  name: string;
+  pattern: RegExp;
+}> = [
+  {
+    name: 'pr_ref',
+    pattern: /\b(?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d{1,6}\b/g,
+  },
+  {
+    name: 'github_url',
+    pattern: /https?:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+/g,
+  },
+  {
+    name: 'linear_ref',
+    pattern: /\b[A-Z]{2,5}-\d+\b/g,
+  },
+  {
+    name: 'sha_ref',
+    pattern: /\b[a-f0-9]{7,40}\b/g,
+  },
+  {
+    name: 'sync_status',
+    pattern:
+      /\b(?:is|isn't|is not|are|aren't|are not)\s+(?:already\s+)?(?:synced|indexed|cloned)\b/gi,
+  },
+  {
+    name: 'merged_status',
+    pattern: /\b(?:was\s+)?merged\s+(?:at|on|in)\b/gi,
+  },
+  {
+    name: 'open_duration',
+    pattern: /\bopen\s+(?:since|for)\s+\b/gi,
+  },
+];
+
+function findMatches(text: string, pattern: RegExp): string[] {
+  const matches = text.match(new RegExp(pattern.source, pattern.flags));
+  return matches ?? [];
+}
+
+function detectClaimMarkers(text: string): string[] {
+  const markers: string[] = [];
+  const seen = new Set<string>();
+
+  for (const { name, pattern } of CLAIM_MARKER_PATTERNS) {
+    if (findMatches(text, pattern).length === 0 || seen.has(name)) {
+      continue;
+    }
+
+    seen.add(name);
+    markers.push(name);
+  }
+
+  return markers;
+}
+
+function errorReason(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.length > 0) {
+    return error;
+  }
+
+  return 'Unknown egress error';
+}
+
+export async function postWithEvidence(
+  input: PostWithEvidenceInput,
+  opts: PostWithEvidenceOptions,
+): Promise<PostWithEvidenceResult> {
+  const detectedMarkers = detectClaimMarkers(input.text);
+  const hasDetectedClaims = detectedMarkers.length > 0;
+  const hasEvidence = input.evidence.length > 0;
+  const shouldBypass = opts.bypassEvidenceCheck === true;
+  const shouldBlock = hasDetectedClaims && !hasEvidence && !shouldBypass;
+
+  if (shouldBlock) {
+    opts.onEvent?.({
+      event: 'proactive_post_blocked_no_evidence',
+      channel: input.channel,
+      markers: detectedMarkers,
+    });
+    return {
+      posted: false,
+      blockedReason: 'no_evidence',
+      detectedMarkers,
+    };
+  }
+
+  try {
+    const egressResult = await opts.egress.postMessageChunked(
+      input.channel,
+      input.text,
+      input.threadTs,
+    );
+    return {
+      posted: true,
+      egressResult,
+      detectedMarkers,
+    };
+  } catch (error) {
+    opts.onEvent?.({
+      event: 'proactive_post_egress_failed',
+      channel: input.channel,
+      reason: errorReason(error),
+    });
+    return {
+      posted: false,
+      blockedReason: 'egress_failed',
+    };
+  }
+}

--- a/packages/proactive/src/index.ts
+++ b/packages/proactive/src/index.ts
@@ -86,3 +86,12 @@ export type {
   RecordSignalInput,
   SignalInboxStore,
 } from './signal-inbox.js';
+
+export { postWithEvidence } from './evidence-egress.js';
+export type {
+  ClaimEvidence,
+  PostWithEvidenceInput,
+  PostWithEvidenceResult,
+  PostWithEvidenceOptions,
+  ProactiveEgress,
+} from './evidence-egress.js';

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/sdk",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Top-level facade for the Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -21,11 +21,11 @@
   "dependencies": {
     "@agent-assistant/core": ">=0.1.0",
     "@agent-assistant/inbox": ">=0.1.0",
-    "@agent-assistant/traits": ">=0.1.0",
+    "@agent-assistant/policy": ">=0.1.0",
+    "@agent-assistant/proactive": ">=0.1.0",
     "@agent-assistant/sessions": ">=0.1.0",
     "@agent-assistant/surfaces": ">=0.1.0",
-    "@agent-assistant/policy": ">=0.1.0",
-    "@agent-assistant/proactive": ">=0.1.0"
+    "@agent-assistant/traits": ">=0.1.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/sdk",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Top-level facade for the Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/sessions",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Session lifecycle, storage, and affinity for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sessions/package.json
+++ b/packages/sessions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/sessions",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Session lifecycle, storage, and affinity for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/specialists",
-  "version": "0.5.0",
+  "version": "0.4.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/specialists",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/specialists/package.json
+++ b/packages/specialists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/specialists",
-  "version": "0.4.17",
+  "version": "0.5.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/specialists/src/bridge.test.ts
+++ b/packages/specialists/src/bridge.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSpecialistBridge, resolveSpecialistTransports } from './bridge.js';
+import type {
+  DelegationRequest,
+  DelegationTransport,
+  SpecialistFindings,
+} from './shared/findings.js';
+
+type GitHubRequest = DelegationRequest;
+
+class FakeDelegationTransport implements DelegationTransport {
+  readonly calls: GitHubRequest[] = [];
+
+  constructor(
+    private readonly handler: <TRequest extends GitHubRequest>(
+      request: TRequest,
+    ) => Promise<SpecialistFindings>,
+  ) {}
+
+  delegate<TRequest extends GitHubRequest>(request: TRequest): Promise<SpecialistFindings> {
+    this.calls.push(request);
+    return this.handler(request);
+  }
+}
+
+function createFindings(overrides: Partial<SpecialistFindings> = {}): SpecialistFindings {
+  return {
+    requestId: 'req-1',
+    capability: 'github.investigate',
+    status: 'complete',
+    summary: 'ok',
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe('createSpecialistBridge', () => {
+  it('investigate forwards owner/repo/number to github transport', async () => {
+    const transport = new FakeDelegationTransport(async (request) =>
+      createFindings({
+        requestId: request.requestId,
+        capability: request.capability,
+      }),
+    );
+    const bridge = createSpecialistBridge({ transports: { github: transport } });
+
+    await bridge.investigate({ owner: 'AgentWorkforce', repo: 'sage', number: 173 });
+
+    expect(transport.calls).toHaveLength(1);
+    expect(transport.calls[0]).toEqual({
+      requestId: expect.any(String),
+      capability: 'github.investigate',
+      params: {
+        capability: 'github.investigate',
+        query: 'AgentWorkforce/sage#173',
+        pr: {
+          owner: 'AgentWorkforce',
+          repo: 'sage',
+          number: 173,
+        },
+      },
+      timeoutMs: 30_000,
+    });
+  });
+
+  it('enumerate with filters propagates filters', async () => {
+    const transport = new FakeDelegationTransport(async (request) =>
+      createFindings({
+        requestId: request.requestId,
+        capability: request.capability,
+      }),
+    );
+    const bridge = createSpecialistBridge({ transports: { github: transport } });
+    const filters = { repo: 'a/b' } as unknown as Parameters<typeof bridge.enumerate>[1];
+
+    await bridge.enumerate('foo', filters);
+
+    expect(transport.calls).toHaveLength(1);
+    expect(transport.calls[0]).toEqual({
+      requestId: expect.any(String),
+      capability: 'github.enumerate',
+      params: {
+        capability: 'github.enumerate',
+        query: 'foo',
+        filters: { repo: 'a/b' },
+      },
+      timeoutMs: 30_000,
+    });
+  });
+
+  it('missing transport returns failed status, never throws', async () => {
+    const events: Array<{ event: string; capability?: string; reason?: string }> = [];
+    const bridge = createSpecialistBridge({
+      transports: {},
+      onEvent: (event) => {
+        events.push({
+          event: event.event,
+          capability: event.capability,
+          reason: event.reason,
+        });
+      },
+    });
+
+    const result = await bridge.investigate({ owner: 'AgentWorkforce', repo: 'sage', number: 173 });
+
+    expect(result).toEqual({
+      requestId: expect.any(String),
+      capability: 'github.investigate',
+      status: 'failed',
+      summary: 'transport_unavailable',
+      findings: [],
+      confidence: 0,
+    });
+    expect(events).toEqual([
+      {
+        event: 'specialist_unavailable',
+        capability: 'github.investigate',
+        reason: 'transport_unavailable',
+      },
+    ]);
+  });
+
+  it('transport throws → wrapped as failed', async () => {
+    const events: Array<{ event: string; capability?: string; reason?: string }> = [];
+    const transport = new FakeDelegationTransport(async () => {
+      throw new Error('boom');
+    });
+    const bridge = createSpecialistBridge({
+      transports: { github: transport },
+      onEvent: (event) => {
+        events.push({
+          event: event.event,
+          capability: event.capability,
+          reason: event.reason,
+        });
+      },
+    });
+
+    const result = await bridge.investigate({ owner: 'AgentWorkforce', repo: 'sage', number: 173 });
+
+    expect(result).toEqual({
+      requestId: expect.any(String),
+      capability: 'github.investigate',
+      status: 'failed',
+      summary: 'boom',
+      findings: [],
+      confidence: 0,
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      event: 'specialist_failed',
+      capability: 'github.investigate',
+      reason: 'boom',
+    });
+  });
+
+  it('timeout enforced - returns failed before transport resolves', async () => {
+    const events: Array<{ event: string; capability?: string; reason?: string }> = [];
+    const transport = new FakeDelegationTransport(
+      async () => await new Promise<SpecialistFindings>(() => undefined),
+    );
+    const bridge = createSpecialistBridge({
+      transports: { github: transport },
+      onEvent: (event) => {
+        events.push({
+          event: event.event,
+          capability: event.capability,
+          reason: event.reason,
+        });
+      },
+    });
+    const startedAt = Date.now();
+
+    const result = await bridge.investigate(
+      { owner: 'AgentWorkforce', repo: 'sage', number: 173 },
+      { timeoutMs: 50 },
+    );
+
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(result).toEqual({
+      requestId: expect.any(String),
+      capability: 'github.investigate',
+      status: 'failed',
+      summary: 'Delegation timed out',
+      findings: [],
+      confidence: 0,
+    });
+    expect(elapsedMs).toBeGreaterThanOrEqual(40);
+    expect(elapsedMs).toBeLessThan(150);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      event: 'specialist_timeout',
+      capability: 'github.investigate',
+      reason: 'Delegation timed out',
+    });
+  });
+});
+
+describe('resolveSpecialistTransports', () => {
+  it('resolveSpecialistTransports drops nulls', () => {
+    const github = new FakeDelegationTransport(async (request) =>
+      createFindings({
+        requestId: request.requestId,
+        capability: request.capability,
+      }),
+    );
+
+    const result = resolveSpecialistTransports({
+      resolveGithub: () => github,
+      resolveLinear: () => null,
+    });
+
+    expect(result).toEqual({ github });
+    expect(Object.keys(result)).toEqual(['github']);
+  });
+});

--- a/packages/specialists/src/bridge.ts
+++ b/packages/specialists/src/bridge.ts
@@ -1,0 +1,349 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  GitHubEnumerationParams,
+  GitHubInvestigationParams,
+  GitHubPullRequestRef,
+  GitHubQueryFilterSet,
+} from './github/types.js';
+import type { LinearEnumerationParams, LinearQueryFilterSet } from './linear/types.js';
+import {
+  DelegationTimeoutError,
+  type DelegationRequestFor,
+  type DelegationStatus,
+  type DelegationTransport,
+  type SpecialistFinding,
+  type SpecialistFindings,
+  type SpecialistFindingsFor,
+} from './shared/findings.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const GITHUB_INVESTIGATE_CAPABILITY: GitHubInvestigationParams['capability'] = 'github.investigate';
+const GITHUB_ENUMERATE_CAPABILITY: GitHubEnumerationParams['capability'] = 'github.enumerate';
+const LINEAR_ENUMERATE_CAPABILITY: LinearEnumerationParams['capability'] = 'linear.enumerate';
+
+type SpecialistBridgeEvent = {
+  event: string;
+  capability?: string;
+  reason?: string;
+  ms?: number;
+};
+
+interface LinearDelegationRequestFor<TParams extends LinearEnumerationParams> {
+  requestId: string;
+  workspaceId?: string;
+  capability: TParams['capability'];
+  params: TParams;
+  timeoutMs?: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface LinearSpecialistFindingsFor<TParams extends LinearEnumerationParams> {
+  requestId: string;
+  capability: TParams['capability'];
+  status: DelegationStatus;
+  summary: string;
+  findings: SpecialistFinding[];
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface LinearDelegationTransport {
+  delegate<TParams extends LinearEnumerationParams>(
+    request: LinearDelegationRequestFor<TParams>,
+  ): Promise<LinearSpecialistFindingsFor<TParams>>;
+}
+
+export interface SpecialistBridge {
+  investigate(
+    ref: GitHubPullRequestRef,
+    opts?: { timeoutMs?: number },
+  ): Promise<SpecialistFindings>;
+  enumerate(
+    query: string,
+    filters?: GitHubQueryFilterSet,
+    opts?: { timeoutMs?: number },
+  ): Promise<SpecialistFindings>;
+  linearEnumerate(
+    query: string,
+    filters?: LinearQueryFilterSet,
+    opts?: { timeoutMs?: number },
+  ): Promise<SpecialistFindings>;
+}
+
+export interface SpecialistTransports {
+  github?: DelegationTransport;
+  linear?: DelegationTransport;
+  notion?: DelegationTransport;
+}
+
+export interface CreateSpecialistBridgeOptions {
+  transports: SpecialistTransports;
+  defaultTimeoutMs?: number;
+  onEvent?: (event: SpecialistBridgeEvent) => void;
+}
+
+export interface SpecialistTransportResolver {
+  resolveGithub?: () => DelegationTransport | null;
+  resolveLinear?: () => DelegationTransport | null;
+  resolveNotion?: () => DelegationTransport | null;
+}
+
+export function createSpecialistBridge(opts: CreateSpecialistBridgeOptions): SpecialistBridge {
+  const defaultTimeoutMs = opts.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return {
+    async investigate(ref, callOpts) {
+      const params: GitHubInvestigationParams = {
+        capability: GITHUB_INVESTIGATE_CAPABILITY,
+        query: `${ref.owner}/${ref.repo}#${ref.number}`,
+        pr: ref,
+      };
+
+      return runGitHubDelegation({
+        capability: GITHUB_INVESTIGATE_CAPABILITY,
+        params,
+        timeoutMs: callOpts?.timeoutMs ?? defaultTimeoutMs,
+        transport: opts.transports.github,
+        onEvent: opts.onEvent,
+      });
+    },
+
+    async enumerate(query, filters, callOpts) {
+      const params: GitHubEnumerationParams = filters === undefined
+        ? {
+            capability: GITHUB_ENUMERATE_CAPABILITY,
+            query,
+          }
+        : {
+            capability: GITHUB_ENUMERATE_CAPABILITY,
+            query,
+            filters,
+          };
+
+      return runGitHubDelegation({
+        capability: GITHUB_ENUMERATE_CAPABILITY,
+        params,
+        timeoutMs: callOpts?.timeoutMs ?? defaultTimeoutMs,
+        transport: opts.transports.github,
+        onEvent: opts.onEvent,
+      });
+    },
+
+    async linearEnumerate(query, filters, callOpts) {
+      const params: LinearEnumerationParams = filters === undefined
+        ? {
+            capability: LINEAR_ENUMERATE_CAPABILITY,
+            query,
+          }
+        : {
+            capability: LINEAR_ENUMERATE_CAPABILITY,
+            query,
+            filters,
+          };
+
+      const result = await runLinearDelegation({
+        capability: LINEAR_ENUMERATE_CAPABILITY,
+        params,
+        timeoutMs: callOpts?.timeoutMs ?? defaultTimeoutMs,
+        transport: opts.transports.linear,
+        onEvent: opts.onEvent,
+      });
+
+      return result as unknown as SpecialistFindings;
+    },
+  };
+}
+
+export function resolveSpecialistTransports(
+  resolver: SpecialistTransportResolver,
+): SpecialistTransports {
+  const transports: SpecialistTransports = {};
+
+  const github = resolver.resolveGithub?.() ?? null;
+  if (github !== null) {
+    transports.github = github;
+  }
+
+  const linear = resolver.resolveLinear?.() ?? null;
+  if (linear !== null) {
+    transports.linear = linear;
+  }
+
+  const notion = resolver.resolveNotion?.() ?? null;
+  if (notion !== null) {
+    transports.notion = notion;
+  }
+
+  return transports;
+}
+
+async function runGitHubDelegation<TParams extends GitHubInvestigationParams | GitHubEnumerationParams>(args: {
+  capability: TParams['capability'];
+  params: TParams;
+  timeoutMs: number;
+  transport: DelegationTransport | undefined;
+  onEvent: ((event: SpecialistBridgeEvent) => void) | undefined;
+}): Promise<SpecialistFindingsFor<TParams>> {
+  const request: DelegationRequestFor<TParams> = {
+    requestId: randomUUID(),
+    capability: args.capability,
+    params: args.params,
+    timeoutMs: args.timeoutMs,
+  };
+
+  if (args.transport === undefined) {
+    return createUnavailableFindings(request, args.onEvent);
+  }
+
+  const startedAt = Date.now();
+
+  try {
+    return await withDelegationTimeout(
+      args.transport.delegate(request),
+      request.requestId,
+      args.timeoutMs,
+    );
+  } catch (error) {
+    return createFailedFindings({
+      requestId: request.requestId,
+      capability: request.capability,
+      error,
+      startedAt,
+      onEvent: args.onEvent,
+    });
+  }
+}
+
+async function runLinearDelegation(args: {
+  capability: LinearEnumerationParams['capability'];
+  params: LinearEnumerationParams;
+  timeoutMs: number;
+  transport: DelegationTransport | undefined;
+  onEvent: ((event: SpecialistBridgeEvent) => void) | undefined;
+}): Promise<LinearSpecialistFindingsFor<LinearEnumerationParams>> {
+  const request: LinearDelegationRequestFor<LinearEnumerationParams> = {
+    requestId: randomUUID(),
+    capability: args.capability,
+    params: args.params,
+    timeoutMs: args.timeoutMs,
+  };
+
+  if (args.transport === undefined) {
+    return createUnavailableFindings(request, args.onEvent);
+  }
+
+  const startedAt = Date.now();
+  const transport = args.transport as unknown as LinearDelegationTransport;
+
+  try {
+    return await withDelegationTimeout(
+      transport.delegate(request),
+      request.requestId,
+      args.timeoutMs,
+    );
+  } catch (error) {
+    return createFailedFindings({
+      requestId: request.requestId,
+      capability: request.capability,
+      error,
+      startedAt,
+      onEvent: args.onEvent,
+    });
+  }
+}
+
+function createUnavailableFindings<TRequest extends { requestId: string; capability: string }>(
+  request: TRequest,
+  onEvent?: (event: SpecialistBridgeEvent) => void,
+): {
+  requestId: string;
+  capability: TRequest['capability'];
+  status: 'failed';
+  summary: 'transport_unavailable';
+  findings: [];
+  confidence: 0;
+} {
+  onEvent?.({
+    event: 'specialist_unavailable',
+    capability: request.capability,
+    reason: 'transport_unavailable',
+  });
+
+  return {
+    requestId: request.requestId,
+    capability: request.capability,
+    status: 'failed',
+    summary: 'transport_unavailable',
+    findings: [],
+    confidence: 0,
+  };
+}
+
+function createFailedFindings<TCapability extends string>(args: {
+  requestId: string;
+  capability: TCapability;
+  error: unknown;
+  startedAt: number;
+  onEvent: ((event: SpecialistBridgeEvent) => void) | undefined;
+}): {
+  requestId: string;
+  capability: TCapability;
+  status: 'failed';
+  summary: string;
+  findings: [];
+  confidence: 0;
+} {
+  const summary = getErrorMessage(args.error);
+
+  args.onEvent?.({
+    event: args.error instanceof DelegationTimeoutError ? 'specialist_timeout' : 'specialist_failed',
+    capability: args.capability,
+    reason: summary,
+    ms: Date.now() - args.startedAt,
+  });
+
+  return {
+    requestId: args.requestId,
+    capability: args.capability,
+    status: 'failed',
+    summary,
+    findings: [],
+    confidence: 0,
+  };
+}
+
+async function withDelegationTimeout<TResult>(
+  promise: Promise<TResult>,
+  requestId: string,
+  timeoutMs: number,
+): Promise<TResult> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<TResult>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          reject(new DelegationTimeoutError('Delegation timed out', { requestId, timeoutMs }));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim().length > 0) {
+    return error;
+  }
+
+  return 'Unknown delegation error';
+}

--- a/packages/specialists/src/fallback.test.ts
+++ b/packages/specialists/src/fallback.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SpecialistBridge } from './bridge.js';
+import { runSpecialistFallback } from './fallback.js';
+import type { SpecialistFindings } from './shared/findings.js';
+
+type InvestigateRef = Parameters<SpecialistBridge['investigate']>[0];
+type GitHubFilters = Parameters<SpecialistBridge['enumerate']>[1];
+type LinearFilters = Parameters<SpecialistBridge['linearEnumerate']>[1];
+type CallOptions = { timeoutMs?: number } | undefined;
+
+class RecordingBridge implements SpecialistBridge {
+  readonly investigateCalls: Array<{ ref: InvestigateRef; opts: CallOptions }> = [];
+  readonly enumerateCalls: Array<{ query: string; filters: GitHubFilters; opts: CallOptions }> = [];
+  readonly linearEnumerateCalls: Array<{ query: string; filters: LinearFilters; opts: CallOptions }> = [];
+
+  constructor(
+    private readonly responses: {
+      investigate?: SpecialistFindings;
+      enumerate?: SpecialistFindings;
+      linearEnumerate?: SpecialistFindings;
+    } = {},
+  ) {}
+
+  async investigate(ref: InvestigateRef, opts?: CallOptions): Promise<SpecialistFindings> {
+    this.investigateCalls.push({ ref, opts });
+    return this.responses.investigate ?? createFindings();
+  }
+
+  async enumerate(
+    query: string,
+    filters?: GitHubFilters,
+    opts?: CallOptions,
+  ): Promise<SpecialistFindings> {
+    this.enumerateCalls.push({ query, filters, opts });
+    return this.responses.enumerate ?? createFindings();
+  }
+
+  async linearEnumerate(
+    query: string,
+    filters?: LinearFilters,
+    opts?: CallOptions,
+  ): Promise<SpecialistFindings> {
+    this.linearEnumerateCalls.push({ query, filters, opts });
+    return this.responses.linearEnumerate ?? createFindings();
+  }
+}
+
+function createFindings(
+  overrides: Partial<SpecialistFindings> = {},
+): SpecialistFindings {
+  return {
+    requestId: 'req-fallback',
+    capability: 'github.enumerate',
+    status: 'complete',
+    summary: 'ok',
+    findings: [],
+    ...overrides,
+  };
+}
+
+describe('runSpecialistFallback', () => {
+  it('routes PR refs to github_investigate', async () => {
+    const bridge = new RecordingBridge();
+
+    const result = await runSpecialistFallback(
+      { message: 'please look at AgentWorkforce/sage#173' },
+      { bridge },
+    );
+
+    expect(result.route).toBe('github_investigate');
+    expect(bridge.investigateCalls).toEqual([
+      {
+        ref: { owner: 'AgentWorkforce', repo: 'sage', number: 173 },
+        opts: undefined,
+      },
+    ]);
+    expect(bridge.enumerateCalls).toEqual([]);
+    expect(bridge.linearEnumerateCalls).toEqual([]);
+  });
+
+  it('routes github keyword plus owner/repo to github_enumerate', async () => {
+    const bridge = new RecordingBridge();
+    const message = 'is relayfile synced in the AgentWorkforce/cloud repo?';
+
+    const result = await runSpecialistFallback({ message }, { bridge });
+
+    expect(result.route).toBe('github_enumerate');
+    expect(bridge.enumerateCalls).toEqual([
+      {
+        query: message,
+        filters: { repo: ['AgentWorkforce/cloud'] },
+        opts: undefined,
+      },
+    ]);
+    expect(bridge.investigateCalls).toEqual([]);
+    expect(bridge.linearEnumerateCalls).toEqual([]);
+  });
+
+  it('routes Linear ticket patterns to linear_enumerate', async () => {
+    const bridge = new RecordingBridge();
+    const message = 'ENG-456 status?';
+
+    const result = await runSpecialistFallback({ message }, { bridge });
+
+    expect(result.route).toBe('linear_enumerate');
+    expect(bridge.linearEnumerateCalls).toEqual([
+      {
+        query: message,
+        filters: undefined,
+        opts: undefined,
+      },
+    ]);
+    expect(bridge.investigateCalls).toEqual([]);
+    expect(bridge.enumerateCalls).toEqual([]);
+  });
+
+  it('returns none with a truthful failure reason for plain questions', async () => {
+    const bridge = new RecordingBridge();
+
+    const result = await runSpecialistFallback(
+      { message: "what's the latest?" },
+      { bridge },
+    );
+
+    expect(result).toEqual({
+      route: 'none',
+      truthfulFailureReason: 'no_routable_keywords',
+    });
+    expect(bridge.investigateCalls).toEqual([]);
+    expect(bridge.enumerateCalls).toEqual([]);
+    expect(bridge.linearEnumerateCalls).toEqual([]);
+  });
+
+  it('prefers github_investigate over enumerate when a numbered ref is present', async () => {
+    const bridge = new RecordingBridge();
+
+    const result = await runSpecialistFallback(
+      { message: 'show me the diff for AgentWorkforce/cloud#397' },
+      { bridge },
+    );
+
+    expect(result.route).toBe('github_investigate');
+    expect(bridge.investigateCalls).toEqual([
+      {
+        ref: { owner: 'AgentWorkforce', repo: 'cloud', number: 397 },
+        opts: undefined,
+      },
+    ]);
+    expect(bridge.enumerateCalls).toEqual([]);
+  });
+
+  it('surfaces specialist failures with truthfulFailureReason and preserves findings', async () => {
+    const failedFindings = createFindings({
+      status: 'failed',
+      summary: 'transport_unavailable',
+    });
+    const bridge = new RecordingBridge({ investigate: failedFindings });
+
+    const result = await runSpecialistFallback(
+      { message: 'please look at AgentWorkforce/sage#173' },
+      { bridge },
+    );
+
+    expect(result.route).toBe('github_investigate');
+    expect(result.truthfulFailureReason).toBe('specialist_failed');
+    expect(result.findings).toBe(failedFindings);
+  });
+
+  it('rejects path-shaped owner/repo matches from file paths', async () => {
+    const bridge = new RecordingBridge();
+
+    const result = await runSpecialistFallback(
+      { message: 'what is happening in src/foo/bar.ts?' },
+      { bridge },
+    );
+
+    expect(result).toEqual({
+      route: 'none',
+      truthfulFailureReason: 'no_routable_keywords',
+    });
+    expect(bridge.investigateCalls).toEqual([]);
+    expect(bridge.enumerateCalls).toEqual([]);
+    expect(bridge.linearEnumerateCalls).toEqual([]);
+  });
+});

--- a/packages/specialists/src/fallback.ts
+++ b/packages/specialists/src/fallback.ts
@@ -1,0 +1,138 @@
+import type { SpecialistBridge } from './bridge.js';
+import type { GitHubPullRequestRef, GitHubQueryFilterSet } from './github/types.js';
+import type { SpecialistFindings } from './shared/findings.js';
+
+const OWNER_REPO_PATTERN = /([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\b/g;
+const NUMBER_REF_PATTERN = /#(\d+)\b/;
+const LINEAR_TICKET_PATTERN = /\b[A-Z]{2,5}-\d+\b/;
+const LINEAR_WORD_PATTERN = /\bLinear\b/;
+const GITHUB_KEYWORD_PATTERN = /\b(?:github|repo|pr|pull request|issue|commit)\b/i;
+
+type RoutedFallbackRoute = Exclude<SpecialistFallbackResult['route'], 'none'>;
+
+interface OwnerRepoRef {
+  owner: string;
+  repo: string;
+}
+
+export interface SpecialistFallbackInput {
+  message: string;
+  threadHistory?: ReadonlyArray<{ role: 'user' | 'assistant'; text: string }>;
+}
+
+export interface SpecialistFallbackResult {
+  route: 'github_investigate' | 'github_enumerate' | 'linear_enumerate' | 'none';
+  findings?: SpecialistFindings;
+  /** When route='none', caller should call truthfulFailureReply. */
+  truthfulFailureReason?: string;
+}
+
+export interface RunSpecialistFallbackOptions {
+  bridge: SpecialistBridge;
+  timeoutMs?: number;
+}
+
+export async function runSpecialistFallback(
+  input: SpecialistFallbackInput,
+  opts: RunSpecialistFallbackOptions,
+): Promise<SpecialistFallbackResult> {
+  const message = input.message;
+  const ownerRepo = parseOwnerRepo(message);
+  const callOpts = opts.timeoutMs === undefined ? undefined : { timeoutMs: opts.timeoutMs };
+
+  // Keep precedence aligned with Sage spec section 1: first match wins.
+  if (ownerRepo !== null) {
+    const pullRequestRef = parseNumberedRef(message, ownerRepo);
+    if (pullRequestRef !== null) {
+      const findings = await opts.bridge.investigate(pullRequestRef, callOpts);
+      return toRoutedResult('github_investigate', findings);
+    }
+  }
+
+  if (LINEAR_TICKET_PATTERN.test(message) || LINEAR_WORD_PATTERN.test(message)) {
+    const findings = await opts.bridge.linearEnumerate(message, undefined, callOpts);
+    return toRoutedResult('linear_enumerate', findings);
+  }
+
+  if (ownerRepo !== null && GITHUB_KEYWORD_PATTERN.test(message)) {
+    const findings = await opts.bridge.enumerate(
+      message,
+      createRepoFilter(ownerRepo),
+      callOpts,
+    );
+    return toRoutedResult('github_enumerate', findings);
+  }
+
+  return {
+    route: 'none',
+    truthfulFailureReason: 'no_routable_keywords',
+  };
+}
+
+function parseNumberedRef(message: string, ownerRepo: OwnerRepoRef): GitHubPullRequestRef | null {
+  const match = NUMBER_REF_PATTERN.exec(message);
+  if (!match) {
+    return null;
+  }
+
+  const rawNumber = match[1];
+  if (rawNumber === undefined) {
+    return null;
+  }
+
+  const number = Number.parseInt(rawNumber, 10);
+  if (!Number.isSafeInteger(number)) {
+    return null;
+  }
+
+  return {
+    owner: ownerRepo.owner,
+    repo: ownerRepo.repo,
+    number,
+  };
+}
+
+function parseOwnerRepo(message: string): OwnerRepoRef | null {
+  for (const match of message.matchAll(OWNER_REPO_PATTERN)) {
+    const fullMatch = match[0];
+    const owner = match[1];
+    const repo = match[2];
+    const start = match.index;
+
+    if (fullMatch === undefined || owner === undefined || repo === undefined || start === undefined) {
+      continue;
+    }
+
+    if (message[start + fullMatch.length] === '/') {
+      continue;
+    }
+
+    return { owner, repo };
+  }
+
+  return null;
+}
+
+function createRepoFilter(ownerRepo: OwnerRepoRef): GitHubQueryFilterSet {
+  return {
+    repo: [`${ownerRepo.owner}/${ownerRepo.repo}`],
+  };
+}
+
+function toRoutedResult(
+  route: RoutedFallbackRoute,
+  findings: SpecialistFindings,
+): SpecialistFallbackResult {
+  if (findings.status === 'failed') {
+    return {
+      route,
+      findings,
+      truthfulFailureReason: 'specialist_failed',
+    };
+  }
+
+  return {
+    route,
+    findings,
+  };
+}

--- a/packages/specialists/src/index.ts
+++ b/packages/specialists/src/index.ts
@@ -2,3 +2,20 @@ export * from './shared/index.js';
 export * from './github/index.js';
 export * from './linear/index.js';
 export * from './notion/index.js';
+export {
+  createSpecialistBridge,
+  resolveSpecialistTransports,
+} from './bridge.js';
+export type {
+  SpecialistBridge,
+  SpecialistTransports,
+  SpecialistTransportResolver,
+  CreateSpecialistBridgeOptions,
+} from './bridge.js';
+
+export { runSpecialistFallback } from './fallback.js';
+export type {
+  SpecialistFallbackInput,
+  SpecialistFallbackResult,
+  RunSpecialistFallbackOptions,
+} from './fallback.js';

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/surfaces",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Surface connection registry, inbound normalization, and outbound dispatch for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/surfaces",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Surface connection registry, inbound normalization, and outbound dispatch for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,6 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "dependencies": {},
   "devDependencies": {
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/telemetry",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Usage, cost, and response telemetry primitives for Agent Assistant",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/telemetry",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Usage, cost, and response telemetry primitives for Agent Assistant",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/traits/package.json
+++ b/packages/traits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/traits",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Validated immutable assistant traits for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/traits/package.json
+++ b/packages/traits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/traits",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Validated immutable assistant traits for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/turn-context/package.json
+++ b/packages/turn-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/turn-context",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Turn-scoped context assembly for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/turn-context/package.json
+++ b/packages/turn-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/turn-context",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Turn-scoped context assembly for Agent Assistant SDK",
   "type": "module",
   "main": "dist/index.js",
@@ -22,9 +22,9 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@agent-assistant/traits": "^0.2.0",
     "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
-    "@agent-assistant/memory": "^0.2.0"
+    "@agent-assistant/memory": "^0.2.0",
+    "@agent-assistant/traits": "^0.2.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/vfs/package.json
+++ b/packages/vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/vfs",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Provider-neutral virtual filesystem contracts and Bash-oriented CLI runner for assistant products",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vfs/package.json
+++ b/packages/vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/vfs",
-  "version": "0.4.0",
+  "version": "0.3.18",
   "description": "Provider-neutral virtual filesystem contracts and Bash-oriented CLI runner for assistant products",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vfs/package.json
+++ b/packages/vfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/vfs",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "description": "Provider-neutral virtual filesystem contracts and Bash-oriented CLI runner for assistant products",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/vfs/package.json
+++ b/packages/vfs/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./clone": {
+      "import": "./dist/clone/index.js",
+      "types": "./dist/clone/index.d.ts"
     }
   },
   "files": [

--- a/packages/vfs/src/clone/clone-requester.test.ts
+++ b/packages/vfs/src/clone/clone-requester.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CloneRequester } from './clone-requester.js';
+
+const baseUrl = 'https://cloud.example.test';
+const bearerToken = 'token-1';
+const payload = {
+  workspaceId: 'w1',
+  owner: 'o',
+  repo: 'r',
+  ref: 'refs/heads/main',
+  connectionId: 'c1',
+};
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(body === undefined ? undefined : JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    ...init,
+  });
+}
+
+function createRecordingFetch(
+  responseFactory:
+    | Response
+    | ((input: RequestInfo | URL, init?: RequestInit) => Response | Promise<Response>),
+) {
+  const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+  const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init });
+
+    if (typeof responseFactory === 'function') {
+      return await responseFactory(input, init);
+    }
+
+    return responseFactory;
+  });
+
+  return {
+    calls,
+    fetch: fetch as unknown as typeof globalThis.fetch,
+  };
+}
+
+function createJobStore(seed?: Record<string, { jobId: string; requestedAt: string }>) {
+  const data = new Map<string, { jobId: string; requestedAt: string }>(
+    Object.entries(seed ?? {}),
+  );
+
+  return {
+    async get(key: string) {
+      return data.get(key) ?? null;
+    },
+    async put(key: string, value: { jobId: string; requestedAt: string }) {
+      data.set(key, value);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('CloneRequester', () => {
+  it('sends 5-field payload', async () => {
+    const { calls, fetch } = createRecordingFetch(jsonResponse({ jobId: 'j1' }));
+    const requester = new CloneRequester({
+      baseUrl,
+      bearerToken,
+      fetch,
+    });
+
+    const result = await requester.requestIfNeeded(payload);
+
+    expect(result).toEqual({ submitted: true, jobId: 'j1' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input).toBe(`${baseUrl}/api/v1/github/clone/request`);
+    expect(calls[0]?.init).toMatchObject({
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(JSON.parse(String(calls[0]?.init?.body))).toEqual(payload);
+  });
+
+  it('cooldown gates duplicate submit within window', async () => {
+    const { fetch } = createRecordingFetch(jsonResponse({ jobId: 'j1' }));
+    const requester = new CloneRequester({
+      baseUrl,
+      bearerToken,
+      cooldownMs: 60_000,
+      fetch,
+    });
+
+    const first = await requester.requestIfNeeded(payload);
+    const second = await requester.requestIfNeeded(payload);
+
+    expect(first).toEqual({ submitted: true, jobId: 'j1' });
+    expect(second).toEqual({
+      submitted: false,
+      cooldownReason: 'in_cooldown',
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('4xx response is non-throwing', async () => {
+    const { fetch } = createRecordingFetch(
+      jsonResponse({ reason: 'bad request' }, { status: 400 }),
+    );
+    const requester = new CloneRequester({
+      baseUrl,
+      bearerToken,
+      fetch,
+    });
+
+    await expect(requester.requestIfNeeded(payload)).resolves.toMatchObject({
+      submitted: false,
+      error: {
+        status: 400,
+      },
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetch override is honored', async () => {
+    const globalFetch = vi.fn(async () => jsonResponse({ jobId: 'global' }));
+    const customFetch = vi.fn(async () => jsonResponse({ jobId: 'j1' }));
+    vi.stubGlobal('fetch', globalFetch);
+
+    const requester = new CloneRequester({
+      baseUrl,
+      bearerToken,
+      fetch: customFetch as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await requester.requestIfNeeded(payload);
+
+    expect(result).toEqual({ submitted: true, jobId: 'j1' });
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+
+  it('jobStore persists jobId on success', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'));
+
+    const jobStore = createJobStore();
+    const { fetch } = createRecordingFetch(jsonResponse({ jobId: 'j1' }));
+    const requester = new CloneRequester({
+      baseUrl,
+      bearerToken,
+      fetch,
+      jobStore,
+    });
+
+    const result = await requester.requestIfNeeded(payload);
+
+    expect(result).toEqual({ submitted: true, jobId: 'j1' });
+    await expect(jobStore.get('w1:o/r')).resolves.toEqual({
+      jobId: 'j1',
+      requestedAt: '2026-01-02T03:04:05.000Z',
+    });
+  });
+
+  it('lookupJobId reads from jobStore', async () => {
+    const jobStore = createJobStore({
+      'w1:o/r': {
+        jobId: 'j1',
+        requestedAt: '2026-01-02T03:04:05.000Z',
+      },
+    });
+    const { fetch } = createRecordingFetch(jsonResponse({ jobId: 'network' }));
+    const requester = new CloneRequester({
+      baseUrl,
+      bearerToken,
+      fetch,
+      jobStore,
+    });
+
+    const jobId = await requester.lookupJobId('w1', 'o', 'r');
+
+    expect(jobId).toBe('j1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vfs/src/clone/clone-requester.test.ts
+++ b/packages/vfs/src/clone/clone-requester.test.ts
@@ -145,6 +145,22 @@ describe('CloneRequester', () => {
     expect(globalFetch).not.toHaveBeenCalled();
   });
 
+  it('default fetch resolves at call time (Worker compat)', async () => {
+    // Codex P1: storing a bare globalThis.fetch reference in the constructor
+    // throws "Illegal invocation" in Cloudflare Workers. The lambda fallback
+    // (input, init) => globalThis.fetch(input, init) defers binding to call
+    // time. Verify by mutating globalThis.fetch AFTER construction.
+    const requester = new CloneRequester({ baseUrl, bearerToken });
+
+    const lateFetch = vi.fn(async () => jsonResponse({ jobId: 'late' }));
+    vi.stubGlobal('fetch', lateFetch);
+
+    const result = await requester.requestIfNeeded(payload);
+
+    expect(result).toEqual({ submitted: true, jobId: 'late' });
+    expect(lateFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('jobStore persists jobId on success', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'));

--- a/packages/vfs/src/clone/clone-requester.ts
+++ b/packages/vfs/src/clone/clone-requester.ts
@@ -1,4 +1,4 @@
-import type { CloneRequestPayload } from "./types";
+import type { CloneRequestPayload } from "./types.js";
 
 const DEFAULT_COOLDOWN_MS = 300_000;
 const CLEANUP_THRESHOLD = 1_000;

--- a/packages/vfs/src/clone/clone-requester.ts
+++ b/packages/vfs/src/clone/clone-requester.ts
@@ -129,7 +129,12 @@ export class CloneRequester {
   constructor(opts: CloneRequesterOptions) {
     this.baseUrl = requireNonEmpty(opts.baseUrl, "baseUrl").replace(/\/+$/, "");
     this.bearerToken = requireNonEmpty(opts.bearerToken, "bearerToken");
-    this.fetchImpl = opts.fetch ?? globalThis.fetch;
+    // Wrap globalThis.fetch in a lambda so each call resolves the binding at
+    // invocation time. Storing a bare `globalThis.fetch` reference throws
+    // "Illegal invocation" in Cloudflare Workers because the receiver context
+    // is lost when called via a class field. Same pattern used in
+    // clone-status-reader.ts and sentinel.ts.
+    this.fetchImpl = opts.fetch ?? ((input, init) => globalThis.fetch(input, init));
     this.cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS;
     this.jobStore = opts.jobStore;
     this.onEvent = opts.onEvent;

--- a/packages/vfs/src/clone/clone-requester.ts
+++ b/packages/vfs/src/clone/clone-requester.ts
@@ -1,0 +1,311 @@
+import type { CloneRequestPayload } from "./types";
+
+const DEFAULT_COOLDOWN_MS = 300_000;
+const CLEANUP_THRESHOLD = 1_000;
+const CLONE_REQUEST_PATH = "/api/v1/github/clone/request";
+
+interface ObservedCloneJob {
+  jobId: string | null;
+  requestedAt: number;
+}
+
+export interface CloneRequesterOptions {
+  /** Authority for the clone-request endpoint (e.g. https://cloud...). */
+  baseUrl: string;
+  /** Bearer token. SageCloudApiToken or SpecialistCloudApiToken. */
+  bearerToken: string;
+  /** Optional fetch (defaults to globalThis.fetch). Per .claude/rules/workers-fetch.md. */
+  fetch?: typeof globalThis.fetch;
+  /** In-memory cooldown. Default 300_000 (5 min). */
+  cooldownMs?: number;
+  /** Optional persistence for { workspaceId:owner/repo -> { jobId, requestedAt } }. */
+  jobStore?: CloneJobStore;
+  /** Optional event sink. */
+  onEvent?: (event: {
+    event: string;
+    jobId?: string;
+    reason?: string;
+    status?: number;
+  }) => void;
+}
+
+export interface CloneJobStore {
+  get(key: string): Promise<{ jobId: string; requestedAt: string } | null>;
+  put(key: string, value: { jobId: string; requestedAt: string }): Promise<void>;
+}
+
+export interface CloneRequestResult {
+  submitted: boolean;
+  jobId?: string;
+  cooldownReason?: "in_cooldown";
+  error?: { status: number; body?: unknown };
+}
+
+function requireNonEmpty(value: string, field: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`Clone requester configuration is missing ${field}`);
+  }
+  return normalized;
+}
+
+function createCacheKey(workspaceId: string, owner: string, repo: string): string {
+  return `${workspaceId}:${owner}/${repo}`;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message ? error.message : String(error);
+}
+
+function parseRequestedAt(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+function extractJobId(body: unknown): string | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const candidate = (body as { jobId?: unknown }).jobId;
+  if (typeof candidate !== "string") {
+    return null;
+  }
+
+  const normalized = candidate.trim();
+  return normalized || null;
+}
+
+function extractReason(body: unknown): string | undefined {
+  if (typeof body === "string") {
+    const normalized = body.trim();
+    return normalized || undefined;
+  }
+
+  if (!body || typeof body !== "object") {
+    return undefined;
+  }
+
+  const reason = (body as { reason?: unknown }).reason;
+  if (typeof reason === "string" && reason.trim()) {
+    return reason.trim();
+  }
+
+  const message = (body as { message?: unknown }).message;
+  if (typeof message === "string" && message.trim()) {
+    return message.trim();
+  }
+
+  const error = (body as { error?: unknown }).error;
+  if (typeof error === "string" && error.trim()) {
+    return error.trim();
+  }
+
+  return undefined;
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+export class CloneRequester {
+  private readonly baseUrl: string;
+  private readonly bearerToken: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly cooldownMs: number;
+  private readonly jobStore?: CloneJobStore;
+  private readonly onEvent?: CloneRequesterOptions["onEvent"];
+  private readonly observedJobs = new Map<string, ObservedCloneJob>();
+
+  constructor(opts: CloneRequesterOptions) {
+    this.baseUrl = requireNonEmpty(opts.baseUrl, "baseUrl").replace(/\/+$/, "");
+    this.bearerToken = requireNonEmpty(opts.bearerToken, "bearerToken");
+    this.fetchImpl = opts.fetch ?? globalThis.fetch;
+    this.cooldownMs = opts.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+    this.jobStore = opts.jobStore;
+    this.onEvent = opts.onEvent;
+  }
+
+  async requestIfNeeded(payload: CloneRequestPayload): Promise<CloneRequestResult> {
+    const key = createCacheKey(payload.workspaceId, payload.owner, payload.repo);
+    const now = Date.now();
+
+    this.cleanupExpired(now);
+
+    try {
+      const existing = await this.getObservedJob(key);
+      if (existing && now - existing.requestedAt < this.cooldownMs) {
+        return { submitted: false, cooldownReason: "in_cooldown" };
+      }
+
+      this.observedJobs.set(key, {
+        jobId: existing?.jobId ?? null,
+        requestedAt: now,
+      });
+      this.cleanupExpired(now);
+
+      const response = await this.fetchImpl(`${this.baseUrl}${CLONE_REQUEST_PATH}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.bearerToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const body = await readResponseBody(response);
+      if (!response.ok) {
+        const reason =
+          extractReason(body) ?? `Clone request failed with status ${response.status}`;
+        this.emitEvent({
+          event: "clone_request_failed",
+          reason,
+          status: response.status,
+        });
+        return {
+          submitted: false,
+          error: { status: response.status, body },
+        };
+      }
+
+      const jobId = extractJobId(body);
+      if (!jobId) {
+        const reason = "Clone request response did not include a jobId";
+        this.emitEvent({
+          event: "clone_request_failed",
+          reason,
+          status: response.status,
+        });
+        return {
+          submitted: false,
+          error: { status: response.status, body },
+        };
+      }
+
+      const requestedAt = new Date(now).toISOString();
+      this.observedJobs.set(key, { jobId, requestedAt: now });
+      await this.persistObservedJob(key, { jobId, requestedAt });
+      this.emitEvent({ event: "clone_requested", jobId });
+      return { submitted: true, jobId };
+    } catch (error) {
+      this.emitEvent({
+        event: "clone_request_error",
+        reason: toErrorMessage(error),
+      });
+      return { submitted: false, error: { status: 0 } };
+    }
+  }
+
+  async lookupJobId(
+    workspaceId: string,
+    owner: string,
+    repo: string,
+  ): Promise<string | null> {
+    const key = createCacheKey(workspaceId, owner, repo);
+    const observed = this.observedJobs.get(key);
+    if (observed?.jobId) {
+      return observed.jobId;
+    }
+
+    const stored = await this.readStoredJob(key);
+    if (!stored) {
+      return null;
+    }
+
+    const requestedAt = parseRequestedAt(stored.requestedAt) ?? Date.now();
+    this.observedJobs.set(key, { jobId: stored.jobId, requestedAt });
+    this.cleanupExpired(Date.now());
+    return stored.jobId;
+  }
+
+  private async getObservedJob(key: string): Promise<ObservedCloneJob | null> {
+    const inMemory = this.observedJobs.get(key) ?? null;
+    const stored = await this.readStoredJob(key);
+
+    if (!stored) {
+      return inMemory;
+    }
+
+    const fromStore: ObservedCloneJob = {
+      jobId: stored.jobId,
+      requestedAt: parseRequestedAt(stored.requestedAt) ?? 0,
+    };
+
+    if (!inMemory || fromStore.requestedAt >= inMemory.requestedAt) {
+      this.observedJobs.set(key, fromStore);
+      return fromStore;
+    }
+
+    return inMemory;
+  }
+
+  private async readStoredJob(
+    key: string,
+  ): Promise<{ jobId: string; requestedAt: string } | null> {
+    if (!this.jobStore) {
+      return null;
+    }
+
+    try {
+      return await this.jobStore.get(key);
+    } catch (error) {
+      this.emitEvent({
+        event: "clone_request_error",
+        reason: `clone job store get failed: ${toErrorMessage(error)}`,
+      });
+      return null;
+    }
+  }
+
+  private async persistObservedJob(
+    key: string,
+    value: { jobId: string; requestedAt: string },
+  ): Promise<void> {
+    if (!this.jobStore) {
+      return;
+    }
+
+    try {
+      await this.jobStore.put(key, value);
+    } catch (error) {
+      this.emitEvent({
+        event: "clone_request_error",
+        reason: `clone job store put failed: ${toErrorMessage(error)}`,
+      });
+    }
+  }
+
+  private cleanupExpired(now: number): void {
+    if (this.observedJobs.size <= CLEANUP_THRESHOLD) {
+      return;
+    }
+
+    for (const [key, observed] of this.observedJobs) {
+      if (now - observed.requestedAt > this.cooldownMs) {
+        this.observedJobs.delete(key);
+      }
+    }
+  }
+
+  private emitEvent(event: {
+    event: string;
+    jobId?: string;
+    reason?: string;
+    status?: number;
+  }): void {
+    try {
+      this.onEvent?.(event);
+    } catch {
+      // Event sinks are best-effort only; requestIfNeeded must never throw.
+    }
+  }
+}

--- a/packages/vfs/src/clone/clone-status-reader.test.ts
+++ b/packages/vfs/src/clone/clone-status-reader.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CloneStatusReader } from './clone-status-reader.js';
+
+function jsonResponse(payload: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    status: 200,
+    ...init,
+  });
+}
+
+function createReader(options?: {
+  cacheTtlMs?: number;
+  fetch?: typeof globalThis.fetch;
+  onEvent?: (event: {
+    event: string;
+    state?: string;
+    ms?: number;
+    reason?: string;
+  }) => void;
+}) {
+  return new CloneStatusReader({
+    baseUrl: 'https://clone.example.test',
+    bearerToken: 'test-token',
+    cacheTtlMs: options?.cacheTtlMs,
+    fetch: options?.fetch,
+    onEvent: options?.onEvent,
+  });
+}
+
+describe('CloneStatusReader', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('statusForRepo hits /by-repo with query params', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'no_jobs' }));
+    const reader = createReader({ fetch: fetchMock as typeof globalThis.fetch });
+
+    await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain(
+      '/api/v1/github/clone/status/by-repo?workspaceId=workspace-123&owner=openai&repo=sage',
+    );
+    expect(init).toMatchObject({
+      method: 'GET',
+      headers: expect.objectContaining({
+        Accept: 'application/json',
+        Authorization: 'Bearer test-token',
+      }),
+    });
+  });
+
+  it('state=succeeded returns CloneJobStatus', async () => {
+    const payload = {
+      jobId: 'job-123',
+      state: 'succeeded',
+      completedAt: '2026-05-02T10:00:00.000Z',
+      headSha: 'abc123def456',
+    };
+    const fetchMock = vi.fn(async () => jsonResponse(payload));
+    const reader = createReader({ fetch: fetchMock as typeof globalThis.fetch });
+
+    const result = await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(result).toEqual(payload);
+  });
+
+  it('state=no_jobs returns null', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ state: 'no_jobs' }));
+    const reader = createReader({ fetch: fetchMock as typeof globalThis.fetch });
+
+    const result = await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(result).toBeNull();
+  });
+
+  it('cache TTL avoids second network call', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-02T12:00:00.000Z'));
+
+    const payload = {
+      jobId: 'job-123',
+      state: 'running',
+      startedAt: '2026-05-02T11:59:00.000Z',
+    };
+    const fetchMock = vi.fn(async () => jsonResponse(payload));
+    const reader = createReader({
+      cacheTtlMs: 1_000,
+      fetch: fetchMock as typeof globalThis.fetch,
+    });
+
+    await reader.statusForRepo('workspace-123', 'openai', 'sage');
+    await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_001);
+
+    await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate evicts from cache', async () => {
+    const payload = {
+      jobId: 'job-123',
+      state: 'queued',
+      queuedAt: '2026-05-02T11:58:00.000Z',
+    };
+    const fetchMock = vi.fn(async () => jsonResponse(payload));
+    const reader = createReader({
+      cacheTtlMs: 30_000,
+      fetch: fetchMock as typeof globalThis.fetch,
+    });
+
+    await reader.statusForRepo('workspace-123', 'openai', 'sage');
+    reader.invalidate('workspace-123', 'openai', 'sage');
+    await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('404 returns null and is cached briefly', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-02T12:00:00.000Z'));
+
+    const fetchMock = vi.fn(async () => new Response(null, { status: 404, statusText: 'Not Found' }));
+    const reader = createReader({
+      cacheTtlMs: 1_000,
+      fetch: fetchMock as typeof globalThis.fetch,
+    });
+
+    await expect(reader.statusForRepo('workspace-123', 'openai', 'sage')).resolves.toBeNull();
+    await expect(reader.statusForRepo('workspace-123', 'openai', 'sage')).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('errors return null and emit clone_status_error event', async () => {
+    const events: Array<{
+      event: string;
+      state?: string;
+      ms?: number;
+      reason?: string;
+    }> = [];
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network unavailable');
+    });
+    const reader = createReader({
+      fetch: fetchMock as typeof globalThis.fetch,
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    const result = await reader.statusForRepo('workspace-123', 'openai', 'sage');
+
+    expect(result).toBeNull();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: 'clone_status_error',
+      reason: 'network unavailable',
+    });
+  });
+});

--- a/packages/vfs/src/clone/clone-status-reader.ts
+++ b/packages/vfs/src/clone/clone-status-reader.ts
@@ -1,0 +1,267 @@
+import type { CloneJobState, CloneJobStatus } from './types.js';
+
+export interface CloneStatusReaderOptions {
+  baseUrl: string;
+  bearerToken: string;
+  fetch?: typeof globalThis.fetch;
+  /** In-memory cache TTL. Default 30_000 (30s). */
+  cacheTtlMs?: number;
+  onEvent?: (event: {
+    event: string;
+    state?: string;
+    ms?: number;
+    reason?: string;
+  }) => void;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  value: CloneJobStatus | null;
+}
+
+interface PollResult {
+  cacheable: boolean;
+  value: CloneJobStatus | null;
+}
+
+interface ParsedCloneStatus {
+  state?: string;
+  valid: boolean;
+  value: CloneJobStatus | null;
+}
+
+const DEFAULT_CACHE_TTL_MS = 30_000;
+const CLONE_JOB_STATES: ReadonlySet<CloneJobState> = new Set([
+  'queued',
+  'running',
+  'succeeded',
+  'failed',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isCloneJobState(value: unknown): value is CloneJobState {
+  return typeof value === 'string' && CLONE_JOB_STATES.has(value as CloneJobState);
+}
+
+function parseCloneJobStatus(payload: unknown): ParsedCloneStatus {
+  if (payload === null) {
+    return {
+      valid: true,
+      value: null,
+    };
+  }
+
+  if (!isRecord(payload)) {
+    return {
+      valid: false,
+      value: null,
+    };
+  }
+
+  const state = optionalString(payload.state);
+  if (state === 'no_jobs') {
+    return {
+      state,
+      valid: true,
+      value: null,
+    };
+  }
+
+  const jobId = optionalString(payload.jobId);
+  if (!jobId || !isCloneJobState(state)) {
+    return {
+      state,
+      valid: false,
+      value: null,
+    };
+  }
+
+  return {
+    state,
+    valid: true,
+    value: {
+      jobId,
+      state,
+      ...(optionalString(payload.queuedAt) ? { queuedAt: optionalString(payload.queuedAt) } : {}),
+      ...(optionalString(payload.startedAt)
+        ? { startedAt: optionalString(payload.startedAt) }
+        : {}),
+      ...(optionalString(payload.completedAt)
+        ? { completedAt: optionalString(payload.completedAt) }
+        : {}),
+      ...(optionalString(payload.headSha) ? { headSha: optionalString(payload.headSha) } : {}),
+      ...(optionalString(payload.errorMessage)
+        ? { errorMessage: optionalString(payload.errorMessage) }
+        : {}),
+      ...(optionalString(payload.cloneSource)
+        ? { cloneSource: optionalString(payload.cloneSource) }
+        : {}),
+    },
+  };
+}
+
+function toReason(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export class CloneStatusReader {
+  private readonly baseUrl: string;
+  private readonly bearerToken: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly cacheTtlMs: number;
+  private readonly onEvent?: CloneStatusReaderOptions['onEvent'];
+  private readonly repoCache = new Map<string, CacheEntry>();
+
+  constructor(opts: CloneStatusReaderOptions) {
+    this.baseUrl = opts.baseUrl;
+    this.bearerToken = opts.bearerToken;
+    this.fetchImpl = opts.fetch ?? ((input, init) => globalThis.fetch(input, init));
+    this.cacheTtlMs =
+      typeof opts.cacheTtlMs === 'number' && Number.isFinite(opts.cacheTtlMs) && opts.cacheTtlMs >= 0
+        ? opts.cacheTtlMs
+        : DEFAULT_CACHE_TTL_MS;
+    this.onEvent = opts.onEvent;
+  }
+
+  async statusForRepo(
+    workspaceId: string,
+    owner: string,
+    repo: string,
+  ): Promise<CloneJobStatus | null> {
+    const cacheKey = this.repoCacheKey(workspaceId, owner, repo);
+    const cached = this.repoCache.get(cacheKey);
+    const now = Date.now();
+
+    if (cached && cached.expiresAt > now) {
+      return cached.value;
+    }
+
+    if (cached) {
+      this.repoCache.delete(cacheKey);
+    }
+
+    const url = new URL('/api/v1/github/clone/status/by-repo', this.baseUrl);
+    url.searchParams.set('workspaceId', workspaceId);
+    url.searchParams.set('owner', owner);
+    url.searchParams.set('repo', repo);
+
+    const result = await this.poll(url);
+    if (result.cacheable) {
+      this.repoCache.set(cacheKey, {
+        expiresAt: now + this.cacheTtlMs,
+        value: result.value,
+      });
+    }
+
+    return result.value;
+  }
+
+  async statusForJob(jobId: string): Promise<CloneJobStatus | null> {
+    const url = new URL(
+      `/api/v1/github/clone/status/${encodeURIComponent(jobId)}`,
+      this.baseUrl,
+    );
+
+    return (await this.poll(url)).value;
+  }
+
+  invalidate(workspaceId: string, owner: string, repo: string): void {
+    this.repoCache.delete(this.repoCacheKey(workspaceId, owner, repo));
+  }
+
+  private repoCacheKey(workspaceId: string, owner: string, repo: string): string {
+    return `${workspaceId}:${owner}/${repo}`;
+  }
+
+  private async poll(url: URL): Promise<PollResult> {
+    const startedAt = Date.now();
+
+    try {
+      const response = await this.fetchImpl(url, {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${this.bearerToken}`,
+        },
+        method: 'GET',
+      });
+
+      if (response.status === 404) {
+        return {
+          cacheable: true,
+          value: null,
+        };
+      }
+
+      if (!response.ok) {
+        this.emit({
+          event: 'clone_status_error',
+          reason: `HTTP ${response.status} ${response.statusText}`.trim(),
+        });
+        return {
+          cacheable: false,
+          value: null,
+        };
+      }
+
+      const parsed = parseCloneJobStatus(await response.json());
+      if (!parsed.valid) {
+        this.emit({
+          event: 'clone_status_error',
+          reason: 'Invalid clone status response payload',
+        });
+        return {
+          cacheable: false,
+          value: null,
+        };
+      }
+
+      this.emit({
+        event: 'clone_status_polled',
+        ms: Date.now() - startedAt,
+        state: parsed.state ?? parsed.value?.state,
+      });
+
+      return {
+        cacheable: true,
+        value: parsed.value,
+      };
+    } catch (error) {
+      this.emit({
+        event: 'clone_status_error',
+        reason: toReason(error),
+      });
+      return {
+        cacheable: false,
+        value: null,
+      };
+    }
+  }
+
+  private emit(event: {
+    event: string;
+    state?: string;
+    ms?: number;
+    reason?: string;
+  }): void {
+    if (!this.onEvent) {
+      return;
+    }
+
+    try {
+      this.onEvent(event);
+    } catch {
+      // Intentionally swallow observer failures so reads never throw.
+    }
+  }
+}

--- a/packages/vfs/src/clone/ensure-clone-fresh.test.ts
+++ b/packages/vfs/src/clone/ensure-clone-fresh.test.ts
@@ -184,6 +184,7 @@ describe('ensureCloneFresh', () => {
     expect(advisory).toEqual({
       notice: 'clone_requested',
       cloneState: 'queued',
+      cloneJobId: 'job-req-1',
     });
   });
 
@@ -271,6 +272,7 @@ describe('ensureCloneFresh', () => {
     expect(advisory).toEqual({
       notice: 'clone_requested',
       cloneState: 'queued',
+      cloneJobId: 'job-req-1',
     });
   });
 
@@ -327,5 +329,49 @@ describe('ensureCloneFresh', () => {
     expect(sentinelReader.read).not.toHaveBeenCalled();
     expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
     expect(connectionIdResolver).not.toHaveBeenCalled();
+  });
+
+  it('request 4xx returns clone_failed (not clone_requested)', async () => {
+    // Codex P1: avoid masking real failures behind clone_requested.
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester } = createOptions({
+      status: null,
+      sentinel: null,
+      connectionId: 'c1',
+    });
+    cloneRequester.requestIfNeeded.mockResolvedValueOnce({
+      submitted: false,
+      error: { status: 400 },
+    });
+
+    const advisory = await ensureCloneFresh(WORKSPACE_ID, OWNER, REPO, options);
+
+    expect(advisory).toEqual({
+      notice: 'clone_failed',
+      cloneState: 'unknown',
+      reason: 'request_failed_status_400',
+    });
+  });
+
+  it('request throws → clone_failed with thrown message', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester } = createOptions({
+      status: null,
+      sentinel: null,
+      connectionId: 'c1',
+    });
+    cloneRequester.requestIfNeeded.mockRejectedValueOnce(new Error('boom'));
+
+    const advisory = await ensureCloneFresh(WORKSPACE_ID, OWNER, REPO, options);
+
+    expect(advisory).toEqual({
+      notice: 'clone_failed',
+      cloneState: 'unknown',
+      reason: 'boom',
+    });
   });
 });

--- a/packages/vfs/src/clone/ensure-clone-fresh.test.ts
+++ b/packages/vfs/src/clone/ensure-clone-fresh.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ensureCloneFresh,
+  type EnsureCloneFreshOptions,
+} from './ensure-clone-fresh.js';
+import type { CloneAdvisory, CloneJobStatus, CloneSentinel } from './types.js';
+
+const NOW = new Date('2026-05-02T12:00:00.000Z');
+const WORKSPACE_ID = 'w1';
+const OWNER = 'octocat';
+const REPO = 'hello-world';
+
+type StatusReaderStub = {
+  statusForRepo: ReturnType<typeof vi.fn>;
+};
+
+type SentinelReaderStub = {
+  read: ReturnType<typeof vi.fn>;
+};
+
+type CloneRequesterStub = {
+  requestIfNeeded: ReturnType<typeof vi.fn>;
+};
+
+type ConnectionIdResolverStub = ReturnType<typeof vi.fn>;
+
+function isoDaysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function createStatusReader(status: CloneJobStatus | null): StatusReaderStub {
+  return {
+    statusForRepo: vi.fn(async () => status),
+  };
+}
+
+function createSentinelReader(
+  sentinel: CloneSentinel | null,
+): SentinelReaderStub {
+  return {
+    read: vi.fn(async () =>
+      sentinel === null ? null : { content: JSON.stringify(sentinel) },
+    ),
+  };
+}
+
+function createCloneRequester(): CloneRequesterStub {
+  return {
+    requestIfNeeded: vi.fn(async () => ({ submitted: true, jobId: 'job-req-1' })),
+  };
+}
+
+function createConnectionIdResolver(
+  connectionId: string | null = 'c1',
+): ConnectionIdResolverStub {
+  return vi.fn(async () => connectionId);
+}
+
+function createOptions(args?: {
+  status?: CloneJobStatus | null;
+  sentinel?: CloneSentinel | null;
+  connectionId?: string | null;
+  defaultRef?: string;
+}) {
+  const statusReader = createStatusReader(args?.status ?? null);
+  const sentinelReader = createSentinelReader(args?.sentinel ?? null);
+  const cloneRequester = createCloneRequester();
+  const connectionIdResolver = createConnectionIdResolver(args?.connectionId);
+
+  const options: EnsureCloneFreshOptions = {
+    statusReader:
+      statusReader as unknown as EnsureCloneFreshOptions['statusReader'],
+    sentinelReader:
+      sentinelReader as unknown as EnsureCloneFreshOptions['sentinelReader'],
+    cloneRequester:
+      cloneRequester as unknown as EnsureCloneFreshOptions['cloneRequester'],
+    connectionIdResolver,
+    ...(args?.defaultRef ? { defaultRef: args.defaultRef } : {}),
+  };
+
+  return {
+    options,
+    statusReader,
+    sentinelReader,
+    cloneRequester,
+    connectionIdResolver,
+  };
+}
+
+describe('ensureCloneFresh', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('state=running returns clone_in_progress advisory', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, sentinelReader, cloneRequester, connectionIdResolver } =
+      createOptions({
+        status: {
+          state: 'running',
+          jobId: 'job-123',
+          startedAt: '2026-05-02T11:45:00.000Z',
+        },
+      });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(advisory).toEqual<CloneAdvisory>({
+      notice: 'clone_in_progress',
+      cloneState: 'running',
+      cloneJobId: 'job-123',
+      cloneStartedAt: '2026-05-02T11:45:00.000Z',
+    });
+    expect(sentinelReader.read).not.toHaveBeenCalled();
+    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    expect(connectionIdResolver).not.toHaveBeenCalled();
+  });
+
+  it('state=succeeded fresh returns null', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, sentinelReader, cloneRequester, connectionIdResolver } =
+      createOptions({
+        status: {
+          state: 'succeeded',
+          jobId: 'job-123',
+          completedAt: isoDaysAgo(5),
+          headSha: 'abc123',
+        },
+      });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(advisory).toBeNull();
+    expect(sentinelReader.read).not.toHaveBeenCalled();
+    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    expect(connectionIdResolver).not.toHaveBeenCalled();
+  });
+
+  it('state=succeeded stale triggers fresh request', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester, connectionIdResolver } = createOptions({
+      status: {
+        state: 'succeeded',
+        jobId: 'job-123',
+        completedAt: isoDaysAgo(31),
+        headSha: 'stale123',
+      },
+      sentinel: null,
+      connectionId: 'c1',
+    });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(connectionIdResolver).toHaveBeenCalledWith(WORKSPACE_ID, OWNER, REPO);
+    expect(cloneRequester.requestIfNeeded).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      owner: OWNER,
+      repo: REPO,
+      ref: 'refs/heads/main',
+      connectionId: 'c1',
+    });
+    expect(advisory).toEqual({
+      notice: 'clone_requested',
+      cloneState: 'queued',
+    });
+  });
+
+  it('state=failed surfaces clone_failed', async () => {
+    const { options, sentinelReader, cloneRequester, connectionIdResolver } =
+      createOptions({
+        status: {
+          state: 'failed',
+          jobId: 'job-oom',
+          errorMessage: 'OOM',
+        },
+      });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(advisory).toEqual({
+      notice: 'clone_failed',
+      cloneState: 'failed',
+      cloneJobId: 'job-oom',
+      reason: 'OOM',
+    });
+    expect(sentinelReader.read).not.toHaveBeenCalled();
+    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    expect(connectionIdResolver).not.toHaveBeenCalled();
+  });
+
+  it('status outage falls through to sentinel', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester, connectionIdResolver } = createOptions({
+      status: null,
+      sentinel: {
+        jobId: 'job-sentinel',
+        headSha: 'head123',
+        defaultBranch: 'main',
+        clonedAt: isoDaysAgo(1),
+        filesWritten: 42,
+        cloneSource: 'github',
+      },
+    });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(advisory).toBeNull();
+    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    expect(connectionIdResolver).not.toHaveBeenCalled();
+  });
+
+  it('no status, no sentinel → request fired', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester, connectionIdResolver } = createOptions({
+      status: null,
+      sentinel: null,
+      connectionId: 'c1',
+    });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(connectionIdResolver).toHaveBeenCalledWith(WORKSPACE_ID, OWNER, REPO);
+    expect(cloneRequester.requestIfNeeded).toHaveBeenCalledWith({
+      workspaceId: WORKSPACE_ID,
+      owner: OWNER,
+      repo: REPO,
+      ref: 'refs/heads/main',
+      connectionId: 'c1',
+    });
+    expect(advisory).toEqual({
+      notice: 'clone_requested',
+      cloneState: 'queued',
+    });
+  });
+
+  it('unresolvable connectionId returns clone_failed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester, connectionIdResolver } = createOptions({
+      status: null,
+      sentinel: null,
+      connectionId: null,
+    });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    expect(connectionIdResolver).toHaveBeenCalledWith(WORKSPACE_ID, OWNER, REPO);
+    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    expect(advisory).toEqual({
+      notice: 'clone_failed',
+      cloneState: 'unknown',
+      reason: 'connection_unresolved',
+    });
+  });
+
+  it('spec §5a — listing-shape independence', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, sentinelReader, cloneRequester, connectionIdResolver } =
+      createOptions({
+        status: {
+          state: 'succeeded',
+          jobId: 'job-123',
+          completedAt: isoDaysAgo(2),
+          headSha: 'fresh123',
+        },
+        sentinel: null,
+      });
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      options,
+    );
+
+    // Ensures the heuristic-replacement contract: listing entries no longer drive the decision.
+    expect(advisory).toBeNull();
+    expect(sentinelReader.read).not.toHaveBeenCalled();
+    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    expect(connectionIdResolver).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vfs/src/clone/ensure-clone-fresh.ts
+++ b/packages/vfs/src/clone/ensure-clone-fresh.ts
@@ -1,4 +1,4 @@
-import { CloneRequester } from './clone-requester.js'
+import { CloneRequester, type CloneRequestResult } from './clone-requester.js'
 import { CloneStatusReader } from './clone-status-reader.js'
 import { readCloneSentinel, type VfsReader } from './sentinel.js'
 import type { CloneAdvisory } from './types.js'
@@ -93,18 +93,40 @@ export async function ensureCloneFresh(
     }
   }
 
-  opts.cloneRequester
-    .requestIfNeeded({
+  // Await the enqueue so the advisory reflects the actual outcome. A
+  // fire-and-forget here would return clone_requested even when the request
+  // 4xx'd / 5xx'd / threw — masking real failures from callers.
+  let requestResult: CloneRequestResult
+  try {
+    requestResult = await opts.cloneRequester.requestIfNeeded({
       workspaceId,
       owner,
       repo,
       ref: opts.defaultRef ?? DEFAULT_REF,
       connectionId,
     })
-    .catch(() => {})
+  } catch (error) {
+    return {
+      notice: 'clone_failed',
+      cloneState: 'unknown',
+      reason: error instanceof Error ? error.message : 'request_threw',
+    }
+  }
 
+  if (requestResult.error) {
+    return {
+      notice: 'clone_failed',
+      cloneState: 'unknown',
+      reason: `request_failed_status_${requestResult.error.status}`,
+    }
+  }
+
+  // submitted=true OR cooldownReason='in_cooldown' both mean the request is
+  // either freshly queued or already in flight from a recent submit — both
+  // are accurately described by clone_requested.
   return {
     notice: 'clone_requested',
     cloneState: 'queued',
+    cloneJobId: requestResult.jobId,
   }
 }

--- a/packages/vfs/src/clone/ensure-clone-fresh.ts
+++ b/packages/vfs/src/clone/ensure-clone-fresh.ts
@@ -1,0 +1,110 @@
+import { CloneRequester } from './clone-requester.js'
+import { CloneStatusReader } from './clone-status-reader.js'
+import { readCloneSentinel, type VfsReader } from './sentinel.js'
+import type { CloneAdvisory } from './types.js'
+
+const DEFAULT_STALE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000
+const DEFAULT_REF = 'refs/heads/main'
+
+export interface EnsureCloneFreshOptions {
+  statusReader: CloneStatusReader
+  sentinelReader: VfsReader
+  cloneRequester: CloneRequester
+  /** Default 30 days. */
+  staleThresholdMs?: number
+  /** Default ref for new requests. */
+  defaultRef?: string
+  /** Default connectionId for new requests. */
+  connectionIdResolver: (
+    workspaceId: string,
+    owner: string,
+    repo: string,
+  ) => Promise<string | null>
+}
+
+function resolveStaleThresholdMs(value?: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value
+  }
+
+  return DEFAULT_STALE_THRESHOLD_MS
+}
+
+function isWithinThreshold(timestamp: string | undefined, thresholdMs: number): boolean {
+  if (!timestamp) {
+    return false
+  }
+
+  const parsed = Date.parse(timestamp)
+  if (Number.isNaN(parsed)) {
+    return false
+  }
+
+  return Date.now() - parsed <= thresholdMs
+}
+
+export async function ensureCloneFresh(
+  workspaceId: string,
+  owner: string,
+  repo: string,
+  opts: EnsureCloneFreshOptions,
+): Promise<CloneAdvisory | null> {
+  const staleThresholdMs = resolveStaleThresholdMs(opts.staleThresholdMs)
+  const status = await opts.statusReader.statusForRepo(workspaceId, owner, repo)
+
+  if (status?.state === 'queued' || status?.state === 'running') {
+    return {
+      notice: 'clone_in_progress',
+      cloneState: status.state,
+      cloneJobId: status.jobId,
+      cloneStartedAt: status.startedAt,
+    }
+  }
+
+  if (
+    status?.state === 'succeeded' &&
+    isWithinThreshold(status.completedAt, staleThresholdMs)
+  ) {
+    return null
+  }
+
+  if (status?.state === 'failed') {
+    return {
+      notice: 'clone_failed',
+      cloneState: 'failed',
+      cloneJobId: status.jobId,
+      reason: status.errorMessage,
+    }
+  }
+
+  const sentinel = await readCloneSentinel(workspaceId, owner, repo, {
+    reader: opts.sentinelReader,
+  })
+  if (sentinel && isWithinThreshold(sentinel.clonedAt, staleThresholdMs)) {
+    return null
+  }
+
+  const connectionId = await opts.connectionIdResolver(workspaceId, owner, repo)
+  if (connectionId === null) {
+    return {
+      notice: 'clone_failed',
+      cloneState: 'unknown',
+      reason: 'connection_unresolved',
+    }
+  }
+
+  opts.cloneRequester
+    .requestIfNeeded({
+      workspaceId,
+      owner,
+      repo,
+      ref: opts.defaultRef ?? DEFAULT_REF,
+      connectionId,
+    })
+    .catch(() => {})
+
+  return {
+    notice: 'clone_requested',
+    cloneState: 'queued',
+  }
+}

--- a/packages/vfs/src/clone/index.ts
+++ b/packages/vfs/src/clone/index.ts
@@ -1,0 +1,13 @@
+export * from './types.js';
+export { CloneRequester } from './clone-requester.js';
+export type {
+  CloneRequesterOptions,
+  CloneJobStore,
+  CloneRequestResult,
+} from './clone-requester.js';
+export { CloneStatusReader } from './clone-status-reader.js';
+export type { CloneStatusReaderOptions } from './clone-status-reader.js';
+export { readCloneSentinel } from './sentinel.js';
+export type { VfsReader, ReadSentinelOptions } from './sentinel.js';
+export { ensureCloneFresh } from './ensure-clone-fresh.js';
+export type { EnsureCloneFreshOptions } from './ensure-clone-fresh.js';

--- a/packages/vfs/src/clone/sentinel.test.ts
+++ b/packages/vfs/src/clone/sentinel.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { readCloneSentinel, type VfsReader } from './sentinel.js';
+
+const workspaceId = 'workspace-1';
+const owner = 'octocat';
+const repo = 'hello-world';
+const cloneSentinelPath = `/github/repos/${owner}/${repo}/.relayfile/clone.json`;
+const legacySentinelPath = `/github/repos/${owner}/${repo}/meta.json`;
+
+function createReader(
+  readImpl: (path: string) => Promise<{ content: string } | null>,
+): VfsReader & { read: ReturnType<typeof vi.fn> } {
+  return {
+    read: vi.fn(readImpl),
+  };
+}
+
+describe('readCloneSentinel', () => {
+  it('.relayfile/clone.json takes priority', async () => {
+    const content = JSON.stringify({
+      jobId: 'job-123',
+      headSha: 'abc123',
+      defaultBranch: 'main',
+      clonedAt: '2026-05-02T10:00:00.000Z',
+      filesWritten: 42,
+      cloneSource: 'github',
+    });
+    const reader = createReader(async (path) => {
+      if (path === cloneSentinelPath) {
+        return { content };
+      }
+
+      return {
+        content: JSON.stringify({
+          headSha: 'legacy-sha',
+          clonedAt: '2026-05-01T00:00:00.000Z',
+        }),
+      };
+    });
+
+    const sentinel = await readCloneSentinel(workspaceId, owner, repo, { reader });
+
+    expect(reader.read).toHaveBeenCalledTimes(1);
+    expect(reader.read).toHaveBeenCalledWith(cloneSentinelPath);
+    expect(sentinel).toEqual({
+      jobId: 'job-123',
+      headSha: 'abc123',
+      defaultBranch: 'main',
+      clonedAt: '2026-05-02T10:00:00.000Z',
+      filesWritten: 42,
+      cloneSource: 'github',
+    });
+  });
+
+  it('falls back to meta.json', async () => {
+    const reader = createReader(async (path) => {
+      if (path === cloneSentinelPath) {
+        return null;
+      }
+
+      if (path === legacySentinelPath) {
+        return {
+          content: JSON.stringify({
+            jobId: 'from-legacy-file',
+            headSha: 'def456',
+            clonedAt: '2026-05-01T08:30:00.000Z',
+          }),
+        };
+      }
+
+      return null;
+    });
+
+    const sentinel = await readCloneSentinel(workspaceId, owner, repo, { reader });
+
+    expect(reader.read).toHaveBeenCalledTimes(2);
+    expect(reader.read).toHaveBeenNthCalledWith(1, cloneSentinelPath);
+    expect(reader.read).toHaveBeenNthCalledWith(2, legacySentinelPath);
+    expect(sentinel?.jobId).toBe('legacy');
+  });
+
+  it('skipLegacy=true skips fallback', async () => {
+    const reader = createReader(async (path) => {
+      if (path === cloneSentinelPath) {
+        return null;
+      }
+
+      if (path === legacySentinelPath) {
+        return {
+          content: JSON.stringify({
+            headSha: 'def456',
+            clonedAt: '2026-05-01T08:30:00.000Z',
+          }),
+        };
+      }
+
+      return null;
+    });
+
+    const sentinel = await readCloneSentinel(workspaceId, owner, repo, {
+      reader,
+      skipLegacy: true,
+    });
+
+    expect(reader.read).toHaveBeenCalledTimes(1);
+    expect(reader.read).toHaveBeenCalledWith(cloneSentinelPath);
+    expect(sentinel).toBeNull();
+  });
+
+  it('parse error → null', async () => {
+    const reader = createReader(async (path) => {
+      if (path === cloneSentinelPath) {
+        return { content: '{"badJson":' };
+      }
+
+      return null;
+    });
+
+    const sentinel = await readCloneSentinel(workspaceId, owner, repo, { reader });
+
+    expect(reader.read).toHaveBeenCalledTimes(1);
+    expect(reader.read).toHaveBeenCalledWith(cloneSentinelPath);
+    expect(sentinel).toBeNull();
+  });
+
+  it('missing required fields → null', async () => {
+    const reader = createReader(async (path) => {
+      if (path === cloneSentinelPath) {
+        return { content: '{}' };
+      }
+
+      return null;
+    });
+
+    const sentinel = await readCloneSentinel(workspaceId, owner, repo, { reader });
+
+    expect(sentinel).toBeNull();
+  });
+});

--- a/packages/vfs/src/clone/sentinel.ts
+++ b/packages/vfs/src/clone/sentinel.ts
@@ -1,0 +1,80 @@
+import type { CloneSentinel } from './types.js';
+
+export interface ReadSentinelOptions {
+  /** A VfsProvider used to fetch the file. */
+  reader: VfsReader;
+  /** Default false — when true, don't fall back to meta.json. */
+  skipLegacy?: boolean;
+}
+
+export interface VfsReader {
+  read(path: string): Promise<{ content: string } | null>;
+}
+
+const buildCloneSentinelPath = (owner: string, repo: string): string =>
+  `/github/repos/${owner}/${repo}/.relayfile/clone.json`;
+
+const buildLegacySentinelPath = (owner: string, repo: string): string =>
+  `/github/repos/${owner}/${repo}/meta.json`;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+function parseCloneSentinel(
+  content: string,
+  jobIdOverride?: string,
+): CloneSentinel | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) {
+    return null;
+  }
+
+  if (typeof parsed.clonedAt !== 'string' || typeof parsed.headSha !== 'string') {
+    return null;
+  }
+
+  return {
+    jobId:
+      jobIdOverride ??
+      (typeof parsed.jobId === 'string' ? parsed.jobId : 'unknown'),
+    headSha: parsed.headSha,
+    defaultBranch:
+      typeof parsed.defaultBranch === 'string' ? parsed.defaultBranch : '',
+    clonedAt: parsed.clonedAt,
+    filesWritten:
+      typeof parsed.filesWritten === 'number' ? parsed.filesWritten : 0,
+    cloneSource:
+      typeof parsed.cloneSource === 'string' ? parsed.cloneSource : 'unknown',
+  };
+}
+
+export async function readCloneSentinel(
+  workspaceId: string,
+  owner: string,
+  repo: string,
+  opts: ReadSentinelOptions,
+): Promise<CloneSentinel | null> {
+  void workspaceId;
+
+  const primaryResult = await opts.reader.read(buildCloneSentinelPath(owner, repo));
+  if (primaryResult !== null) {
+    return parseCloneSentinel(primaryResult.content);
+  }
+
+  if (opts.skipLegacy) {
+    return null;
+  }
+
+  const legacyResult = await opts.reader.read(buildLegacySentinelPath(owner, repo));
+  if (legacyResult === null) {
+    return null;
+  }
+
+  return parseCloneSentinel(legacyResult.content, 'legacy');
+}

--- a/packages/vfs/src/clone/types.ts
+++ b/packages/vfs/src/clone/types.ts
@@ -1,0 +1,42 @@
+export interface CloneRequestPayload {
+  workspaceId: string;
+  owner: string;
+  repo: string;
+  ref: string; // e.g. 'refs/heads/main'
+  connectionId: string; // Nango connection id
+}
+
+export type CloneJobState = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export interface CloneJobStatus {
+  jobId: string;
+  state: CloneJobState;
+  queuedAt?: string; // ISO
+  startedAt?: string; // ISO
+  completedAt?: string; // ISO
+  headSha?: string;
+  errorMessage?: string;
+  cloneSource?: string;
+}
+
+export interface CloneSentinel {
+  jobId: string;
+  headSha: string;
+  defaultBranch: string;
+  clonedAt: string; // ISO
+  filesWritten: number;
+  cloneSource: string;
+}
+
+export type CloneAdvisoryNotice =
+  | 'clone_requested'
+  | 'clone_in_progress'
+  | 'clone_failed';
+
+export interface CloneAdvisory {
+  notice: CloneAdvisoryNotice;
+  cloneState: CloneJobState | 'unknown';
+  cloneJobId?: string;
+  cloneStartedAt?: string;
+  reason?: string; // populated for clone_failed
+}

--- a/packages/vfs/src/index.ts
+++ b/packages/vfs/src/index.ts
@@ -24,3 +24,12 @@ export type {
   VfsSearchResult,
 } from './types.js';
 export type { TruncatedReadResult } from './output.js';
+// Clone primitives — see './clone' subpath for the focused submodule.
+export type {
+  CloneRequestPayload,
+  CloneJobState,
+  CloneJobStatus,
+  CloneSentinel,
+  CloneAdvisory,
+  CloneAdvisoryNotice,
+} from './clone/types.js';

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/webhook-runtime",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assistant/webhook-runtime",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,8 +35,8 @@
     "example:sim": "tsx examples/slack-to-github-sim.ts"
   },
   "dependencies": {
-    "@agent-assistant/surfaces": "^0.3.0",
     "@agent-assistant/specialists": "^0.3.5",
+    "@agent-assistant/surfaces": "^0.3.0",
     "@hono/node-server": "^2.0.0",
     "hono": "^4"
   },


### PR DESCRIPTION
## Summary

Adds the primitives consumed by sage's anti-fabrication pipeline (sage spec: `specs/sage-anti-fabrication-pipeline.md`).

New public API:
- `@agent-assistant/harness` — `exceedsEvidenceBudget`, `evidence_density_violation` stop reason, `truthfulFailureReply`, `buildIntegrationsLayer`
- `@agent-assistant/specialists` — `SpecialistBridge`, `resolveSpecialistTransports`, `runSpecialistFallback` (deterministic keyword router)
- `@agent-assistant/vfs` — new `./clone` subpath: `CloneRequester` (full 5-field payload), `CloneStatusReader`, `ensureCloneFresh`, sentinel reader
- `@agent-assistant/proactive` — `postWithEvidence` egress wrapper

Closes three fabrication mechanisms structurally in sage: swarm-fallback synthesis, evidence-sparse table fabrication, truncated integration-context read as ground truth. Also adopts the durable clone queue (cloud PR #397).

## Publish

Will be published via `Publish Packages` workflow_dispatch (`package_group=runtime-core`, `version=minor`) — the version-bump commit lands on this branch automatically.

## Test plan
- [x] Per-package vitest suites pass (each new primitive ships with tests)
- [x] Full AA workspace build green
- [x] Existing AA test suites pass (regression gate)
- [ ] Sage adoption PRs exercise the primitives end-to-end (anti-fabrication-phase1..4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
