### PR TITLE
fix(vfs/clone): make connectionId optional, let cloud derive from workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,12 +62,20 @@
       "resolved": "packages/examples",
       "link": true
     },
+    "node_modules/@agent-assistant/harness": {
+      "resolved": "packages/harness",
+      "link": true
+    },
     "node_modules/@agent-assistant/inbox": {
       "resolved": "packages/inbox",
       "link": true
     },
     "node_modules/@agent-assistant/integration-tests": {
       "resolved": "packages/integration",
+      "link": true
+    },
+    "node_modules/@agent-assistant/memory": {
+      "resolved": "packages/memory",
       "link": true
     },
     "node_modules/@agent-assistant/policy": {
@@ -3592,30 +3600,6 @@
         "nanoid": "^5.1.6"
       }
     },
-    "packages/cloudflare-runtime/node_modules/@agent-assistant/core": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
-      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
-      "peerDependencies": {
-        "@agent-assistant/traits": ">=0.1.0"
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-assistant/harness": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/harness/-/harness-0.4.21.tgz",
-      "integrity": "sha512-XdKIUXFRG1TXtMeri/wu6VlaKGjglw258qKpANsbuBWJvXYvhss7Rzv4udwdJ2qKO+HTsseOiY0o7+v5CES4Zg==",
-      "dependencies": {
-        "@agent-assistant/connectivity": "^0.2.6",
-        "@agent-assistant/coordination": "^0.2.6",
-        "@agent-assistant/core": "^0.2.0",
-        "@agent-assistant/memory": "^0.4.0",
-        "@agent-assistant/traits": "^0.2.0",
-        "@agent-assistant/turn-context": "^0.3.4",
-        "@agent-assistant/vfs": "^0.2.23",
-        "@agent-relay/sdk": "^6.0.7",
-        "zod": "^3.25.0"
-      }
-    },
     "packages/cloudflare-runtime/node_modules/@agent-assistant/specialists": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@agent-assistant/specialists/-/specialists-0.3.12.tgz",
