### PR TITLE
feat(proactive): runFollowUpBatch + decidePostingPolicy + block-counter interface

### DIFF
--- a/packages/proactive/package.json
+++ b/packages/proactive/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@agent-assistant/coordination": "^0.4.25",
     "@agent-assistant/surfaces": ">=0.2.19",
     "nanoid": "^5.0.7"
   },

--- a/packages/proactive/src/decide-posting-policy.test.ts
+++ b/packages/proactive/src/decide-posting-policy.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyUnverifiedPrefix,
+  decidePostingPolicy,
+  readFailOpenFromEnv,
+  UNVERIFIED_PREFIX,
+  type VerifyDraftOutcome,
+} from './decide-posting-policy.js';
+
+describe('decidePostingPolicy', () => {
+  it('verified outcome → post with text + evidence', () => {
+    const outcome: VerifyDraftOutcome<string> = {
+      kind: 'verified',
+      text: 'PR #42 is merged',
+      evidence: ['merge-commit-deadbeef'],
+    };
+    const decision = decidePostingPolicy(outcome, { failOpen: true });
+    expect(decision).toEqual({
+      action: 'post',
+      text: 'PR #42 is merged',
+      evidence: ['merge-commit-deadbeef'],
+    });
+  });
+
+  it('no_supporting_evidence → block (regardless of fail-open)', () => {
+    const outcome: VerifyDraftOutcome = { kind: 'no_supporting_evidence' };
+    expect(decidePostingPolicy(outcome, { failOpen: true })).toEqual({
+      action: 'block',
+      reason: 'no_supporting_evidence',
+    });
+    expect(decidePostingPolicy(outcome, { failOpen: false })).toEqual({
+      action: 'block',
+      reason: 'no_supporting_evidence',
+    });
+  });
+
+  it('bridge_unavailable + failOpen → post_unverified with prefix', () => {
+    const outcome: VerifyDraftOutcome = {
+      kind: 'bridge_unavailable',
+      draftedText: 'I noticed an unresolved question.',
+    };
+    expect(decidePostingPolicy(outcome, { failOpen: true })).toEqual({
+      action: 'post_unverified',
+      text: '[unverified] I noticed an unresolved question.',
+      reason: 'bridge_unavailable',
+    });
+  });
+
+  it('bridge_unavailable + failOpen=false → block with verification_unavailable', () => {
+    const outcome: VerifyDraftOutcome = {
+      kind: 'bridge_unavailable',
+      draftedText: 'I noticed an unresolved question.',
+    };
+    expect(decidePostingPolicy(outcome, { failOpen: false })).toEqual({
+      action: 'block',
+      reason: 'verification_unavailable',
+    });
+  });
+
+  it('verification_degraded + failOpen → post_unverified, surfaces reason', () => {
+    const outcome: VerifyDraftOutcome = {
+      kind: 'verification_degraded',
+      draftedText: 'Following up on the deploy thread.',
+      reason: 'specialist_returned_partial',
+    };
+    expect(decidePostingPolicy(outcome, { failOpen: true })).toEqual({
+      action: 'post_unverified',
+      text: '[unverified] Following up on the deploy thread.',
+      reason: 'specialist_returned_partial',
+    });
+  });
+
+  it('verification_degraded + failOpen=false → block with the same reason', () => {
+    const outcome: VerifyDraftOutcome = {
+      kind: 'verification_degraded',
+      draftedText: 'Following up on the deploy thread.',
+      reason: 'specialist_returned_partial',
+    };
+    expect(decidePostingPolicy(outcome, { failOpen: false })).toEqual({
+      action: 'block',
+      reason: 'specialist_returned_partial',
+    });
+  });
+
+  it('post_unverified does not double-prefix already-prefixed text', () => {
+    const outcome: VerifyDraftOutcome = {
+      kind: 'bridge_unavailable',
+      draftedText: '[unverified] already prefixed',
+    };
+    expect(decidePostingPolicy(outcome, { failOpen: true })).toEqual({
+      action: 'post_unverified',
+      text: '[unverified] already prefixed',
+      reason: 'bridge_unavailable',
+    });
+  });
+});
+
+describe('applyUnverifiedPrefix', () => {
+  it('adds the prefix when absent', () => {
+    expect(applyUnverifiedPrefix('hi')).toBe('[unverified] hi');
+  });
+
+  it('is idempotent', () => {
+    const once = applyUnverifiedPrefix('hi');
+    expect(applyUnverifiedPrefix(once)).toBe(once);
+  });
+
+  it('exposes the prefix as a constant', () => {
+    expect(UNVERIFIED_PREFIX).toBe('[unverified] ');
+  });
+});
+
+describe('readFailOpenFromEnv', () => {
+  it('defaults to true when neither env var is set', () => {
+    expect(readFailOpenFromEnv({})).toBe(true);
+  });
+
+  it('respects AA_PROACTIVE_FAIL_OPEN_VERIFICATION=false', () => {
+    expect(readFailOpenFromEnv({ AA_PROACTIVE_FAIL_OPEN_VERIFICATION: 'false' })).toBe(false);
+  });
+
+  it('respects the legacy SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION=false alias', () => {
+    expect(readFailOpenFromEnv({ SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION: 'false' })).toBe(false);
+  });
+
+  it('AA="true" alongside legacy SAGE="false" still fails closed (conservative read)', () => {
+    expect(
+      readFailOpenFromEnv({
+        AA_PROACTIVE_FAIL_OPEN_VERIFICATION: 'true',
+        SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION: 'false',
+      }),
+    ).toBe(false);
+  });
+
+  it('non-"false" values do not trigger fail-closed', () => {
+    expect(readFailOpenFromEnv({ AA_PROACTIVE_FAIL_OPEN_VERIFICATION: '0' })).toBe(true);
+    expect(readFailOpenFromEnv({ AA_PROACTIVE_FAIL_OPEN_VERIFICATION: 'no' })).toBe(true);
+    expect(readFailOpenFromEnv({ AA_PROACTIVE_FAIL_OPEN_VERIFICATION: 'False' })).toBe(true);
+  });
+});

