### PR TITLE
fix(publish): avoid npm fsTop bug during version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,11 +246,18 @@ jobs:
 
           for (const pkg of packages) {
             const cwd = path.join(process.cwd(), 'packages', pkg);
+            // For custom version, use `npm pkg set` — pure JSON edit, no
+            // workspace re-link logic that npm's `version` command triggers.
+            // For bump types (patch/minor/major/pre*), use `npm version`
+            // WITH `--no-workspaces-update` to avoid the npm bug where
+            // iterating across workspace siblings dies with
+            //   "Cannot read properties of null (reading 'fsTop')"
+            // when npm tries to update workspace cross-deps.
             const args = custom
-              ? ['version', custom, '--no-git-tag-version']
+              ? ['pkg', 'set', `version=${custom}`]
               : bump.startsWith('pre')
-                ? ['version', bump, `--preid=${preid}`, '--no-git-tag-version']
-                : ['version', bump, '--no-git-tag-version'];
+                ? ['version', bump, `--preid=${preid}`, '--no-git-tag-version', '--no-workspaces-update']
+                : ['version', bump, '--no-git-tag-version', '--no-workspaces-update'];
 
             execFileSync('npm', args, { cwd, stdio: 'inherit' });
             const packageJson = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));


### PR DESCRIPTION
## Summary

The `Version all publishable packages` step in `publish.yml` intermittently dies with:

```
npm error Cannot read properties of null (reading 'fsTop')
```

after a few packages succeed. This is a known npm bug in newer versions when `npm version <bump>` iterates across workspace siblings — it tries to rewrite cross-workspace dependency entries and dies on internal `@npmcli/fs` state.

## Fix

- For `custom_version` input → use `npm pkg set version=X`. Pure JSON edit, no workspace re-link.
- For semver bumps (patch / minor / major / pre*) → add `--no-workspaces-update` so npm leaves sibling cross-deps alone. The publish-matrix's prepack step (`tsc`) handles cross-package builds at publish time, not at version-bump time.

## Reproduced

Today's runtime-core publish dispatched with `custom_version=0.4.21` failed mid-loop after 4 successes (sdk, vfs, specialists, webhook-runtime each printed `v0.4.21`, then the 5th call died).

## Test plan

- [ ] Dispatch `Publish Packages` workflow_dispatch from this branch
- [ ] Confirm all 21 runtime-core packages bump + publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