@@ -3631,32 +3615,6 @@
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/@agent-assistant/surfaces/-/surfaces-0.3.21.tgz",
       "integrity": "sha512-zHAIYUrwnHnQkj89ImdVwJSN6GL3xroU6rQk5lb/SzReKH6Kod8uwpEOAA+s/nQF6RQW6ts9c7sJexFxHhuN9Q=="
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-assistant/traits": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
-      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
-      "license": "MIT"
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-assistant/turn-context": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/turn-context/-/turn-context-0.3.21.tgz",
-      "integrity": "sha512-QBM/pgl2Z9L95nlnI8P5U3w4ivDG1IhV9UNle+cz0edEDcfITmzTuxqTwSkcjt3ODHCBssHI5XF6dN6f0g2ECQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
-        "@agent-assistant/memory": "^0.2.0",
-        "@agent-assistant/traits": "^0.2.0"
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-assistant/turn-context/node_modules/@agent-assistant/memory": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
-      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@agent-relay/memory": "^4.0.23"
-      }
     },
     "packages/cloudflare-runtime/node_modules/@agent-assistant/vfs": {
       "version": "0.2.24",
@@ -3681,95 +3639,6 @@
         "@agent-assistant/harness": {
           "optional": true
         }
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-relay/config": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-4.0.40.tgz",
-      "integrity": "sha512-SEXTOTlxkC2kss17YzvAR9bmwMIBclurjI0O2k5xbxxqK/dH3iMM4sJpXXqat1iug95Lrp2Vp/hQJt6xOGeI9g==",
-      "dependencies": {
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.1"
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-relay/hooks": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-4.0.40.tgz",
-      "integrity": "sha512-WVbmXtJV3dHsKXs7zVOMpjeuEGBBWt0DCkqLuANKQMAaR2FkrhUbK0XZWL3lz2IHDlByM3tu9y4KgzbSoKu5hA==",
-      "dependencies": {
-        "@agent-relay/config": "4.0.40",
-        "@agent-relay/sdk": "4.0.40",
-        "@agent-relay/trajectory": "4.0.40"
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-relay/hooks/node_modules/@agent-relay/sdk": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-4.0.40.tgz",
-      "integrity": "sha512-/65zrEALDUOPU96SBMBl462r6J5w/vQyshR0OV9KnLfzp5eRBhgv9p3beeFDgq6WuLto/A28U5zgnTyST3/n4g==",
-      "dependencies": {
-        "@agent-relay/config": "4.0.40",
-        "@relaycast/sdk": "^1.1.0",
-        "@relayfile/sdk": ">=0.1.2 <1",
-        "@sinclair/typebox": "^0.34.48",
-        "agent-trajectories": "^0.5.4",
-        "chalk": "^4.1.2",
-        "ignore": "^7.0.5",
-        "listr2": "^10.2.1",
-        "tar": "^7.5.10",
-        "ws": "^8.18.3",
-        "yaml": "^2.7.0"
-      },
-      "peerDependencies": {
-        "@agent-relay/credential-proxy": "4.0.40",
-        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
-        "@google/adk": ">=0.5.0",
-        "@langchain/langgraph": ">=1.2.0",
-        "@mariozechner/pi-coding-agent": ">=0.50.0",
-        "@openai/agents": ">=0.7.0",
-        "ai": ">=5.0.0",
-        "crewai": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@agent-relay/credential-proxy": {
-          "optional": true
-        },
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
-        "@google/adk": {
-          "optional": true
-        },
-        "@langchain/langgraph": {
-          "optional": true
-        },
-        "@mariozechner/pi-coding-agent": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "crewai": {
-          "optional": true
-        }
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-relay/memory": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-4.0.40.tgz",
-      "integrity": "sha512-W/pUIMq4FrxmVqn73mUoEz4mEyBrmrqrkW2uNWf/cxRQZoMki4D9dNCO6QiTVNHUNxFdXhMuS8fxLP8Ht3NEdg==",
-      "dependencies": {
-        "@agent-relay/hooks": "4.0.40"
-      }
-    },
-    "packages/cloudflare-runtime/node_modules/@agent-relay/trajectory": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-4.0.40.tgz",
-      "integrity": "sha512-+h0aRuT1Gmp6iTXACN+qcdh2ntIbZq6Bk55vTa7GGtyVUldLS5O2XSKDHUWn/gSiThUAlySApr4ZsG9lX1Jbkg==",
-      "dependencies": {
-        "@agent-relay/config": "4.0.40"
       }
     },
     "packages/connectivity": {
@@ -4105,6 +3974,174 @@
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
+      }
+    },
+    "packages/harness": {
+      "name": "@agent-assistant/harness",
+      "version": "0.4.21",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "@agent-assistant/coordination": "^0.2.6",
+        "@agent-assistant/core": "^0.2.0",
+        "@agent-assistant/memory": "^0.4.0",
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/turn-context": "^0.3.4",
+        "@agent-assistant/vfs": "^0.2.23",
+        "@agent-relay/sdk": "^6.0.7",
+        "zod": "^3.25.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.6.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/connectivity": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/connectivity/-/connectivity-0.2.24.tgz",
+      "integrity": "sha512-Nkrv8xJnQrX+6nzGVqnBGdcit6yqsF0mA4rk2kfX2Kduv14lVyVM9wjpLWLLF165v7LifCg/VlatYBPTEbLxRw==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/coordination": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.2.24.tgz",
+      "integrity": "sha512-InsJwU05TtGxS9iHawFl8EZtzHfesauMaYq6belYrIWF9n/uG7VD9le4jiYnuh+o5/RPQq+Z/ZuK1QKqzad+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/core": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/core/-/core-0.2.24.tgz",
+      "integrity": "sha512-lHEkhObn25O3wrDXLR+puQNtulumrwbXuUH2CvdlqfqHnDXtukmJcxnuRw6M9F3antGJOeS4YNcFpB35JlGtlA==",
+      "peerDependencies": {
+        "@agent-assistant/traits": ">=0.1.0"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/traits": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
+      "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
+      "license": "MIT"
+    },
+    "packages/harness/node_modules/@agent-assistant/turn-context": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/turn-context/-/turn-context-0.3.21.tgz",
+      "integrity": "sha512-QBM/pgl2Z9L95nlnI8P5U3w4ivDG1IhV9UNle+cz0edEDcfITmzTuxqTwSkcjt3ODHCBssHI5XF6dN6f0g2ECQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
+        "@agent-assistant/memory": "^0.2.0",
+        "@agent-assistant/traits": "^0.2.0"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/turn-context/node_modules/@agent-assistant/memory": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/memory/-/memory-0.2.24.tgz",
+      "integrity": "sha512-Cjhwq5MsBSFPBvP1yebcY4pZf/+qN2ZQbvCgl78+2gi07Ul8AyYyuCfjc72EMnEMrklrSCS0s/Uy3EHFbZJPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@agent-relay/memory": "^4.0.23"
+      }
+    },
+    "packages/harness/node_modules/@agent-assistant/vfs": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
+      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
+      "license": "MIT"
+    },
+    "packages/harness/node_modules/@agent-relay/config": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/config/-/config-4.0.40.tgz",
+      "integrity": "sha512-SEXTOTlxkC2kss17YzvAR9bmwMIBclurjI0O2k5xbxxqK/dH3iMM4sJpXXqat1iug95Lrp2Vp/hQJt6xOGeI9g==",
+      "dependencies": {
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
+      }
+    },
+    "packages/harness/node_modules/@agent-relay/hooks": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/hooks/-/hooks-4.0.40.tgz",
+      "integrity": "sha512-WVbmXtJV3dHsKXs7zVOMpjeuEGBBWt0DCkqLuANKQMAaR2FkrhUbK0XZWL3lz2IHDlByM3tu9y4KgzbSoKu5hA==",
+      "dependencies": {
+        "@agent-relay/config": "4.0.40",
+        "@agent-relay/sdk": "4.0.40",
+        "@agent-relay/trajectory": "4.0.40"
+      }
+    },
+    "packages/harness/node_modules/@agent-relay/hooks/node_modules/@agent-relay/sdk": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/sdk/-/sdk-4.0.40.tgz",
+      "integrity": "sha512-/65zrEALDUOPU96SBMBl462r6J5w/vQyshR0OV9KnLfzp5eRBhgv9p3beeFDgq6WuLto/A28U5zgnTyST3/n4g==",
+      "dependencies": {
+        "@agent-relay/config": "4.0.40",
+        "@relaycast/sdk": "^1.1.0",
+        "@relayfile/sdk": ">=0.1.2 <1",
+        "@sinclair/typebox": "^0.34.48",
+        "agent-trajectories": "^0.5.4",
+        "chalk": "^4.1.2",
+        "ignore": "^7.0.5",
+        "listr2": "^10.2.1",
+        "tar": "^7.5.10",
+        "ws": "^8.18.3",
+        "yaml": "^2.7.0"
+      },
+      "peerDependencies": {
+        "@agent-relay/credential-proxy": "4.0.40",
+        "@anthropic-ai/claude-agent-sdk": ">=0.1.0",
+        "@google/adk": ">=0.5.0",
+        "@langchain/langgraph": ">=1.2.0",
+        "@mariozechner/pi-coding-agent": ">=0.50.0",
+        "@openai/agents": ">=0.7.0",
+        "ai": ">=5.0.0",
+        "crewai": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@agent-relay/credential-proxy": {
+          "optional": true
+        },
+        "@anthropic-ai/claude-agent-sdk": {
+          "optional": true
+        },
+        "@google/adk": {
+          "optional": true
+        },
+        "@langchain/langgraph": {
+          "optional": true
+        },
+        "@mariozechner/pi-coding-agent": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        },
+        "crewai": {
+          "optional": true
+        }
+      }
+    },
+    "packages/harness/node_modules/@agent-relay/memory": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/memory/-/memory-4.0.40.tgz",
+      "integrity": "sha512-W/pUIMq4FrxmVqn73mUoEz4mEyBrmrqrkW2uNWf/cxRQZoMki4D9dNCO6QiTVNHUNxFdXhMuS8fxLP8Ht3NEdg==",
+      "dependencies": {
+        "@agent-relay/hooks": "4.0.40"
+      }
+    },
+    "packages/harness/node_modules/@agent-relay/trajectory": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@agent-relay/trajectory/-/trajectory-4.0.40.tgz",
+      "integrity": "sha512-+h0aRuT1Gmp6iTXACN+qcdh2ntIbZq6Bk55vTa7GGtyVUldLS5O2XSKDHUWn/gSiThUAlySApr4ZsG9lX1Jbkg==",
+      "dependencies": {
+        "@agent-relay/config": "4.0.40"
       }
     },
     "packages/inbox": {

--- a/packages/vfs/src/clone/ensure-clone-fresh.test.ts
+++ b/packages/vfs/src/clone/ensure-clone-fresh.test.ts
@@ -276,7 +276,13 @@ describe('ensureCloneFresh', () => {
     });
   });
 