--- a/packages/proactive/src/decide-posting-policy.test.ts
+++ b/packages/proactive/src/decide-posting-policy.test.ts
@@ -138,4 +138,23 @@ describe('readFailOpenFromEnv', () => {
     expect(readFailOpenFromEnv({ AA_PROACTIVE_FAIL_OPEN_VERIFICATION: 'no' })).toBe(true);
     expect(readFailOpenFromEnv({ AA_PROACTIVE_FAIL_OPEN_VERIFICATION: 'False' })).toBe(true);
   });
+
+  it('does not throw on hosts without globalThis.process (pure Workers / browsers)', () => {
+    // Codex / CodeRabbit P1 on AA PR #82: previous shape used
+    // `env: NodeJS.ProcessEnv = process.env` which threw ReferenceError on
+    // Workers without nodejs_compat. Verify the no-arg default falls back
+    // safely when `process` is undefined on the host.
+    const original = (globalThis as { process?: unknown }).process;
+    try {
+      delete (globalThis as { process?: unknown }).process;
+      expect(() => readFailOpenFromEnv()).not.toThrow();
+      expect(readFailOpenFromEnv()).toBe(true);
+    } finally {
+      if (original === undefined) {
+        delete (globalThis as { process?: unknown }).process;
+      } else {
+        (globalThis as { process?: unknown }).process = original;
+      }
+    }
+  });
 });

