### PR TITLE
feat(coordination): boundedParallel batch runner with timeout + abort

### DIFF
--- a/packages/coordination/src/bounded-parallel.test.ts
+++ b/packages/coordination/src/bounded-parallel.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  boundedParallel,
+  BOUNDED_PARALLEL_TIMEOUT_REASON,
+  type BoundedParallelResult,
+} from './bounded-parallel.js';
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('aborted'));
+      return;
+    }
+    const handle = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(handle);
+        reject(signal.reason ?? new Error('aborted'));
+      },
+      { once: true },
+    );
+  });
+}
+
+describe('boundedParallel', () => {
+  it('returns [] for empty input without invoking fn', async () => {
+    const fn = vi.fn(async (n: number) => n * 2);
+    const results = await boundedParallel<number, number>([], fn);
+    expect(results).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('preserves input order in results', async () => {
+    const items = [10, 50, 30, 5, 20];
+    const results = await boundedParallel<number, number>(
+      items,
+      async (n, signal) => {
+        await delay(n, signal);
+        return n * 2;
+      },
+      { concurrency: 3 },
+    );
+    expect(results).toEqual([
+      { status: 'fulfilled', value: 20 },
+      { status: 'fulfilled', value: 100 },
+      { status: 'fulfilled', value: 60 },
+      { status: 'fulfilled', value: 10 },
+      { status: 'fulfilled', value: 40 },
+    ]);
+  });
+
+  it('caps in-flight concurrency at the configured limit', async () => {
+    let inFlight = 0;
+    let observedMax = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await boundedParallel(
+      items,
+      async () => {
+        inFlight += 1;
+        observedMax = Math.max(observedMax, inFlight);
+        await delay(20);
+        inFlight -= 1;
+      },
+      { concurrency: 3 },
+    );
+
+    expect(observedMax).toBe(3);
+  });
+
+  it('settles per-item timeouts as { status: "timeout" } without poisoning the rest', async () => {
+    const results = await boundedParallel<number, string>(
+      [10, 5_000, 20],
+      async (n, signal) => {
+        await delay(n, signal);
+        return `done-${n}`;
+      },
+      { concurrency: 3, perItemTimeoutMs: 100 },
+    );
+
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 'done-10' });
+    expect(results[1]).toEqual({ status: 'timeout' });
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 'done-20' });
+  });
+
+  it('passes a signal to fn that aborts on per-item timeout', async () => {
+    let observedReason: unknown;
+    const results = await boundedParallel<number, string>(
+      [5_000],
+      async (_n, signal) => {
+        return new Promise<string>((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              observedReason = signal.reason;
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+      { perItemTimeoutMs: 50 },
+    );
+
+    expect(results[0]).toEqual({ status: 'timeout' });
+    expect(observedReason).toBe(BOUNDED_PARALLEL_TIMEOUT_REASON);
+  });
+
+  it('surfaces synchronous and async rejections as { status: "rejected", reason }', async () => {
+    const results = await boundedParallel<number, number>(
+      [1, 2, 3],
+      async (n) => {
+        if (n === 2) throw new Error(`boom-${n}`);
+        return n;
+      },
+    );
+
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 1 });
+    expect(results[1].status).toBe('rejected');
+    if (results[1].status === 'rejected') {
+      expect((results[1].reason as Error).message).toBe('boom-2');
+    }
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 3 });
+  });
+
+  it('aborts in-flight items and drops pending items when external signal aborts', async () => {
+    const controller = new AbortController();
+    const startedIndices: number[] = [];
+
+    const promise = boundedParallel<number, number>(
+      [0, 1, 2, 3, 4, 5, 6, 7],
+      async (n, signal) => {
+        startedIndices.push(n);
+        await delay(200, signal);
+        return n;
+      },
+      { concurrency: 2, signal: controller.signal },
+    );
+
+    // Let the first 2 workers pick up items 0 and 1, then yank the cord.
+    await delay(20);
+    controller.abort();
+
+    const results = await promise;
+
+    // Items 0 and 1 were in-flight: their inner delay throws on abort;
+    // settleAfterAbort sees externalSignal.aborted=true and returns 'aborted'.
+    expect(results[0]).toEqual({ status: 'aborted' });
+    expect(results[1]).toEqual({ status: 'aborted' });
+    // Items 2..7 may or may not have been picked up by a worker before the
+    // abort fired; in either branch they settle as 'aborted' (pending → never
+    // called fn; in-flight → fn aborted). What we care about is no rejections
+    // surface and no fulfilled values get through.
+    for (let i = 2; i < 8; i += 1) {
+      expect(results[i]).toEqual({ status: 'aborted' });
+    }
+    // At least the first 2 items got picked up before the abort.
+    expect(startedIndices.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('settles every item as aborted when the signal is already aborted at call time', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fn = vi.fn();
+
+    const results = await boundedParallel<number, number>(
+      [1, 2, 3],
+      fn,
+      { signal: controller.signal },
+    );
+
+    expect(results).toEqual<BoundedParallelResult<number>[]>([
+      { status: 'aborted' },
+      { status: 'aborted' },
+      { status: 'aborted' },
+    ]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('caps concurrency to items.length when concurrency exceeds it', async () => {
+    let inFlight = 0;
+    let observedMax = 0;
+    await boundedParallel(
+      [1, 2, 3],
+      async () => {
+        inFlight += 1;
+        observedMax = Math.max(observedMax, inFlight);
+        await delay(10);
+        inFlight -= 1;
+      },
+      { concurrency: 100 },
+    );
+    expect(observedMax).toBe(3);
+  });
+
+  it('coerces non-positive concurrency to 1', async () => {
+    let inFlight = 0;
+    let observedMax = 0;
+    await boundedParallel(
+      [1, 2, 3, 4],
+      async () => {
+        inFlight += 1;
+        observedMax = Math.max(observedMax, inFlight);
+        await delay(10);
+        inFlight -= 1;
+      },
+      { concurrency: 0 },
+    );
+    expect(observedMax).toBe(1);
+  });
+});

--- a/packages/coordination/src/bounded-parallel.ts
+++ b/packages/coordination/src/bounded-parallel.ts
@@ -1,0 +1,173 @@
+/**
+ * Bounded-parallel batch runner with per-item timeout and AbortSignal support.
+ *
+ * Captures the structural fix from sage's proactive follow-ups loop (PR #200,
+ * `runCandidatePool` in src/proactive/follow-up-checker.ts) as a reusable
+ * primitive. Every AA consumer that processes a batch of independent items
+ * — proactive follow-ups, evidence collection, batched memory recall — can
+ * lean on this instead of reimplementing the worker-pool pattern.
+ *
+ * Properties:
+ *   - Bounded concurrency: at most `concurrency` items in flight at any time.
+ *     Default 5, picked to leave headroom under Cloudflare Workers' ~6
+ *     concurrent outbound HTTP cap (see sage's `.claude/rules/workers-fetch.md`).
+ *   - Per-item timeout: items exceeding `perItemTimeoutMs` resolve as
+ *     `{ status: 'timeout' }` and the inner `fn` receives an aborted
+ *     AbortSignal so it can cancel any in-flight work cleanly.
+ *   - Batch-level abort: an external `signal` cancels in-flight workers
+ *     (via the per-item signal) AND drops any pending items as
+ *     `{ status: 'aborted' }` without ever calling `fn`.
+ *   - Settled-not-thrown: like Promise.allSettled, individual rejections do
+ *     NOT abort the batch — they surface as `{ status: 'rejected', reason }`
+ *     entries. The whole-batch abort is the only mechanism that stops
+ *     processing.
+ *
+ * Returns results in the same order as `items`. Empty input returns an empty
+ * array without spawning workers.
+ */
+
+const DEFAULT_CONCURRENCY = 5;
+
+export interface BoundedParallelOptions {
+  /**
+   * Maximum number of in-flight tasks. Capped at `items.length`. Defaults to
+   * {@link DEFAULT_CONCURRENCY} (5).
+   */
+  concurrency?: number;
+  /**
+   * Per-item budget in milliseconds. When set, items that don't resolve
+   * within this window settle as `{ status: 'timeout' }`. The per-item
+   * AbortSignal handed to `fn` aborts when the timeout fires, so inner
+   * `fetch(..., { signal })` calls can cancel cleanly.
+   */
+  perItemTimeoutMs?: number;
+  /**
+   * Optional batch-level AbortSignal. When it aborts:
+   *   - In-flight items see their per-item signal abort (combined with
+   *     this one) and settle as either `{ status: 'aborted' }` if `fn`
+   *     propagates the abort, or `{ status: 'rejected' }` if `fn` swallows
+   *     the abort and rejects with something else.
+   *   - Pending items (not yet picked up by a worker) settle as
+   *     `{ status: 'aborted' }` without ever calling `fn`.
+   */
+  signal?: AbortSignal;
+}
+
+export type BoundedParallelResult<R> =
+  | { status: 'fulfilled'; value: R }
+  | { status: 'rejected'; reason: unknown }
+  | { status: 'timeout' }
+  | { status: 'aborted' };
+
+/**
+ * Sentinel reason used by the per-item timeout AbortController so callers
+ * can distinguish a timeout abort from an external batch-level abort.
+ */
+export const BOUNDED_PARALLEL_TIMEOUT_REASON = Symbol(
+  '@agent-assistant/coordination:bounded-parallel:timeout',
+);
+
+/**
+ * Sentinel reason used by the per-item AbortController when the external
+ * batch-level `signal` aborts.
+ */
+export const BOUNDED_PARALLEL_ABORTED_REASON = Symbol(
+  '@agent-assistant/coordination:bounded-parallel:aborted',
+);
+
+function isAbortLike(reason: unknown, sentinel: symbol): boolean {
+  if (reason === sentinel) return true;
+  if (reason instanceof Error && (reason.name === 'AbortError' || reason.name === 'TimeoutError')) {
+    return true;
+  }
+  return false;
+}
+
+function settleAfterAbort<R>(
+  reason: unknown,
+  externalSignal: AbortSignal | undefined,
+): BoundedParallelResult<R> {
+  // Distinguish a per-item timeout abort from a batch-level abort. The
+  // external signal aborting mid-flight always wins the classification —
+  // the user-facing intent was "stop the batch", and a coincident timeout
+  // shouldn't relabel that as a per-item failure.
+  if (externalSignal?.aborted) return { status: 'aborted' };
+  if (isAbortLike(reason, BOUNDED_PARALLEL_TIMEOUT_REASON)) return { status: 'timeout' };
+  if (isAbortLike(reason, BOUNDED_PARALLEL_ABORTED_REASON)) return { status: 'aborted' };
+  return { status: 'rejected', reason };
+}
+
+export async function boundedParallel<T, R>(
+  items: ReadonlyArray<T>,
+  fn: (item: T, signal: AbortSignal) => Promise<R>,
+  options: BoundedParallelOptions = {},
+): Promise<BoundedParallelResult<R>[]> {
+  if (items.length === 0) return [];
+
+  const concurrency = Math.max(
+    1,
+    Math.min(options.concurrency ?? DEFAULT_CONCURRENCY, items.length),
+  );
+  const externalSignal = options.signal;
+  const perItemTimeoutMs = options.perItemTimeoutMs;
+
+  const results = new Array<BoundedParallelResult<R>>(items.length);
+
+  // If the batch is aborted before we even start, settle every item without
+  // spawning workers. Cheaper than creating N AbortControllers just to
+  // tear them down.
+  if (externalSignal?.aborted) {
+    for (let i = 0; i < items.length; i += 1) {
+      results[i] = { status: 'aborted' };
+    }
+    return results;
+  }
+
+  let nextIndex = 0;
+
+  async function runOne(index: number): Promise<void> {
+    // If the batch was aborted while this item sat in the queue, mark it
+    // aborted without ever calling `fn`. Pending items pay zero cost when
+    // the operator yanks the cord.
+    if (externalSignal?.aborted) {
+      results[index] = { status: 'aborted' };
+      return;
+    }
+
+    const controller = new AbortController();
+    const onExternalAbort = (): void => {
+      controller.abort(BOUNDED_PARALLEL_ABORTED_REASON);
+    };
+    externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    if (perItemTimeoutMs !== undefined && perItemTimeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        controller.abort(BOUNDED_PARALLEL_TIMEOUT_REASON);
+      }, perItemTimeoutMs);
+    }
+
+    try {
+      const item = items[index] as T;
+      const value = await fn(item, controller.signal);
+      results[index] = { status: 'fulfilled', value };
+    } catch (reason) {
+      results[index] = settleAfterAbort<R>(reason, externalSignal);
+    } finally {
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      externalSignal?.removeEventListener('abort', onExternalAbort);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: concurrency }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        await runOne(index);
+      }
+    }),
+  );
+
+  return results;
+}

