### PR TITLE
feat(memory): add createSupermemoryClient factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3165,6 +3165,15 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/supermemory": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/supermemory/-/supermemory-4.21.1.tgz",
+      "integrity": "sha512-KayOHtD94g7O+yN2qxaHEO5UIXtDl+duaKuhW7gvaraVtP1RHxFn80Pb5s5rKmqIvC+ruaARRlgMw7s/y+6LGQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "supermemory": "bin/cli"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3654,7 +3663,7 @@
     },
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -3737,7 +3746,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3749,7 +3758,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -4016,7 +4025,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -4039,7 +4048,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -4072,7 +4081,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -4240,7 +4249,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -5028,10 +5037,11 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
-        "@agent-relay/memory": "^6.0.9"
+        "@agent-relay/memory": "^6.0.9",
+        "supermemory": "^4.21.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5040,7 +5050,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -5052,9 +5062,10 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
+        "@agent-assistant/coordination": "^0.4.25",
         "@agent-assistant/surfaces": ">=0.2.19",
         "nanoid": "^5.0.7"
       },
@@ -5074,7 +5085,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -5091,7 +5102,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5099,7 +5110,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -5138,7 +5149,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5146,7 +5157,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -5419,7 +5430,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5428,7 +5439,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
@@ -5593,7 +5604,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -5620,7 +5631,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.4.23",
+      "version": "0.4.25",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@agent-assistant/surfaces": "^0.3.0",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@agent-relay/memory": "^6.0.9"
+    "@agent-relay/memory": "^6.0.9",
+    "supermemory": "^4.21.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -59,3 +59,9 @@ export type {
   TurnMemoryContext,
   TurnMemoryScopeKind,
 } from './turn-memory.js';
+
+export { createSupermemoryClient } from './supermemory-client.js';
+export type {
+  CreateSupermemoryClientOptions,
+  EnvSource,
+} from './supermemory-client.js';