-  it('unresolvable connectionId returns clone_failed', async () => {
+  it('unresolvable connectionId still submits the request and lets cloud derive it', async () => {
+    // Connection IDs are dynamic per workspace and cloud's
+    // /api/v1/github/clone/request derives connectionId from
+    // workspaceIntegrations when omitted. The old behavior (return
+    // connection_unresolved) prevented any clone for workspaces whose
+    // resolver couldn't pre-populate the connectionId — even though the
+    // cloud route can derive it just fine.
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
 
@@ -294,11 +300,48 @@ describe('ensureCloneFresh', () => {
     );
 
     expect(connectionIdResolver).toHaveBeenCalledWith(WORKSPACE_ID, OWNER, REPO);
-    expect(cloneRequester.requestIfNeeded).not.toHaveBeenCalled();
+    // Submitted without connectionId — cloud route fills it in.
+    expect(cloneRequester.requestIfNeeded).toHaveBeenCalledTimes(1);
+    const submittedPayload = cloneRequester.requestIfNeeded.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(submittedPayload).toMatchObject({
+      workspaceId: WORKSPACE_ID,
+      owner: OWNER,
+      repo: REPO,
+    });
+    expect(submittedPayload).not.toHaveProperty('connectionId');
     expect(advisory).toEqual({
-      notice: 'clone_failed',
-      cloneState: 'unknown',
-      reason: 'connection_unresolved',
+      notice: 'clone_requested',
+      cloneState: 'queued',
+      cloneJobId: 'job-req-1',
+    });
+  });
+
+  it('omitted connectionIdResolver still submits the request without connectionId', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { options, cloneRequester } = createOptions({
+      status: null,
+      sentinel: null,
+    });
+    // Drop the resolver entirely — consumer never provides one.
+    const optionsWithoutResolver = { ...options };
+    delete (optionsWithoutResolver as { connectionIdResolver?: unknown }).connectionIdResolver;
+
+    const advisory = await ensureCloneFresh(
+      WORKSPACE_ID,
+      OWNER,
+      REPO,
+      optionsWithoutResolver,
+    );
+
+    expect(cloneRequester.requestIfNeeded).toHaveBeenCalledTimes(1);
+    const submittedPayload = cloneRequester.requestIfNeeded.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(submittedPayload).not.toHaveProperty('connectionId');
+    expect(advisory).toEqual({
+      notice: 'clone_requested',
+      cloneState: 'queued',
+      cloneJobId: 'job-req-1',
     });
   });
 

--- a/packages/vfs/src/clone/ensure-clone-fresh.ts
+++ b/packages/vfs/src/clone/ensure-clone-fresh.ts
@@ -14,8 +14,15 @@ export interface EnsureCloneFreshOptions {
   staleThresholdMs?: number
   /** Default ref for new requests. */
   defaultRef?: string
-  /** Default connectionId for new requests. */
-  connectionIdResolver: (
+  /**
+   * Optional resolver for the Nango connectionId of a (workspace, owner,
+   * repo). When omitted (or when it returns null), the request is sent to
+   * the cloud clone-request route without a connectionId and the route
+   * derives it from `workspaceIntegrations` server-side. Consumers should
+   * only provide this if they have the connectionId locally cached and
+   * want to skip cloud's lookup.
+   */
+  connectionIdResolver?: (
     workspaceId: string,
     owner: string,
     repo: string,
@@ -84,14 +91,12 @@ export async function ensureCloneFresh(
     return null
   }
 
-  const connectionId = await opts.connectionIdResolver(workspaceId, owner, repo)
-  if (connectionId === null) {
-    return {
-      notice: 'clone_failed',
-      cloneState: 'unknown',
-      reason: 'connection_unresolved',
-    }
-  }
+  // connectionId is optional — when null/missing, the cloud route derives it
+  // from workspaceIntegrations. Connection IDs are dynamic (per-workspace)
+  // so consumers shouldn't be forced to plumb them across processes.
+  const connectionId = opts.connectionIdResolver
+    ? await opts.connectionIdResolver(workspaceId, owner, repo)
+    : null
 
   // Await the enqueue so the advisory reflects the actual outcome. A
   // fire-and-forget here would return clone_requested even when the request
@@ -103,7 +108,7 @@ export async function ensureCloneFresh(
       owner,
       repo,
       ref: opts.defaultRef ?? DEFAULT_REF,
-      connectionId,
+      ...(connectionId ? { connectionId } : {}),
     })
   } catch (error) {
     return {

--- a/packages/vfs/src/clone/types.ts
+++ b/packages/vfs/src/clone/types.ts
@@ -3,7 +3,11 @@ export interface CloneRequestPayload {
   owner: string;
   repo: string;
   ref: string; // e.g. 'refs/heads/main'
-  connectionId: string; // Nango connection id
+  // Nango connection id. Optional — if omitted, the cloud clone-request
+  // route derives it from the workspace's GitHub integration row in
+  // workspaceIntegrations. Cloud-side derivation is the authoritative
+  // path; consumers shouldn't need to plumb connectionIds across repos.
+  connectionId?: string;
 }
 
 export type CloneJobState = 'queued' | 'running' | 'succeeded' | 'failed';


### PR DESCRIPTION
## Summary
The previous design required consumers to plumb a Nango connectionId through `ensureCloneFresh` before any clone could be requested. When the resolver returned null, `ensureCloneFresh` short-circuited with `connection_unresolved` and the clone never fired — observed in prod sage Slack today (\`Clone for AgentWorkforce/cloud failed with reason: connection_unresolved\`).

Connection IDs are dynamic (per-workspace) so this forced consumers like sage to either hard-code a single \`SAGE_DEFAULT_CONNECTION_ID\` (only works for one workspace) or maintain their own workspace→connection mapping that duplicates cloud's \`workspaceIntegrations\` table.

Cloud's \`/api/v1/github/clone/request\` route already derives \`connectionId\` from \`workspaceIntegrations\` when omitted ([AgentWorkforce/cloud#404](https://github.com/AgentWorkforce/cloud/pull/404)). This PR aligns the package with that contract:

- \`CloneRequestPayload.connectionId\` is now optional.
- \`EnsureCloneFreshOptions.connectionIdResolver\` is now optional.
- When the resolver is missing OR returns null, the request is sent to cloud without \`connectionId\` and the route fills it in. No more \`connection_unresolved\` short-circuit.

## Test plan
- [x] \`vitest run packages/vfs/src/clone\` — 30/30 pass
- [x] Renamed test: \"unresolvable connectionId returns clone_failed\" → \"unresolvable connectionId still submits the request and lets cloud derive it\"; asserts the payload reaches \`requestIfNeeded\` without \`connectionId\` and the advisory is \`clone_requested\`
- [x] New test: omitted \`connectionIdResolver\` (consumer doesn't provide one) also submits the request

## Followup in sage
Once this is published and sage bumps `@agent-assistant/vfs`, sage's `createConnectionIdResolver` helper (in `sage-vfs-provider.ts`) becomes dead code and can be deleted — the cloud route handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)