--- a/packages/coordination/src/index.ts
+++ b/packages/coordination/src/index.ts
@@ -7,6 +7,17 @@ export {
 } from './coordination.js';
 
 export {
+  boundedParallel,
+  BOUNDED_PARALLEL_TIMEOUT_REASON,
+  BOUNDED_PARALLEL_ABORTED_REASON,
+} from './bounded-parallel.js';
+
+export type {
+  BoundedParallelOptions,
+  BoundedParallelResult,
+} from './bounded-parallel.js';
+
+export {
   CoordinationBlockedError,
   CoordinationError,
   DelegationPlanError,


### PR DESCRIPTION
## Summary

- New `boundedParallel<T, R>(items, fn, options)` primitive in `@agent-assistant/coordination`
- Bounded concurrency (default 5), per-item timeout, batch-level AbortSignal, settled-not-thrown semantics
- Designed against sage PR #200's in-place `runCandidatePool` (sage `src/proactive/follow-up-checker.ts:1609`); sage adoption is the next PR in the sequence per `docs/specs/proactive-batch-runner.md` §5.1
- 10 new tests; existing 39 coordination tests still pass; build + types clean

## Why

Sage shipped an in-place bounded-parallel runner in PR #200 to fix the prod proactive follow-ups timeout. The pattern (worker pool + per-item timeout + per-run cap + AbortSignal threading) is generic — every AA consumer that processes a batch of independent items needs the same safety properties. This PR extracts the primitive so future surfaces don't reimplement it (and so sage's `runCandidatePool` can be deleted in the follow-up adoption PR).

The interface deliberately matches the spec at `docs/specs/proactive-batch-runner.md` §5.1 in sage:

```ts
export interface BoundedParallelOptions {
  concurrency?: number;        // default 5
  perItemTimeoutMs?: number;
  signal?: AbortSignal;
}

export type BoundedParallelResult<R> =
  | { status: 'fulfilled'; value: R }
  | { status: 'rejected'; reason: unknown }
  | { status: 'timeout' }
  | { status: 'aborted' };

export async function boundedParallel<T, R>(
  items: ReadonlyArray<T>,
  fn: (item: T, signal: AbortSignal) => Promise<R>,
  options?: BoundedParallelOptions,
): Promise<BoundedParallelResult<R>[]>;
```

## Design notes

- **Settled-not-thrown** (mirrors `Promise.allSettled`): individual rejections don't poison the batch. The only thing that stops processing is a batch-level abort.
- **Two distinguished sentinel symbols** (`BOUNDED_PARALLEL_TIMEOUT_REASON`, `BOUNDED_PARALLEL_ABORTED_REASON`): callers can inspect `abortReason === BOUNDED_PARALLEL_TIMEOUT_REASON` to distinguish per-item timeout from batch-level abort. The result classification rule: external-signal-aborted-mid-flight always wins over a coincident per-item timeout — the user-facing intent was "stop the batch."
- **Pending items pay zero cost on abort**: when the external signal aborts, queued items that haven't been picked up by a worker yet settle as `{ status: 'aborted' }` without ever calling `fn`. Cheaper than spawning N controllers just to tear them down.
- **Empty input → `[]`**: no workers spawned.
- **Concurrency edge cases**: capped at `items.length`; non-positive values coerced to 1.

## Test plan

- [x] `cd packages/coordination && npm test` — 49 / 49 pass (39 existing + 10 new)
- [x] `npm run build` — clean (after building peer deps `@agent-assistant/routing` + `@agent-assistant/connectivity` per the package's `prebuild` script)
- [x] Verified `boundedParallel` + sentinel symbols + types exported in `dist/index.{js,d.ts}`

## Out of scope (follow-up)

- Version bump — handled by separate `chore(release)` commit per the existing convention (recent: `2740310 chore(release): publish runtime-core v0.4.24`)
- Sage adoption — `runCandidatePool` in sage's `src/proactive/follow-up-checker.ts` becomes a thin call to `boundedParallel`; staged at sage `workflows/proactive-batch-runner/04-sage-adopt.ts`
- AA #2 (`runFollowUpBatch` in `@agent-assistant/proactive`) consumes this primitive — next PR in the sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)