--- a/packages/memory/src/supermemory-client.test.ts
+++ b/packages/memory/src/supermemory-client.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSupermemoryClient } from './supermemory-client.js';
+
+describe('createSupermemoryClient', () => {
+  it('returns null when SUPERMEMORY_API_KEY is unset (no-op for local dev)', () => {
+    expect(createSupermemoryClient({ env: {} })).toBeNull();
+    expect(createSupermemoryClient({ env: { SUPERMEMORY_API_KEY: '' } })).toBeNull();
+    expect(createSupermemoryClient({ env: { SUPERMEMORY_API_KEY: '   ' } })).toBeNull();
+  });
+
+  it('returns a configured Supermemory instance when the API key is present', () => {
+    const client = createSupermemoryClient({
+      env: { SUPERMEMORY_API_KEY: 'sm_test_key' },
+    });
+    expect(client).not.toBeNull();
+    // Smoke check that the SDK was actually constructed with our wiring —
+    // we don't depend on internal field names, just that the resource
+    // facades are reachable.
+    expect(typeof client?.documents.list).toBe('function');
+  });
+
+  it('honors a custom apiKeyEnvVar', () => {
+    const client = createSupermemoryClient({
+      env: { MY_APP_SUPERMEMORY_KEY: 'sm_test_key' },
+      apiKeyEnvVar: 'MY_APP_SUPERMEMORY_KEY',
+    });
+    expect(client).not.toBeNull();
+  });
+
+  it('passes the configured fetch override through to the SDK', async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ memories: [], pagination: { totalItems: 0 } }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    const client = createSupermemoryClient({
+      env: { SUPERMEMORY_API_KEY: 'sm_test_key' },
+      fetch: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    expect(client).not.toBeNull();
+
+    await client!.documents.list({ limit: 1 });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl] = fetchSpy.mock.calls[0] as [URL | string];
+    expect(String(calledUrl)).toMatch(/\/v3\/documents\/list$/);
+  });
+
+  it('uses the default endpoint when SUPERMEMORY_ENDPOINT is unset', async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ memories: [] }), { status: 200 }),
+    );
+    const client = createSupermemoryClient({
+      env: { SUPERMEMORY_API_KEY: 'sm_test_key' },
+      fetch: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    await client!.documents.list({ limit: 1 });
+    const [calledUrl] = fetchSpy.mock.calls[0] as [URL | string];
+    expect(String(calledUrl)).toMatch(/^https:\/\/api\.supermemory\.ai\//);
+  });
+
+  it('honors SUPERMEMORY_ENDPOINT override when present', async () => {
+    const fetchSpy = vi.fn(async () =>
+      new Response(JSON.stringify({ memories: [] }), { status: 200 }),
+    );
+    const client = createSupermemoryClient({
+      env: {
+        SUPERMEMORY_API_KEY: 'sm_test_key',
+        SUPERMEMORY_ENDPOINT: 'https://supermemory.test.example',
+      },
+      fetch: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    await client!.documents.list({ limit: 1 });
+    const [calledUrl] = fetchSpy.mock.calls[0] as [URL | string];
+    expect(String(calledUrl)).toMatch(/^https:\/\/supermemory\.test\.example\//);
+  });
+
+  it('does not throw on hosts without globalThis.process (pure Workers / browsers)', () => {
+    // Same Worker-safety contract as @agent-assistant/proactive's
+    // readFailOpenFromEnv (PR #82 review). The no-arg / env-default path
+    // must not hit `process` directly.
+    const original = (globalThis as { process?: unknown }).process;
+    try {
+      delete (globalThis as { process?: unknown }).process;
+      expect(() => createSupermemoryClient()).not.toThrow();
+      expect(createSupermemoryClient()).toBeNull();
+    } finally {
+      if (original === undefined) {
+        delete (globalThis as { process?: unknown }).process;
+      } else {
+        (globalThis as { process?: unknown }).process = original;
+      }
+    }
+  });
+});

--- a/packages/memory/src/supermemory-client.ts
+++ b/packages/memory/src/supermemory-client.ts
@@ -1,0 +1,111 @@
+/**
+ * Single shared factory for the Supermemory TypeScript SDK.
+ *
+ * Extracted from sage's `src/integrations/supermemory-client.ts` (originally
+ * sage PR #198) so every AA consumer that talks to Supermemory shares the
+ * same endpoint, timeout, retry, and Worker-fetch wiring instead of
+ * re-rolling their own copy. Sage previously had four call sites with
+ * subtly different defaults; centralising the construction here removes
+ * that drift class for all future consumers.
+ *
+ * Why this shape:
+ *   - Returns `null` when no API key is available so callers can no-op
+ *     cleanly during local development without wrapping every call site in
+ *     a second env-presence check.
+ *   - Defaults `timeout: 8s` to match the per-call cap that fixed the
+ *     2026-05-04 SEARCH_ERROR outage in prod (sage PR #198). Supermemory
+ *     normally responds in <1s; an 8s ceiling keeps any future wobble
+ *     from saturating the Cloudflare 30s tenant budget.
+ *   - Defaults `maxRetries: 2` (the SDK default) — surfaced explicitly so
+ *     it's obvious from the call site that retries on 5xx/timeout/etc.
+ *     are happening transparently. Without this, the original SEARCH_ERROR
+ *     outage would have been masked by the retry layer entirely.
+ *   - Pins `fetch` to a per-call `globalThis.fetch(...)` closure rather
+ *     than a captured reference. The SDK already calls
+ *     `fetch.call(undefined, url, init)` internally to dodge the
+ *     Cloudflare Workers "Illegal invocation" foot-gun
+ *     (sdk-ts/src/client.ts:594), but passing the explicit closure keeps
+ *     `vi.stubGlobal("fetch", ...)` working in vitest — the SDK captures
+ *     `fetch` at construction time, so a module-level stub set after
+ *     construction would otherwise be invisible.
+ *
+ * Worker-safe: avoids `import { env } from "node:process"` and
+ * `NodeJS.ProcessEnv` in the public surface, both of which would break
+ * Cloudflare Worker consumers without `nodejs_compat`. Same pattern as
+ * `@agent-assistant/proactive`'s `readFailOpenFromEnv` (PR #82 review).
+ */
+
+import Supermemory from 'supermemory';
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_API_KEY_VAR = 'SUPERMEMORY_API_KEY';
+const DEFAULT_ENDPOINT_VAR = 'SUPERMEMORY_ENDPOINT';
+
+/**
+ * Plain map of env var names to their values. Avoids `NodeJS.ProcessEnv` in
+ * the public API so this package stays usable from non-Node runtimes
+ * (Cloudflare Workers without `nodejs_compat`, browsers, Deno, etc.). Matches
+ * the shape exported by `@agent-assistant/proactive`.
+ */
+export type EnvSource = Readonly<Record<string, string | undefined>>;
+
+export interface CreateSupermemoryClientOptions {
+  /** Override the SDK timeout per-instance. Defaults to 8000 ms. */
+  timeoutMs?: number;
+  /** Override the retry budget per-instance. Defaults to 2. */
+  maxRetries?: number;
+  /**
+   * Env source for the API key + endpoint lookup. Defaults to
+   * `globalThis.process?.env ?? {}` so Node, Workers-with-nodejs_compat,
+   * and pure Workers (where `process` is undefined) all behave consistently.
+   * Tests inject a plain object.
+   */
+  env?: EnvSource;
+  /**
+   * Override the env var name read for the API key. Useful for surfaces
+   * that namespace their secrets (e.g. `MY_APP_SUPERMEMORY_API_KEY`).
+   * Defaults to `SUPERMEMORY_API_KEY`.
+   */
+  apiKeyEnvVar?: string;
+  /**
+   * Override the env var name read for the endpoint. Defaults to
+   * `SUPERMEMORY_ENDPOINT`. Unset value falls back to the SDK's default
+   * endpoint (https://api.supermemory.ai).
+   */
+  endpointEnvVar?: string;
+  /**
+   * Override the fetch implementation. Defaults to a per-call closure over
+   * `globalThis.fetch` so test stubs via `vi.stubGlobal('fetch', ...)`
+   * remain visible after the SDK has captured its reference.
+   */
+  fetch?: typeof globalThis.fetch;
+}
+
+function defaultEnvSource(): EnvSource {
+  const proc = (globalThis as { process?: { env?: EnvSource } }).process;
+  return proc?.env ?? {};
+}
+
+function defaultFetch(): typeof globalThis.fetch {
+  return ((input, init) => globalThis.fetch(input, init)) as typeof globalThis.fetch;
+}
+
+export function createSupermemoryClient(
+  options: CreateSupermemoryClientOptions = {},
+): Supermemory | null {
+  const env = options.env ?? defaultEnvSource();
+  const apiKey = env[options.apiKeyEnvVar ?? DEFAULT_API_KEY_VAR]?.trim();
+  if (!apiKey) {
+    return null;
+  }
+
+  const baseURL = env[options.endpointEnvVar ?? DEFAULT_ENDPOINT_VAR]?.trim() || undefined;
+  return new Supermemory({
+    apiKey,
+    ...(baseURL ? { baseURL } : {}),
+    timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxRetries: options.maxRetries ?? DEFAULT_MAX_RETRIES,
+    fetch: options.fetch ?? defaultFetch(),
+  });
+}


### PR DESCRIPTION
## Summary

- New `createSupermemoryClient(options)` factory in `@agent-assistant/memory`
- Wraps the official `supermemory` SDK (v4.21.1) with the timeout / retry / fetch wiring sage shipped in PR #198
- Worker-safe `EnvSource` shape (no `NodeJS.ProcessEnv` in public surface, no `process` access at the no-arg path)
- Independent of AA #82 — different package, different surface
- 7 new tests; existing 77 memory tests still pass; build + types clean

## Why

Sage shipped this factory locally at `src/integrations/supermemory-client.ts` in PR #198 to fix the prod SEARCH_ERROR outage. It centralises 4 call sites that previously had subtly different defaults for endpoint, timeout, retries, and fetch wiring. Moving it upstream so future AA consumers don't reimplement the same wrapper.

## Surface

```ts
export type EnvSource = Readonly<Record<string, string | undefined>>;

export interface CreateSupermemoryClientOptions {
  timeoutMs?: number;        // default 8000
  maxRetries?: number;       // default 2
  env?: EnvSource;           // default: globalThis.process?.env ?? {}
  apiKeyEnvVar?: string;     // default 'SUPERMEMORY_API_KEY'
  endpointEnvVar?: string;   // default 'SUPERMEMORY_ENDPOINT'
  fetch?: typeof globalThis.fetch;
}

export function createSupermemoryClient(
  options?: CreateSupermemoryClientOptions,
): Supermemory | null;  // null when no API key
```

## Design notes

- **Defaults from sage's prod-validated PR #198.** `timeout: 8s` is the per-call cap that fixed the 2026-05-04 SEARCH_ERROR outage; `maxRetries: 2` matches the SDK default but is surfaced explicitly so callers know 5xx retries are happening.
- **Per-call `globalThis.fetch` closure.** The SDK captures `fetch` at construction; without the closure, `vi.stubGlobal('fetch', ...)` set after construction is invisible. The SDK already calls `fetch.call(undefined, url, init)` internally to dodge the Cloudflare Workers "Illegal invocation" foot-gun (`sdk-ts/src/client.ts:594`), so passing the closure is purely for test ergonomics.
- **Worker-safe public surface.** Same shape as AA PR #82's `readFailOpenFromEnv` fix: `EnvSource` instead of `NodeJS.ProcessEnv`, no-arg path reads `globalThis.process?.env ?? {}` so Workers without nodejs_compat get `null` (no API key) instead of a `process is not defined` ReferenceError.
- **Configurable env var names.** `apiKeyEnvVar` / `endpointEnvVar` lets surfaces namespace their secrets (e.g. `MY_APP_SUPERMEMORY_API_KEY`). Defaults match the de-facto Supermemory conventions.
- **Returns `null` on missing key.** Callers no-op cleanly during local dev without a separate env-presence check. Sage's existing call sites already handle this branch.

## Test plan

- [x] `cd packages/memory && npm test` — 84/84 pass (77 existing + 7 new)
  - missing / blank API key returns null
  - present API key constructs an SDK instance
  - custom `apiKeyEnvVar` honored
  - `fetch` override threaded to SDK
  - default endpoint
  - `SUPERMEMORY_ENDPOINT` override
  - `delete globalThis.process` Worker simulation does not throw
- [x] `npm run build` clean
- [x] No `NodeJS.ProcessEnv` / `node:process` in `dist/supermemory-client.d.ts` public signatures (only docstring mentions explaining why)

## Out of scope (follow-up)

- Version bump — handled by separate `chore(release)` commit per the existing convention
- Sage adoption — `src/integrations/supermemory-client.ts` becomes a thin re-export alias for one minor compat cycle, then deletes; staged at sage `workflows/proactive-batch-runner/03-aa-memory.ts` + `04-sage-adopt.ts`

## Sequence status

| PR | Repo | Status |
|---|---|---|
| sage #200 | sage | ✅ Merged |
| AA #81 (`boundedParallel`) | agent-assistant | ✅ Merged → `@agent-assistant/coordination@0.4.25` |
| AA #82 (`runFollowUpBatch` + policy + counter) | agent-assistant | 🟡 Open (review fix landed) |
| **This PR** | agent-assistant | 🟡 Open (independent of #82) |
| sage #4 (adoption) | sage | ⏳ Blocks on AA #82 + this PR publishing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)