--- a/packages/proactive/src/decide-posting-policy.ts
+++ b/packages/proactive/src/decide-posting-policy.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared fail-open posting verification policy.
+ *
+ * Extracted from sage's `src/proactive/verification-policy.ts` (PR #186) so
+ * every AA consumer that posts proactively can apply the same policy
+ * without duplicating the discriminated outcome shape, the env reader, the
+ * `[unverified]` prefix string, or the post/block decision tree.
+ *
+ * The policy:
+ *   - "verified"               → post normally, with the verified text + evidence.
+ *   - "no_supporting_evidence" → block. The specialist responded but found
+ *     nothing that backs the claim; posting an unsubstantiated specific
+ *     claim is worse than silence here. Same under fail-open.
+ *   - "bridge_unavailable" / "verification_degraded":
+ *       fail-open default → post with `[unverified] ` prefix
+ *       fail-open=false   → block
+ *
+ * The kill-switch env var is `AA_PROACTIVE_FAIL_OPEN_VERIFICATION`. The
+ * legacy sage-prefixed name `SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION` is
+ * read as a deprecation alias so the rename can land without flipping
+ * prod behavior on the dependency bump. After sage drops the alias from
+ * its own code (one minor cycle), the legacy read can be removed here too.
+ */
+
+export const UNVERIFIED_PREFIX = '[unverified] ';
+
+export type VerifyDraftOutcome<E = unknown> =
+  | { kind: 'verified'; text: string; evidence: E[] }
+  | { kind: 'bridge_unavailable'; draftedText: string }
+  | { kind: 'verification_degraded'; draftedText: string; reason: string }
+  | { kind: 'no_supporting_evidence' };
+
+export type PolicyDecision<E = unknown> =
+  | { action: 'post'; text: string; evidence: E[] }
+  | { action: 'post_unverified'; text: string; reason: string }
+  | { action: 'block'; reason: string };
+
+export interface PolicyEnv {
+  failOpen: boolean;
+}
+
+/**
+ * Read the fail-open kill switch. Default is fail-open. Operator can flip
+ * `AA_PROACTIVE_FAIL_OPEN_VERIFICATION=false` (or the legacy
+ * `SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION=false` for one deprecation cycle)
+ * to restore strict-block behavior in an emergency.
+ *
+ * Either kill switch wins — i.e. setting EITHER to "false" disables
+ * fail-open. This is intentionally conservative: an operator running the
+ * legacy env var to intentionally fail-closed during an incident must not
+ * silently start failing-open after the migration.
+ */
+export function readFailOpenFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env['AA_PROACTIVE_FAIL_OPEN_VERIFICATION'] === 'false') return false;
+  if (env['SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION'] === 'false') return false;
+  return true;
+}
+
+export function applyUnverifiedPrefix(text: string): string {
+  return text.startsWith(UNVERIFIED_PREFIX) ? text : `${UNVERIFIED_PREFIX}${text}`;
+}
+
+export function decidePostingPolicy<E>(
+  outcome: VerifyDraftOutcome<E>,
+  env: PolicyEnv,
+): PolicyDecision<E> {
+  switch (outcome.kind) {
+    case 'verified':
+      return { action: 'post', text: outcome.text, evidence: outcome.evidence };
+    case 'no_supporting_evidence':
+      return { action: 'block', reason: 'no_supporting_evidence' };
+    case 'bridge_unavailable':
+      if (env.failOpen) {
+        return {
+          action: 'post_unverified',
+          text: applyUnverifiedPrefix(outcome.draftedText),
+          reason: 'bridge_unavailable',
+        };
+      }
+      return { action: 'block', reason: 'verification_unavailable' };
+    case 'verification_degraded':
+      if (env.failOpen) {
+        return {
+          action: 'post_unverified',
+          text: applyUnverifiedPrefix(outcome.draftedText),
+          reason: outcome.reason,
+        };
+      }
+      return { action: 'block', reason: outcome.reason };
+  }
+}

--- a/packages/proactive/src/decide-posting-policy.ts
+++ b/packages/proactive/src/decide-posting-policy.ts
@@ -40,6 +40,29 @@ export interface PolicyEnv {
 }
 
 /**
+ * Plain map of env var names to their values. Avoids `NodeJS.ProcessEnv` in
+ * the public API so this package stays usable from non-Node runtimes
+ * (Cloudflare Workers without `nodejs_compat`, browsers, Deno, etc.) — the
+ * `NodeJS` global type isn't available there and the emitted `.d.ts` would
+ * fail to load. Callers that DO have a Node `process.env` can pass it
+ * directly; the runtime structural shape matches.
+ */
+export type EnvSource = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Best-effort read of the host `process.env` without dragging Node typings
+ * into the public surface. Returns `{}` on hosts where `process` is
+ * undefined (pure Workers, browsers) instead of throwing — the caller's
+ * intent in not passing an env is "use whatever the host provides," and
+ * "the host provides nothing" is a valid answer that should fall through
+ * to the policy default.
+ */
+function defaultEnvSource(): EnvSource {
+  const proc = (globalThis as { process?: { env?: EnvSource } }).process;
+  return proc?.env ?? {};
+}
+
+/**
  * Read the fail-open kill switch. Default is fail-open. Operator can flip
  * `AA_PROACTIVE_FAIL_OPEN_VERIFICATION=false` (or the legacy
  * `SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION=false` for one deprecation cycle)
@@ -49,8 +72,14 @@ export interface PolicyEnv {
  * fail-open. This is intentionally conservative: an operator running the
  * legacy env var to intentionally fail-closed during an incident must not
  * silently start failing-open after the migration.
+ *
+ * Worker-safe: when called without an explicit `env`, falls back to
+ * `globalThis.process?.env ?? {}` so Cloudflare Worker consumers without
+ * `nodejs_compat` get the policy default rather than a `process is not
+ * defined` ReferenceError. (Codex / CodeRabbit P1 review feedback on
+ * AA PR #82.)
  */
-export function readFailOpenFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+export function readFailOpenFromEnv(env: EnvSource = defaultEnvSource()): boolean {
   if (env['AA_PROACTIVE_FAIL_OPEN_VERIFICATION'] === 'false') return false;
   if (env['SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION'] === 'false') return false;
   return true;

--- a/packages/proactive/src/index.ts
+++ b/packages/proactive/src/index.ts
@@ -103,6 +103,7 @@ export {
   UNVERIFIED_PREFIX,
 } from './decide-posting-policy.js';
 export type {
+  EnvSource,
   PolicyDecision,
   PolicyEnv,
   VerifyDraftOutcome,

--- a/packages/proactive/src/index.ts
+++ b/packages/proactive/src/index.ts
@@ -95,3 +95,27 @@ export type {
   PostWithEvidenceOptions,
   ProactiveEgress,
 } from './evidence-egress.js';
+
+export {
+  applyUnverifiedPrefix,
+  decidePostingPolicy,
+  readFailOpenFromEnv,
+  UNVERIFIED_PREFIX,
+} from './decide-posting-policy.js';
+export type {
+  PolicyDecision,
+  PolicyEnv,
+  VerifyDraftOutcome,
+} from './decide-posting-policy.js';
+
+export { runFollowUpBatch } from './run-follow-up-batch.js';
+export type {
+  RunFollowUpBatchInput,
+  RunFollowUpBatchResult,
+  RunFollowUpBatchStats,
+} from './run-follow-up-batch.js';
+
+export type {
+  ProactiveBlockCounter,
+  ProactiveBlockCounterReader,
+} from './proactive-block-counter.js';

--- a/packages/proactive/src/proactive-block-counter.ts
+++ b/packages/proactive/src/proactive-block-counter.ts
@@ -1,0 +1,32 @@
+/**
+ * Best-effort operational counter for proactive surfaces. Lets sage (and
+ * future AA consumers) record that a proactive action was blocked or
+ * degraded without coupling to a specific storage backend.
+ *
+ * Adapter implementations live in the consuming app — sage's KV-backed
+ * implementation is at `src/cloudflare/kv-proactive-block-counter.ts`. The
+ * `/api/proactive/health` route reads a sliding 24-hour count off the
+ * adapter to surface degraded states to operators.
+ *
+ * Conventions:
+ *   - Increment is fire-and-forget. Errors thrown by the adapter MUST be
+ *     swallowed by the caller so a flaky counter never blocks a proactive
+ *     decision. The contract is "do your best to record".
+ *   - Event names are short snake_case strings. Common values include
+ *     `follow_up_post_blocked`, `follow_up_verification_degraded`,
+ *     `pr_match_post_blocked`, `pr_match_verification_degraded`,
+ *     `specialist_unavailable`, `github_specialist_sync_verification_degraded`.
+ *     Adapters do not validate the value — adding new events is just a
+ *     matter of calling `increment(newName)`.
+ *   - `countLast24h` returns a sliding window count. Implementations may
+ *     bucket arbitrarily (per-hour KV keys are typical) but the surface
+ *     guarantees a 24-hour window.
+ */
+
+export interface ProactiveBlockCounter {
+  increment(event: string): Promise<void>;
+}
+
+export interface ProactiveBlockCounterReader {
+  countLast24h(event: string): Promise<number>;
+}

--- a/packages/proactive/src/run-follow-up-batch.test.ts
+++ b/packages/proactive/src/run-follow-up-batch.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { runFollowUpBatch } from './run-follow-up-batch.js';
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('aborted'));
+      return;
+    }
+    const handle = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(handle);
+        reject(signal.reason ?? new Error('aborted'));
+      },
+      { once: true },
+    );
+  });
+}
+
+describe('runFollowUpBatch', () => {
+  it('returns empty result when given no candidates', async () => {
+    const out = await runFollowUpBatch<string, string>({
+      candidates: [],
+      runOne: async (c) => c.toUpperCase(),
+    });
+    expect(out.results).toEqual([]);
+    expect(out.processed).toEqual([]);
+    expect(out.dropped).toEqual([]);
+    expect(out.stats).toEqual({
+      processed: 0,
+      fulfilled: 0,
+      rejected: 0,
+      timedOut: 0,
+      aborted: 0,
+      dropped: 0,
+    });
+  });
+
+  it('runs every candidate when no cap is set and aggregates fulfilled stats', async () => {
+    const items = ['a', 'b', 'c', 'd', 'e'];
+    const out = await runFollowUpBatch<string, string>({
+      candidates: items,
+      runOne: async (c) => c.toUpperCase(),
+      concurrency: 2,
+    });
+    expect(out.processed).toEqual(items);
+    expect(out.dropped).toEqual([]);
+    expect(out.stats.processed).toBe(5);
+    expect(out.stats.fulfilled).toBe(5);
+    expect(out.results.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([
+      'A',
+      'B',
+      'C',
+      'D',
+      'E',
+    ]);
+  });
+
+  it('applies maxCandidatesPerRun as a FIFO prefix and returns the tail in dropped', async () => {
+    const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const seen: number[] = [];
+    const out = await runFollowUpBatch<number, number>({
+      candidates: items,
+      runOne: async (c) => {
+        seen.push(c);
+        return c * 2;
+      },
+      maxCandidatesPerRun: 4,
+      concurrency: 2,
+    });
+    expect(out.processed).toEqual([1, 2, 3, 4]);
+    expect(out.dropped).toEqual([5, 6, 7, 8, 9, 10]);
+    expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    expect(out.stats.processed).toBe(4);
+    expect(out.stats.dropped).toBe(6);
+    expect(out.stats.fulfilled).toBe(4);
+  });
+
+  it('cap of 0 → drops everything, runs nothing', async () => {
+    const fn = async (n: number): Promise<number> => n;
+    const out = await runFollowUpBatch<number, number>({
+      candidates: [1, 2, 3],
+      runOne: fn,
+      maxCandidatesPerRun: 0,
+    });
+    expect(out.processed).toEqual([]);
+    expect(out.dropped).toEqual([1, 2, 3]);
+    expect(out.stats).toEqual({
+      processed: 0,
+      fulfilled: 0,
+      rejected: 0,
+      timedOut: 0,
+      aborted: 0,
+      dropped: 3,
+    });
+  });
+
+  it('cap larger than input is harmless (clamps to length)', async () => {
+    const out = await runFollowUpBatch<number, number>({
+      candidates: [1, 2],
+      runOne: async (c) => c,
+      maxCandidatesPerRun: 100,
+    });
+    expect(out.processed).toEqual([1, 2]);
+    expect(out.dropped).toEqual([]);
+    expect(out.stats.dropped).toBe(0);
+  });
+
+  it('counts rejected and timed-out outcomes separately from fulfilled', async () => {
+    const out = await runFollowUpBatch<number, string>({
+      candidates: [10, 5_000, 20, -1],
+      runOne: async (c, signal) => {
+        if (c < 0) throw new Error(`bad-${c}`);
+        await delay(c, signal);
+        return `done-${c}`;
+      },
+      perCandidateTimeoutMs: 100,
+      concurrency: 4,
+    });
+    expect(out.results[0]).toEqual({ status: 'fulfilled', value: 'done-10' });
+    expect(out.results[1]).toEqual({ status: 'timeout' });
+    expect(out.results[2]).toEqual({ status: 'fulfilled', value: 'done-20' });
+    expect(out.results[3].status).toBe('rejected');
+    expect(out.stats).toEqual({
+      processed: 4,
+      fulfilled: 2,
+      rejected: 1,
+      timedOut: 1,
+      aborted: 0,
+      dropped: 0,
+    });
+  });
+
+  it('threads external abort through to the per-item signal and counts aborted', async () => {
+    const controller = new AbortController();
+    const promise = runFollowUpBatch<number, number>({
+      candidates: [1, 2, 3, 4, 5, 6, 7, 8],
+      runOne: async (c, signal) => {
+        await delay(200, signal);
+        return c;
+      },
+      concurrency: 2,
+      signal: controller.signal,
+    });
+    await delay(20);
+    controller.abort();
+    const out = await promise;
+    expect(out.stats.fulfilled).toBe(0);
+    expect(out.stats.aborted).toBe(8);
+    expect(out.stats.processed).toBe(8);
+  });
+
+  it('preserves input order in results (parallel completion does not shuffle)', async () => {
+    const out = await runFollowUpBatch<number, string>({
+      candidates: [50, 10, 30, 5, 20],
+      runOne: async (c, signal) => {
+        await delay(c, signal);
+        return `t${c}`;
+      },
+      concurrency: 5,
+    });
+    expect(out.results.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([
+      't50',
+      't10',
+      't30',
+      't5',
+      't20',
+    ]);
+  });
+});

--- a/packages/proactive/src/run-follow-up-batch.ts
+++ b/packages/proactive/src/run-follow-up-batch.ts
@@ -1,0 +1,144 @@
+/**
+ * Bounded-parallel batch runner for per-candidate proactive work.
+ *
+ * Layered on top of `boundedParallel` from `@agent-assistant/coordination`
+ * (since v0.4.25). Adds the per-run cap + overflow-tracking pattern that
+ * sage's `runCandidatePool` shipped in PR #200, plus aggregated batch
+ * stats so operators can read failure-class counts off a single object.
+ *
+ * What this primitive does:
+ *   1. Apply a FIFO cap (`maxCandidatesPerRun`) — overflow is returned
+ *      as `dropped` so the caller can preserve provenance (e.g. sage
+ *      seeds `deferredSessionIds` with sliced-off signal candidates so
+ *      `clearProcessedSignals` doesn't remove them from the inbox).
+ *   2. Run the surviving candidates through `boundedParallel` with the
+ *      configured concurrency, per-candidate timeout, and external
+ *      AbortSignal.
+ *   3. Return a structured result: per-item outcomes (preserving order)
+ *      plus an aggregated `stats` block for /health-style surfaces.
+ *
+ * What this primitive deliberately does NOT do:
+ *   - The per-candidate pipeline itself (evidence collection, LLM
+ *     verification, policy gate, post, persistence). Caller's `runOne`
+ *     owns that. Keeping the primitive thin lets each AA surface compose
+ *     its own pipeline without dragging the whole follow-up loop into AA.
+ *   - Sort the candidates. Caller controls ordering; the cap takes the
+ *     prefix. Pass FIFO-sorted input for "oldest first" behavior.
+ *   - Dedup. Caller dedups before passing in (sage uses thread/session
+ *     identity which is sage-specific).
+ */
+
+import {
+  boundedParallel,
+  type BoundedParallelResult,
+} from '@agent-assistant/coordination';
+
+const DEFAULT_CONCURRENCY = 5;
+const DEFAULT_PER_CANDIDATE_TIMEOUT_MS = 8_000;
+
+export interface RunFollowUpBatchInput<C, R> {
+  /**
+   * Candidates to process this run, already sorted + deduped by the caller.
+   * The first `maxCandidatesPerRun` items are run; the remainder is
+   * returned as `dropped` for caller-side overflow handling.
+   */
+  candidates: ReadonlyArray<C>;
+  /**
+   * Per-candidate work. Receives an AbortSignal that fires on per-candidate
+   * timeout OR external batch abort — propagate it to inner `fetch(..., { signal })`
+   * calls so they cancel cleanly.
+   */
+  runOne: (candidate: C, signal: AbortSignal) => Promise<R>;
+  /** Bounded concurrency for the batch. Default 5. */
+  concurrency?: number;
+  /** Per-candidate budget in ms. Default 8000. */
+  perCandidateTimeoutMs?: number;
+  /**
+   * FIFO cap on candidates processed this run. Items beyond the cap are
+   * returned in `dropped` for the caller to handle (re-queue, defer,
+   * etc.). Default: no cap (every candidate runs).
+   */
+  maxCandidatesPerRun?: number;
+  /**
+   * Optional batch-level AbortSignal. Cancels in-flight workers AND drops
+   * pending items as `{ status: 'aborted' }` without ever calling `runOne`.
+   */
+  signal?: AbortSignal;
+}
+
+export interface RunFollowUpBatchStats {
+  /** Number of candidates handed to the pool (post-cap). */
+  processed: number;
+  /** Number whose `runOne` resolved successfully. */
+  fulfilled: number;
+  /** Number whose `runOne` rejected with a non-abort, non-timeout error. */
+  rejected: number;
+  /** Number that exceeded `perCandidateTimeoutMs`. */
+  timedOut: number;
+  /** Number aborted via the external `signal`. */
+  aborted: number;
+  /** Number sliced off by `maxCandidatesPerRun`. */
+  dropped: number;
+}
+
+export interface RunFollowUpBatchResult<C, R> {
+  /** Per-item outcomes, in input order, for the processed prefix. */
+  results: BoundedParallelResult<R>[];
+  /** Candidates handed to the pool (the `processed` prefix). */
+  processed: ReadonlyArray<C>;
+  /**
+   * Candidates that overflowed `maxCandidatesPerRun`. Caller decides
+   * whether to defer, re-queue, or surface them in operator output.
+   */
+  dropped: ReadonlyArray<C>;
+  /** Aggregated counts for /health-style surfaces. */
+  stats: RunFollowUpBatchStats;
+}
+
+export async function runFollowUpBatch<C, R>(
+  input: RunFollowUpBatchInput<C, R>,
+): Promise<RunFollowUpBatchResult<C, R>> {
+  const concurrency = input.concurrency ?? DEFAULT_CONCURRENCY;
+  const perCandidateTimeoutMs = input.perCandidateTimeoutMs ?? DEFAULT_PER_CANDIDATE_TIMEOUT_MS;
+  const cap = input.maxCandidatesPerRun ?? input.candidates.length;
+  const safeCap = Math.max(0, Math.min(cap, input.candidates.length));
+
+  const processed = input.candidates.slice(0, safeCap);
+  const dropped = input.candidates.slice(safeCap);
+
+  const results =
+    processed.length === 0
+      ? []
+      : await boundedParallel<C, R>(processed, input.runOne, {
+          concurrency,
+          perItemTimeoutMs: perCandidateTimeoutMs,
+          ...(input.signal ? { signal: input.signal } : {}),
+        });
+
+  const stats: RunFollowUpBatchStats = {
+    processed: processed.length,
+    fulfilled: 0,
+    rejected: 0,
+    timedOut: 0,
+    aborted: 0,
+    dropped: dropped.length,
+  };
+  for (const result of results) {
+    switch (result.status) {
+      case 'fulfilled':
+        stats.fulfilled += 1;
+        break;
+      case 'rejected':
+        stats.rejected += 1;
+        break;
+      case 'timeout':
+        stats.timedOut += 1;
+        break;
+      case 'aborted':
+        stats.aborted += 1;
+        break;
+    }
+  }
+
+  return { results, processed, dropped, stats };
+}


### PR DESCRIPTION
## Summary

Three primitives extracted from sage so future AA proactive consumers inherit the same safety properties without reimplementing them. Spec: sage `docs/specs/proactive-batch-runner.md` §5.1.

- **`runFollowUpBatch<C, R>`** — bounded-parallel batch runner over candidates. Layered on `boundedParallel` from `@agent-assistant/coordination ^0.4.25` (PR #81). Adds per-run cap + overflow tracking + structured stats.
- **`decidePostingPolicy` + `readFailOpenFromEnv`** — fail-open posting verification policy extracted from sage. Env var renames `SAGE_PROACTIVE_FAIL_OPEN_VERIFICATION` → `AA_PROACTIVE_FAIL_OPEN_VERIFICATION` with deprecation alias.
- **`ProactiveBlockCounter` / `ProactiveBlockCounterReader`** interfaces — minimal contract for `/api/proactive/health` operational counters. Adapter implementations stay in the consuming app.

## Surface

```ts
// runFollowUpBatch
export interface RunFollowUpBatchInput<C, R> {
  candidates: ReadonlyArray<C>;
  runOne: (candidate: C, signal: AbortSignal) => Promise<R>;
  concurrency?: number;             // default 5
  perCandidateTimeoutMs?: number;   // default 8000
  maxCandidatesPerRun?: number;     // default Infinity
  signal?: AbortSignal;
}
export interface RunFollowUpBatchResult<C, R> {
  results: BoundedParallelResult<R>[];   // per-item, in input order
  processed: ReadonlyArray<C>;           // post-cap prefix
  dropped: ReadonlyArray<C>;             // overflow tail (caller handles)
  stats: { processed; fulfilled; rejected; timedOut; aborted; dropped };
}

// decidePostingPolicy
export type VerifyDraftOutcome<E = unknown> =
  | { kind: 'verified'; text; evidence: E[] }
  | { kind: 'bridge_unavailable'; draftedText }
  | { kind: 'verification_degraded'; draftedText; reason }
  | { kind: 'no_supporting_evidence' };
export type PolicyDecision<E = unknown> =
  | { action: 'post'; text; evidence: E[] }
  | { action: 'post_unverified'; text; reason }
  | { action: 'block'; reason };
```

## Design notes

- **`runFollowUpBatch` is intentionally thin.** The per-candidate pipeline (evidence → LLM verify → policy → post → persist) stays in caller code via `runOne`. Each AA surface owns its pipeline; AA owns the orchestration safety properties (concurrency, timeout, cap, abort).
- **Generic over evidence type.** `VerifyDraftOutcome<E>` means consumers aren't locked into sage's `ClaimEvidence`. Sage will pass `<ClaimEvidence>`; another surface could pass its own.
- **Conservative fail-open read.** Setting EITHER `AA_*` or legacy `SAGE_*` env var to `"false"` wins. An operator running the legacy var to intentionally fail-closed during an incident must NOT silently start failing-open after the migration.
- **`EvidenceCollector` deliberately stays in sage.** Its `scoreClosure` has hardcoded sage-domain rules (pr-merge → close, affirmative-reply + reaction → close) that don't generalize across AA consumers. Each surface picks its own scoring policy.

## Test plan

- [x] `cd packages/proactive && npm test` — 141/141 pass (118 existing + 23 new)
  - 8 cases for `runFollowUpBatch`: empty, no-cap, FIFO cap, cap-of-zero, cap-larger-than-input, rejected/timedOut classified, external abort threading, input-order preservation
  - 15 cases for `decidePostingPolicy`: every outcome × failOpen branch, idempotent prefix, AA env var, legacy SAGE env var, conservative-read precedence, non-"false" values don't trigger fail-closed
- [x] `npm run build` clean across the build chain (surfaces → coordination → proactive)
- [x] All four primitives + types exported in `dist/index.d.ts`

## Out of scope (follow-up)

- Version bump — handled by separate `chore(release)` commit per the existing convention
- Sage adoption — `checkFollowUps` collapses ~200 LOC of sequential loop into ~30 LOC of glue calling `runFollowUpBatch`; staged at sage `workflows/proactive-batch-runner/04-sage-adopt.ts`. Sage drops its local `verification-policy.ts`, `runCandidatePool`, `runCandidateWithTimeout`, and the `ProactiveBlockCounter` interface (re-imports from AA)
- AA #3 — `createSupermemoryClient` move from sage to `@agent-assistant/memory`. Independent of this PR

## Sequence status

| PR | Repo | Status |
|---|---|---|
| sage #200 | sage | **MERGED** — in-place runner + spec + workflow scaffolds |
| AA #81 | agent-assistant | **MERGED** — `boundedParallel` published as `@agent-assistant/coordination@0.4.25` |
| **This PR** | agent-assistant | **OPEN** — depends on coordination@0.4.25 |
| AA #3 | agent-assistant | Not started — `createSupermemoryClient` extraction |
| sage #4 | sage | Not started — adoption; deletes in-place runner + verification-policy |

🤖 Generated with [Claude Code](https://claude.com/claude-code)