### PR TITLE
feat(substrate): runtime policy + telemetry events + eval runner + insight envelope

### DIFF
--- a/.trajectories/active/traj_fnw9bwg7gn4b.json
+++ b/.trajectories/active/traj_fnw9bwg7gn4b.json
@@ -1,0 +1,451 @@
+{
+  "id": "traj_fnw9bwg7gn4b",
+  "version": 1,
+  "task": {
+    "title": "sage-v2-substrate-extraction-pr-workflow",
+    "description": "Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "913fd02c040478350280bdc5"
+    }
+  },
+  "status": "active",
+  "startedAt": "2026-05-07T08:58:53.669Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-05-07T08:58:53.669Z"
+    },
+    {
+      "name": "lead-claude",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T08:59:10.867Z"
+    },
+    {
+      "name": "executor-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T09:05:57.185Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ndvgzfr8l2l4",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T08:58:53.669Z",
+      "endedAt": "2026-05-07T08:59:10.868Z",
+      "events": [
+        {
+          "ts": 1778144333669,
+          "type": "note",
+          "content": "Purpose: Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR."
+        },
+        {
+          "ts": 1778144333669,
+          "type": "note",
+          "content": "Approach: 40-step dag workflow — Parsed 40 steps, 39 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_g8j2khk12d7y",
+      "title": "Execution: lead-architecture-contract",
+      "agentName": "lead-claude",
+      "startedAt": "2026-05-07T08:59:10.868Z",
+      "endedAt": "2026-05-07T09:03:36.093Z",
+      "events": [
+        {
+          "ts": 1778144350868,
+          "type": "note",
+          "content": "\"lead-architecture-contract\": Read tmp/sage-v2-substrate-workflow/source-context.md and write docs/architecture/sage-v2-substrate-implementation-plan.",
+          "raw": {
+            "agent": "lead-claude"
+          }
+        },
+        {
+          "ts": 1778144616043,
+          "type": "completion-marker",
+          "content": "\"lead-architecture-contract\" marker-based completion — Legacy STEP_COMPLETE marker observed (4 signal(s), 1 relevant channel post(s), 2 file change(s); signals=lead-architecture-contract, COMPLETE, docs/architecture/sage-v2-substrate-implementation-plan.md, COMPLETE; channel=**[lead-architecture-contract] Output:**\n```\nt\n         i  …           almost done thinking with high effort\n                        almost done thinking with h; files=modified:.relay/workspaces.json, created:docs/architecture/sage-v2-substrate-implementation-plan.md)",
+          "raw": {
+            "stepName": "lead-architecture-contract",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 2 file change(s)",
+              "signals": [
+                "lead-architecture-contract",
+                "COMPLETE",
+                "docs/architecture/sage-v2-substrate-implementation-plan.md",
+                "COMPLETE"
+              ],
+              "channelPosts": [
+                "**[lead-architecture-contract] Output:**\n```\nt\n         i  …           almost done thinking with high effort\n                        almost done thinking with h"
+              ],
+              "files": [
+                "modified:.relay/workspaces.json",
+                "created:docs/architecture/sage-v2-substrate-implementation-plan.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778144616044,
+          "type": "finding",
+          "content": "\"lead-architecture-contract\" completed → ✻ Cogitated for 3m 24s                                           \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_8ltqx594jlas",
+      "title": "Execution: lead-self-reflection",
+      "agentName": "lead-claude",
+      "startedAt": "2026-05-07T09:03:36.093Z",
+      "endedAt": "2026-05-07T09:05:57.188Z",
+      "events": [
+        {
+          "ts": 1778144616093,
+          "type": "note",
+          "content": "\"lead-self-reflection\": Write docs/architecture/sage-v2-substrate-lead-reflection.md",
+          "raw": {
+            "agent": "lead-claude"
+          }
+        },
+        {
+          "ts": 1778144757177,
+          "type": "completion-marker",
+          "content": "\"lead-self-reflection\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 2 relevant channel post(s), 1 file change(s); signals=COMPLETE, Agent Relay collects anonymous usage data to improve the product.Run `agent-relay telemetry disable` to opt out.78>0q╭─── Claude Code v2.1.132 ─────────────────────────────────────────────────────╮, docs/architecture/sage-v2-substrate-lead-reflection.md, lead-self-reflection, COMPLETE, **[lead-self-reflection] Output:**; channel=[lead-self-reflection] Wrote docs/architecture/sage-v2-substrate-lead-reflection.md. Three sections: (1) leak risks — drill-or-stop tag enums, default normalize | **[lead-self-reflection] Output:**\n```\nith high effort\n                                 thinking more with high effort\n                                 thinking; files=created:docs/architecture/sage-v2-substrate-lead-reflection.md)",
+          "raw": {
+            "stepName": "lead-self-reflection",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 2 relevant channel post(s), 1 file change(s)",
+              "signals": [
+                "COMPLETE",
+                "Agent Relay collects anonymous usage data to improve the product.Run `agent-relay telemetry disable` to opt out.78>0q╭─── Claude Code v2.1.132 ─────────────────────────────────────────────────────╮",
+                "docs/architecture/sage-v2-substrate-lead-reflection.md",
+                "lead-self-reflection",
+                "COMPLETE",
+                "**[lead-self-reflection] Output:**"
+              ],
+              "channelPosts": [
+                "[lead-self-reflection] Wrote docs/architecture/sage-v2-substrate-lead-reflection.md. Three sections: (1) leak risks — drill-or-stop tag enums, default normalize",
+                "**[lead-self-reflection] Output:**\n```\nith high effort\n                                 thinking more with high effort\n                                 thinking"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-substrate-lead-reflection.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778144757177,
+          "type": "finding",
+          "content": "\"lead-self-reflection\" completed → ✻ Brewed for 1m 47s                                            \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_c6r4bx8sicll",
+      "title": "Execution: implement-nested-subagent-runner",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:05:57.188Z",
+      "endedAt": "2026-05-07T09:15:56.154Z",
+      "events": [
+        {
+          "ts": 1778144757188,
+          "type": "note",
+          "content": "\"implement-nested-subagent-runner\": Implement the nested subagent runner slice from docs/architecture/sage-v2-substrate-implementation-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778145328741,
+          "type": "completion-evidence",
+          "content": "\"implement-nested-subagent-runner\" verification-based completion — Verification passed (3 signal(s), 6 file change(s), exit=0; signals=0, (node:50858) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0; files=modified:packages/harness/src/index.ts, created:packages/harness/src/nested-subagent-runner.test.ts, created:packages/harness/src/nested-subagent-runner.ts, modified:packages/harness/src/registries/index.ts, modified:packages/harness/src/subagent-registry.test.ts, modified:packages/harness/src/subagent-registry.ts; exit=0)",
+          "raw": {
+            "stepName": "implement-nested-subagent-runner",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "3 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:50858) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0"
+              ],
+              "files": [
+                "modified:packages/harness/src/index.ts",
+                "created:packages/harness/src/nested-subagent-runner.test.ts",
+                "created:packages/harness/src/nested-subagent-runner.ts",
+                "modified:packages/harness/src/registries/index.ts",
+                "modified:packages/harness/src/subagent-registry.test.ts",
+                "modified:packages/harness/src/subagent-registry.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778145328741,
+          "type": "finding",
+          "content": "\"implement-nested-subagent-runner\" completed → - `packages/harness/src/nested-subagent-runner.test.ts`",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_4yasmxjr1mcu",
+      "title": "Execution: fix-harness-after-nested-runner",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:15:56.154Z",
+      "endedAt": "2026-05-07T09:16:31.221Z",
+      "events": [
+        {
+          "ts": 1778145356154,
+          "type": "note",
+          "content": "\"fix-harness-after-nested-runner\": Harness test output after nested runner:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778145368968,
+          "type": "completion-evidence",
+          "content": "\"fix-harness-after-nested-runner\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), exit=0; signals=0, Result, (node:65875) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[fix-harness-after-nested-runner] Output:**; channel=**[fix-harness-after-nested-runner] Output:**\n```\nResult\n`EXIT: 0` was already achieved for the nested runner slice.\nActions taken\nNo code changes were made.\nNo; exit=0)",
+          "raw": {
+            "stepName": "fix-harness-after-nested-runner",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), exit=0",
+              "signals": [
+                "0",
+                "Result",
+                "(node:65875) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[fix-harness-after-nested-runner] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-harness-after-nested-runner] Output:**\n```\nResult\n`EXIT: 0` was already achieved for the nested runner slice.\nActions taken\nNo code changes were made.\nNo"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778145368968,
+          "type": "finding",
+          "content": "\"fix-harness-after-nested-runner\" completed → Result\n\n`EXIT: 0` was already achieved for the nested runner slice.\n\nActions taken\n\nNo code changes were made.\nNo tests ",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_10vgs3xwlagq",
+      "title": "Execution: implement-runtime-budget-policy",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:16:31.221Z",
+      "endedAt": "2026-05-07T09:38:27.278Z",
+      "events": [
+        {
+          "ts": 1778145391221,
+          "type": "note",
+          "content": "\"implement-runtime-budget-policy\": Implement the runtime budget policy slice from docs/architecture/sage-v2-substrate-implementation-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778146684303,
+          "type": "completion-evidence",
+          "content": "\"implement-runtime-budget-policy\" verification-based completion — Verification passed (4 signal(s), 6 file change(s), exit=0; signals=0, (node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, (node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0; files=modified:packages/harness/package.json, modified:packages/harness/src/harness.ts, modified:packages/harness/src/index.ts, created:packages/harness/src/runtime-policy.integration.test.ts, created:packages/harness/src/runtime-policy.test.ts, created:packages/harness/src/runtime-policy/index.ts; exit=0)",
+          "raw": {
+            "stepName": "implement-runtime-budget-policy",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "(node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0"
+              ],
+              "files": [
+                "modified:packages/harness/package.json",
+                "modified:packages/harness/src/harness.ts",
+                "modified:packages/harness/src/index.ts",
+                "created:packages/harness/src/runtime-policy.integration.test.ts",
+                "created:packages/harness/src/runtime-policy.test.ts",
+                "created:packages/harness/src/runtime-policy/index.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778146684303,
+          "type": "finding",
+          "content": "\"implement-runtime-budget-policy\" completed → - Exported harness runtime-policy public surface and subpath export",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_dau46qv2k35d",
+      "title": "Execution: fix-harness-after-runtime-policy",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:38:27.278Z",
+      "endedAt": "2026-05-07T09:39:26.730Z",
+      "events": [
+        {
+          "ts": 1778146707278,
+          "type": "note",
+          "content": "\"fix-harness-after-runtime-policy\": Harness test output after runtime policy:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778146742980,
+          "type": "completion-evidence",
+          "content": "\"fix-harness-after-runtime-policy\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), exit=0; signals=0, **Result**, (node:4723) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[fix-harness-after-runtime-policy] Output:**; channel=**[fix-harness-after-runtime-policy] Output:**\n```\n**Result**\nNo action was required.\nThe supplied `@agent-assistant/harness` test run already ended with `EXIT:; exit=0)",
+          "raw": {
+            "stepName": "fix-harness-after-runtime-policy",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), exit=0",
+              "signals": [
+                "0",
+                "**Result**",
+                "(node:4723) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[fix-harness-after-runtime-policy] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-harness-after-runtime-policy] Output:**\n```\n**Result**\nNo action was required.\nThe supplied `@agent-assistant/harness` test run already ended with `EXIT:"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778146742980,
+          "type": "finding",
+          "content": "\"fix-harness-after-runtime-policy\" completed → **Result**\n\nNo action was required.\n\nThe supplied `@agent-assistant/harness` test run already ended with `EXIT: 0`, with",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_kkegexgb5nlb",
+      "title": "Execution: implement-telemetry-evals-insights",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:39:26.730Z",
+      "events": [
+        {
+          "ts": 1778146766731,
+          "type": "note",
+          "content": "\"implement-telemetry-evals-insights\": Implement the telemetry, eval substrate, and insight contract slices from docs/architecture/sage-v2-substrate-implementa",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778147007366,
+          "type": "decision",
+          "content": "Use a new @agent-assistant/evals workspace package and extend turn-context blocks with optional metadata for insight provenance: Use a new @agent-assistant/evals workspace package and extend turn-context blocks with optional metadata for insight provenance",
+          "raw": {
+            "question": "Use a new @agent-assistant/evals workspace package and extend turn-context blocks with optional metadata for insight provenance",
+            "chosen": "Use a new @agent-assistant/evals workspace package and extend turn-context blocks with optional metadata for insight provenance",
+            "alternatives": [],
+            "reasoning": "The eval substrate has a distinct public contract and tests, while insight provenance needs to survive projection without coupling VFS parsing to execution-request formatting."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778157162829,
+          "type": "decision",
+          "content": "Address PR #86 review comments with a narrow follow-up commit: Address PR #86 review comments with a narrow follow-up commit",
+          "raw": {
+            "question": "Address PR #86 review comments with a narrow follow-up commit",
+            "chosen": "Address PR #86 review comments with a narrow follow-up commit",
+            "alternatives": [],
+            "reasoning": "CI failure is from premature runtime-policy exports, while review comments target nested subagent runner error boundaries, trace propagation, tests, and doc links; keep unrelated workflow-generated dirty files out of the PR."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778157341266,
+          "type": "reflection",
+          "content": "PR #86 follow-up committed and pushed: runtime-policy export leak removed, nested runner seam errors are isolated, child trace precedence has regression coverage, Workers fetch guard now uses dynamic import, and targeted harness validation is green.",
+          "raw": {
+            "focalPoints": [
+              "pr-review",
+              "ci",
+              "trace-propagation",
+              "workers-fetch"
+            ],
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "focal:pr-review",
+            "focal:ci",
+            "focal:trace-propagation",
+            "focal:workers-fetch",
+            "confidence:0.86"
+          ]
+        },
+        {
+          "ts": 1778158009682,
+          "type": "decision",
+          "content": "Address second PR #86 review pass with child-trace direct fallback and GC-friendly counters: Address second PR #86 review pass with child-trace direct fallback and GC-friendly counters",
+          "raw": {
+            "question": "Address second PR #86 review pass with child-trace direct fallback and GC-friendly counters",
+            "chosen": "Address second PR #86 review pass with child-trace direct fallback and GC-friendly counters",
+            "alternatives": [],
+            "reasoning": "CodeRabbit found the direct parentContext fallback still preferred parentTraceId before childTraceId and noted the string-keyed child counter map can retain parent turn entries forever in long-lived harnesses."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778158157216,
+          "type": "reflection",
+          "content": "Second PR #86 review pass pushed in af46554: direct childTraceId now wins over direct parentTraceId, child counter state is bounded with explicit oldest-entry eviction, and regression tests cover direct trace precedence plus distinct IDs for parallel children.",
+          "raw": {
+            "focalPoints": [
+              "pr-review",
+              "trace-propagation",
+              "counter-lifecycle"
+            ],
+            "confidence": 0.84
+          },
+          "significance": "high",
+          "tags": [
+            "focal:pr-review",
+            "focal:trace-propagation",
+            "focal:counter-lifecycle",
+            "confidence:0.84"
+          ]
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": []
+}

--- a/.trajectories/active/traj_wfp3rnu178pc.json
+++ b/.trajectories/active/traj_wfp3rnu178pc.json
@@ -78,6 +78,85 @@
           "raw": {
             "agent": "implementer"
           }
+        },
+        {
+          "ts": 1778142714760,
+          "type": "decision",
+          "content": "Trace Sage v2 PR #208 into Agent Assistant as a substrate extraction spec: Trace Sage v2 PR #208 into Agent Assistant as a substrate extraction spec",
+          "raw": {
+            "question": "Trace Sage v2 PR #208 into Agent Assistant as a substrate extraction spec",
+            "chosen": "Trace Sage v2 PR #208 into Agent Assistant as a substrate extraction spec",
+            "alternatives": [],
+            "reasoning": "Sage proved reusable needs around nested subagent execution, runtime budget policy, telemetry/evals, and insights context, but Sage-specific prompts and Slack-to-Notion workflow should remain product-owned."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778142851471,
+          "type": "reflection",
+          "content": "Opened agent-assistant PR #85 from latest main with a Sage v2 substrate extraction map. The PR keeps product behavior in Sage and identifies reusable Agent Assistant follow-up tracks for nested subagent runner, runtime budget policy, telemetry/evals, and insights context.",
+          "raw": {
+            "focalPoints": [
+              "sage-v2",
+              "agent-assistant",
+              "substrate-extraction",
+              "pr-85"
+            ],
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "focal:sage-v2",
+            "focal:agent-assistant",
+            "focal:substrate-extraction",
+            "focal:pr-85",
+            "confidence:0.86"
+          ]
+        },
+        {
+          "ts": 1778143827319,
+          "type": "decision",
+          "content": "Author Sage v2 substrate extraction as a dedicated Agent Relay workflow: Author Sage v2 substrate extraction as a dedicated Agent Relay workflow",
+          "raw": {
+            "question": "Author Sage v2 substrate extraction as a dedicated Agent Relay workflow",
+            "chosen": "Author Sage v2 substrate extraction as a dedicated Agent Relay workflow",
+            "alternatives": [],
+            "reasoning": "The requested output is orchestration work: Claude lead plus Codex execution, explicit self-reflection, peer review, 80-to-100 validation, and PR publication. A workflow file is the right artifact because it preserves these constraints as executable gates instead of a prose plan."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778144064161,
+          "type": "reflection",
+          "content": "Sage v2 workflow artifact drafted and locally type-checked. Remaining work is narrow: stage only the new workflow, commit it on the existing substrate branch, push, and open or update the PR without absorbing active trajectory/tmp drift.",
+          "raw": {
+            "focalPoints": [
+              "workflow-artifact",
+              "scope-control",
+              "pr-publication"
+            ],
+            "adjustments": "Stage a single path explicitly and leave unrelated dirty files untouched.",
+            "confidence": 0.82
+          },
+          "significance": "high",
+          "tags": [
+            "focal:workflow-artifact",
+            "focal:scope-control",
+            "focal:pr-publication",
+            "confidence:0.82"
+          ]
+        },
+        {
+          "ts": 1778144202576,
+          "type": "decision",
+          "content": "Fix Ricky ESM import resolution in Sage v2 workflow: Fix Ricky ESM import resolution in Sage v2 workflow",
+          "raw": {
+            "question": "Fix Ricky ESM import resolution in Sage v2 workflow",
+            "chosen": "Fix Ricky ESM import resolution in Sage v2 workflow",
+            "alternatives": [],
+            "reasoning": "Ricky runs workflow files through Node ESM, which does not resolve extensionless relative TypeScript imports. The workflow should import the local setup helper with an explicit .ts extension so the runtime loader can find it."
+          },
+          "significance": "high"
         }
       ]
     }

--- a/.trajectories/completed/2026-05/traj_bl065l0xwwoa.json
+++ b/.trajectories/completed/2026-05/traj_bl065l0xwwoa.json
@@ -1,0 +1,449 @@
+{
+  "id": "traj_bl065l0xwwoa",
+  "version": 1,
+  "task": {
+    "title": "sage-v2-substrate-extraction-pr-workflow",
+    "description": "Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "e2d3fc61a0ff7a1a309eabb7"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-07T10:09:14.212Z",
+  "completedAt": "2026-05-07T11:56:49.669Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-05-07T10:09:14.212Z"
+    },
+    {
+      "name": "executor-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T10:09:17.823Z"
+    },
+    {
+      "name": "fresh-eyes-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T10:49:58.308Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_sc2mox1uxpkb",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T10:09:14.212Z",
+      "endedAt": "2026-05-07T10:09:17.828Z",
+      "events": [
+        {
+          "ts": 1778148554213,
+          "type": "note",
+          "content": "Purpose: Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR."
+        },
+        {
+          "ts": 1778148554213,
+          "type": "note",
+          "content": "Approach: 45-step dag workflow — Parsed 45 steps, 44 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_cpkg54vw2yj4",
+      "title": "Execution: implement-telemetry-events",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T10:09:17.828Z",
+      "endedAt": "2026-05-07T10:21:53.361Z",
+      "events": [
+        {
+          "ts": 1778148557828,
+          "type": "note",
+          "content": "\"implement-telemetry-events\": Implement only the telemetry vocabulary slice from docs/architecture/sage-v2-substrate-implementation-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778149313213,
+          "type": "completion-evidence",
+          "content": "\"implement-telemetry-events\" verification-based completion — Verification passed (4 signal(s), 6 file change(s), exit=0; signals=0, (node:95014) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, (node:95014) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0; files=modified:packages/telemetry/dist/cost.d.ts, modified:packages/telemetry/dist/cost.js, created:packages/telemetry/dist/events.d.ts, created:packages/telemetry/dist/events.js, modified:packages/telemetry/dist/harness-bridge.d.ts, modified:packages/telemetry/dist/harness-bridge.js; exit=0)",
+          "raw": {
+            "stepName": "implement-telemetry-events",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:95014) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "(node:95014) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0"
+              ],
+              "files": [
+                "modified:packages/telemetry/dist/cost.d.ts",
+                "modified:packages/telemetry/dist/cost.js",
+                "created:packages/telemetry/dist/events.d.ts",
+                "created:packages/telemetry/dist/events.js",
+                "modified:packages/telemetry/dist/harness-bridge.d.ts",
+                "modified:packages/telemetry/dist/harness-bridge.js"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778149313213,
+          "type": "finding",
+          "content": "\"implement-telemetry-events\" completed → - `packages/telemetry/test/private_content_never_leaks.test.ts`",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_y6s79tpkkpj5",
+      "title": "Execution: implement-eval-substrate",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T10:21:53.361Z",
+      "endedAt": "2026-05-07T10:28:05.441Z",
+      "events": [
+        {
+          "ts": 1778149313361,
+          "type": "note",
+          "content": "\"implement-eval-substrate\": Implement only the eval substrate slice from docs/architecture/sage-v2-substrate-implementation-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778149685401,
+          "type": "completion-evidence",
+          "content": "\"implement-eval-substrate\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0; signals=0, **Implemented**, (node:13596) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[implement-eval-substrate] Output:**; channel=**[implement-eval-substrate] Output:**\n```\nvals`\n**Behavior implemented**\n- Fixture-oriented runner contract: runners receive `{ caseName, fixture }` with injec; files=modified:packages/telemetry/dist/cost.d.ts, modified:packages/telemetry/dist/cost.js, created:packages/telemetry/dist/evals/eval-checks.d.ts, created:packages/telemetry/dist/evals/eval-checks.js, created:packages/telemetry/dist/evals/eval-runner.d.ts, created:packages/telemetry/dist/evals/eval-runner.js; exit=0)",
+          "raw": {
+            "stepName": "implement-eval-substrate",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "**Implemented**",
+                "(node:13596) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[implement-eval-substrate] Output:**"
+              ],
+              "channelPosts": [
+                "**[implement-eval-substrate] Output:**\n```\nvals`\n**Behavior implemented**\n- Fixture-oriented runner contract: runners receive `{ caseName, fixture }` with injec"
+              ],
+              "files": [
+                "modified:packages/telemetry/dist/cost.d.ts",
+                "modified:packages/telemetry/dist/cost.js",
+                "created:packages/telemetry/dist/evals/eval-checks.d.ts",
+                "created:packages/telemetry/dist/evals/eval-checks.js",
+                "created:packages/telemetry/dist/evals/eval-runner.d.ts",
+                "created:packages/telemetry/dist/evals/eval-runner.js"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778149685401,
+          "type": "finding",
+          "content": "\"implement-eval-substrate\" completed → **Implemented**\nAdded the eval substrate as a scoped `@agent-assistant/telemetry/evals` module, matching the plan’s “sma",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_tvku3lvxhv3w",
+      "title": "Execution: implement-insight-contracts",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T10:28:05.441Z",
+      "endedAt": "2026-05-07T10:35:44.240Z",
+      "events": [
+        {
+          "ts": 1778149685441,
+          "type": "note",
+          "content": "\"implement-insight-contracts\": Implement only the insight envelope and reader helper slice from docs/architecture/sage-v2-substrate-implementation-plan",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778150114481,
+          "type": "completion-evidence",
+          "content": "\"implement-insight-contracts\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0; signals=0, Implemented the insight-envelope and reader-helper slice only., (node:24696) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[implement-insight-contracts] Output:**; channel=**[implement-insight-contracts] Output:**\n```\nent-assistant/vfs`.\n- Added `readInsightEnvelope(vfs, path)` with:\n  - `missing` handling\n  - `unsupported_schema`; files=modified:packages/turn-context/dist/assembler.d.ts, modified:packages/turn-context/dist/assembler.js, modified:packages/turn-context/dist/expression.d.ts, modified:packages/turn-context/dist/expression.js, modified:packages/turn-context/dist/identity.d.ts, modified:packages/turn-context/dist/identity.js; exit=0)",
+          "raw": {
+            "stepName": "implement-insight-contracts",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "Implemented the insight-envelope and reader-helper slice only.",
+                "(node:24696) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[implement-insight-contracts] Output:**"
+              ],
+              "channelPosts": [
+                "**[implement-insight-contracts] Output:**\n```\nent-assistant/vfs`.\n- Added `readInsightEnvelope(vfs, path)` with:\n  - `missing` handling\n  - `unsupported_schema`"
+              ],
+              "files": [
+                "modified:packages/turn-context/dist/assembler.d.ts",
+                "modified:packages/turn-context/dist/assembler.js",
+                "modified:packages/turn-context/dist/expression.d.ts",
+                "modified:packages/turn-context/dist/expression.js",
+                "modified:packages/turn-context/dist/identity.d.ts",
+                "modified:packages/turn-context/dist/identity.js"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778150114481,
+          "type": "finding",
+          "content": "\"implement-insight-contracts\" completed → Implemented the insight-envelope and reader-helper slice only.\n\nArtifacts produced:\n- `packages/vfs/src/insight/envelope",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_mdz87gdlo1fl",
+      "title": "Execution: fix-targeted-package-tests",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T10:35:44.240Z",
+      "endedAt": "2026-05-07T10:36:32.968Z",
+      "events": [
+        {
+          "ts": 1778150144240,
+          "type": "note",
+          "content": "\"fix-targeted-package-tests\": Targeted package test output:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778150163153,
+          "type": "completion-evidence",
+          "content": "\"fix-targeted-package-tests\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), exit=0; signals=0, **Result**, (node:70095) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[fix-targeted-package-tests] Output:**; channel=**[fix-targeted-package-tests] Output:**\n```\n**Result**\nNo action taken.\nThe provided targeted package status is already green:\n- `HARNESS_EXIT=0`\n- `TELEMETRY_; exit=0)",
+          "raw": {
+            "stepName": "fix-targeted-package-tests",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), exit=0",
+              "signals": [
+                "0",
+                "**Result**",
+                "(node:70095) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[fix-targeted-package-tests] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-targeted-package-tests] Output:**\n```\n**Result**\nNo action taken.\nThe provided targeted package status is already green:\n- `HARNESS_EXIT=0`\n- `TELEMETRY_"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778150163153,
+          "type": "finding",
+          "content": "\"fix-targeted-package-tests\" completed → Artifacts produced: none.",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_2kdh5rthijcz",
+      "title": "Execution: executor-self-reflection",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T10:36:32.968Z",
+      "endedAt": "2026-05-07T10:44:02.347Z",
+      "events": [
+        {
+          "ts": 1778150192968,
+          "type": "note",
+          "content": "\"executor-self-reflection\": Write docs/architecture/sage-v2-substrate-executor-reflection.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778150559061,
+          "type": "completion-evidence",
+          "content": "\"executor-self-reflection\" verification-based completion — Verification passed (3 signal(s), 6 file change(s), exit=0; signals=0, (node:73906) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, docs/architecture/sage-v2-substrate-executor-reflection.md; files=created:docs/architecture/sage-v2-substrate-executor-reflection.md, modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts, modified:packages/harness/dist/adapter/agent-relay-adapter.js, modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts, modified:packages/harness/dist/adapter/anthropic-model-adapter.js, modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts; exit=0)",
+          "raw": {
+            "stepName": "executor-self-reflection",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "3 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:73906) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "docs/architecture/sage-v2-substrate-executor-reflection.md"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-substrate-executor-reflection.md",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.js",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.js",
+                "modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778150559061,
+          "type": "finding",
+          "content": "\"executor-self-reflection\" completed → EXECUTOR_SELF_REFLECTION_COMPLETE",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_8aopcqxva746",
+      "title": "Execution: fix-build-and-regressions",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T10:44:02.347Z",
+      "endedAt": "2026-05-07T10:49:58.311Z",
+      "events": [
+        {
+          "ts": 1778150642347,
+          "type": "note",
+          "content": "\"fix-build-and-regressions\": Workspace build/regression output:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778150905807,
+          "type": "completion-evidence",
+          "content": "\"fix-build-and-regressions\" verification-based completion — Verification passed (6 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0; signals=0, **Outcome**, (node:86230) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, (node:86230) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[fix-build-and-regressions] Output:**; channel=**[fix-build-and-regressions] Output:**\n```\n**Outcome**\nFixed the workspace build regression. The failure was caused by `@agent-assistant/turn-context` emitting; files=modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-scheduler.d.ts, modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-scheduler.js, modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-store.d.ts, modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-store.js, modified:packages/cloudflare-runtime/dist/adapters/cf-delivery-adapter.d.ts, modified:packages/cloudflare-runtime/dist/adapters/cf-delivery-adapter.js; exit=0)",
+          "raw": {
+            "stepName": "fix-build-and-regressions",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "6 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "**Outcome**",
+                "(node:86230) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "(node:86230) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[fix-build-and-regressions] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-build-and-regressions] Output:**\n```\n**Outcome**\nFixed the workspace build regression. The failure was caused by `@agent-assistant/turn-context` emitting"
+              ],
+              "files": [
+                "modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-scheduler.d.ts",
+                "modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-scheduler.js",
+                "modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-store.d.ts",
+                "modified:packages/cloudflare-runtime/dist/adapters/cf-continuation-store.js",
+                "modified:packages/cloudflare-runtime/dist/adapters/cf-delivery-adapter.d.ts",
+                "modified:packages/cloudflare-runtime/dist/adapters/cf-delivery-adapter.js"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778150905807,
+          "type": "finding",
+          "content": "\"fix-build-and-regressions\" completed → **Outcome**\n\nFixed the workspace build regression. The failure was caused by `@agent-assistant/turn-context` emitting a ",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_i8bdfu6iy9cz",
+      "title": "Execution: codex-fresh-eyes-review",
+      "agentName": "fresh-eyes-codex",
+      "startedAt": "2026-05-07T10:49:58.311Z",
+      "endedAt": "2026-05-07T11:56:49.669Z",
+      "events": [
+        {
+          "ts": 1778150998311,
+          "type": "note",
+          "content": "\"codex-fresh-eyes-review\": Perform a fresh-eyes review of the complete diff:",
+          "raw": {
+            "agent": "fresh-eyes-codex"
+          }
+        },
+        {
+          "ts": 1778151198466,
+          "type": "completion-evidence",
+          "content": "\"codex-fresh-eyes-review\" verification-based completion — Verification passed (3 signal(s), 1 file change(s), exit=0; signals=0, (node:8578) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, docs/architecture/sage-v2-substrate-fresh-eyes-review.md; files=created:docs/architecture/sage-v2-substrate-fresh-eyes-review.md; exit=0)",
+          "raw": {
+            "stepName": "codex-fresh-eyes-review",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "3 signal(s), 1 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:8578) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "docs/architecture/sage-v2-substrate-fresh-eyes-review.md"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-substrate-fresh-eyes-review.md"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778151198466,
+          "type": "finding",
+          "content": "\"codex-fresh-eyes-review\" completed → FRESH_EYES_REVIEW_COMPLETE",
+          "significance": "medium"
+        },
+        {
+          "ts": 1778153134971,
+          "type": "reflection",
+          "content": "Nested runner slice is implemented and validated in harness scope; the remaining adjustment was narrowing public exports and proving /registries reachability without widening the API.",
+          "raw": {
+            "focalPoints": [
+              "api-surface",
+              "exports",
+              "verification"
+            ],
+            "adjustments": "Removed extra RunSubagentInput/RunSubagentResult re-exports from root and registries; added a direct subpath export test.",
+            "confidence": 0.91
+          },
+          "significance": "high",
+          "tags": [
+            "focal:api-surface",
+            "focal:exports",
+            "focal:verification",
+            "confidence:0.91"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Wrote the fresh-eyes self-reflection for the Sage v2 nested subagent runner PR 1 slice, with a PASS_WITH_FOLLOWUPS verdict based on passing targeted validation and a remaining scope-split follow-up for runtime-policy export changes.",
+    "approach": "Standard approach",
+    "confidence": 0.88
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": []
+}

--- a/.trajectories/completed/2026-05/traj_bl065l0xwwoa.md
+++ b/.trajectories/completed/2026-05/traj_bl065l0xwwoa.md
@@ -1,0 +1,45 @@
+# Trajectory: sage-v2-substrate-extraction-pr-workflow
+
+> **Status:** ✅ Completed
+> **Task:** e2d3fc61a0ff7a1a309eabb7
+> **Confidence:** 88%
+> **Started:** May 7, 2026 at 12:09 PM
+> **Completed:** May 7, 2026 at 01:56 PM
+
+---
+
+## Summary
+
+Wrote the fresh-eyes self-reflection for the Sage v2 nested subagent runner PR 1 slice, with a PASS_WITH_FOLLOWUPS verdict based on passing targeted validation and a remaining scope-split follow-up for runtime-policy export changes.
+
+**Approach:** Standard approach
+
+---
+
+## Chapters
+
+### 1. Planning
+*Agent: orchestrator*
+
+### 2. Execution: implement-telemetry-events
+*Agent: executor-codex*
+
+### 3. Execution: implement-eval-substrate
+*Agent: executor-codex*
+
+### 4. Execution: implement-insight-contracts
+*Agent: executor-codex*
+
+### 5. Execution: fix-targeted-package-tests
+*Agent: executor-codex*
+
+### 6. Execution: executor-self-reflection
+*Agent: executor-codex*
+
+### 7. Execution: fix-build-and-regressions
+*Agent: executor-codex*
+
+### 8. Execution: codex-fresh-eyes-review
+*Agent: fresh-eyes-codex*
+
+- Nested runner slice is implemented and validated in harness scope; the remaining adjustment was narrowing public exports and proving /registries reachability without widening the API.

--- a/.trajectories/completed/2026-05/traj_bpncz0f6thfq.json
+++ b/.trajectories/completed/2026-05/traj_bpncz0f6thfq.json
@@ -1,0 +1,162 @@
+{
+  "id": "traj_bpncz0f6thfq",
+  "version": 1,
+  "task": {
+    "title": "sage-v2-nested-subagent-runner-pr-workflow",
+    "description": "First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "59b00d0bb6faf24320a19d9e"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-07T11:30:22.555Z",
+  "completedAt": "2026-05-07T11:35:48.795Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-05-07T11:30:22.555Z"
+    },
+    {
+      "name": "lead-claude",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:30:26.064Z"
+    },
+    {
+      "name": "executor-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:32:33.040Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_an99dkpks981",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T11:30:22.555Z",
+      "endedAt": "2026-05-07T11:30:26.065Z",
+      "events": [
+        {
+          "ts": 1778153422555,
+          "type": "note",
+          "content": "Purpose: First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR."
+        },
+        {
+          "ts": 1778153422556,
+          "type": "note",
+          "content": "Approach: 27-step dag workflow — Parsed 27 steps, 26 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_jum5dmx45fvd",
+      "title": "Execution: lead-self-reflection",
+      "agentName": "lead-claude",
+      "startedAt": "2026-05-07T11:30:26.065Z",
+      "endedAt": "2026-05-07T11:32:33.040Z",
+      "events": [
+        {
+          "ts": 1778153426065,
+          "type": "note",
+          "content": "\"lead-self-reflection\": Write docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md",
+          "raw": {
+            "agent": "lead-claude"
+          }
+        },
+        {
+          "ts": 1778153553035,
+          "type": "completion-marker",
+          "content": "\"lead-self-reflection\" marker-based completion — Legacy STEP_COMPLETE marker observed (5 signal(s), 1 relevant channel post(s), 1 file change(s); signals=lead-self-reflection, COMPLETE, docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md, lead-self-reflection, COMPLETE; channel=**[lead-self-reflection] Output:**\n```\n expand)    \n⏺ Write(docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md)\n  ⎿  Error writing file        ; files=modified:.relay/workspaces.json)",
+          "raw": {
+            "stepName": "lead-self-reflection",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), 1 file change(s)",
+              "signals": [
+                "lead-self-reflection",
+                "COMPLETE",
+                "docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md",
+                "lead-self-reflection",
+                "COMPLETE"
+              ],
+              "channelPosts": [
+                "**[lead-self-reflection] Output:**\n```\n expand)    \n⏺ Write(docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md)\n  ⎿  Error writing file        "
+              ],
+              "files": [
+                "modified:.relay/workspaces.json"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778153553035,
+          "type": "finding",
+          "content": "\"lead-self-reflection\" completed → ✻ Churned fo  1m 6s                                         \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_a6y4g1f9xtri",
+      "title": "Execution: implement-nested-runner",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T11:32:33.040Z",
+      "endedAt": "2026-05-07T11:35:48.795Z",
+      "events": [
+        {
+          "ts": 1778153553040,
+          "type": "note",
+          "content": "\"implement-nested-runner\": Implement only the nested subagent runner slice using docs/architecture/sage-v2-nested-subagent-runner-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778153598636,
+          "type": "decision",
+          "content": "Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation: Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation",
+          "raw": {
+            "question": "Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation",
+            "chosen": "Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation",
+            "alternatives": [],
+            "reasoning": "The plan requires deterministic nested-turn construction, allowlist enforcement, parent-context filtering, and no changes to the registry contract or Sage-specific behavior."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778153742848,
+          "type": "reflection",
+          "content": "Nested runner now matches the substrate seam more literally: createHarness only receives filtered parent context, child ids are scoped per parent turn instead of globally, and direct-runner tests cover the hidden contract edges.",
+          "raw": {
+            "focalPoints": [
+              "runner-contract",
+              "child-id-determinism",
+              "parent-context-filtering"
+            ],
+            "adjustments": "Added direct invocation and parent-scoped child-id tests; kept scope limited to harness nested-runner files.",
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "focal:runner-contract",
+            "focal:child-id-determinism",
+            "focal:parent-context-filtering",
+            "confidence:0.86"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Implemented the nested subagent runner slice with parent-scoped child-id derivation, filtered parent-context handoff, and stronger direct-runner tests.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": []
+}

--- a/.trajectories/completed/2026-05/traj_bpncz0f6thfq.md
+++ b/.trajectories/completed/2026-05/traj_bpncz0f6thfq.md
@@ -1,0 +1,39 @@
+# Trajectory: sage-v2-nested-subagent-runner-pr-workflow
+
+> **Status:** ✅ Completed
+> **Task:** 59b00d0bb6faf24320a19d9e
+> **Confidence:** 90%
+> **Started:** May 7, 2026 at 01:30 PM
+> **Completed:** May 7, 2026 at 01:35 PM
+
+---
+
+## Summary
+
+Implemented the nested subagent runner slice with parent-scoped child-id derivation, filtered parent-context handoff, and stronger direct-runner tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation
+- **Chose:** Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation
+- **Reasoning:** The plan requires deterministic nested-turn construction, allowlist enforcement, parent-context filtering, and no changes to the registry contract or Sage-specific behavior.
+
+---
+
+## Chapters
+
+### 1. Planning
+*Agent: orchestrator*
+
+### 2. Execution: lead-self-reflection
+*Agent: lead-claude*
+
+### 3. Execution: implement-nested-runner
+*Agent: executor-codex*
+
+- Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation: Implement nested runner as a substrate-only adapter around createSubagentToolRegistry with per-parent child-id derivation and flat TaskToolResult translation
+- Nested runner now matches the substrate seam more literally: createHarness only receives filtered parent context, child ids are scoped per parent turn instead of globally, and direct-runner tests cover the hidden contract edges.

--- a/.trajectories/completed/2026-05/traj_fnw9bwg7gn4b.json
+++ b/.trajectories/completed/2026-05/traj_fnw9bwg7gn4b.json
@@ -1,0 +1,353 @@
+{
+  "id": "traj_fnw9bwg7gn4b",
+  "version": 1,
+  "task": {
+    "title": "sage-v2-substrate-extraction-pr-workflow",
+    "description": "Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "913fd02c040478350280bdc5"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-07T08:58:53.669Z",
+  "completedAt": "2026-05-07T09:38:55.620Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-05-07T08:58:53.669Z"
+    },
+    {
+      "name": "lead-claude",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T08:59:10.867Z"
+    },
+    {
+      "name": "executor-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T09:05:57.185Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ndvgzfr8l2l4",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T08:58:53.669Z",
+      "endedAt": "2026-05-07T08:59:10.868Z",
+      "events": [
+        {
+          "ts": 1778144333669,
+          "type": "note",
+          "content": "Purpose: Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR."
+        },
+        {
+          "ts": 1778144333669,
+          "type": "note",
+          "content": "Approach: 40-step dag workflow — Parsed 40 steps, 39 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_g8j2khk12d7y",
+      "title": "Execution: lead-architecture-contract",
+      "agentName": "lead-claude",
+      "startedAt": "2026-05-07T08:59:10.868Z",
+      "endedAt": "2026-05-07T09:03:36.093Z",
+      "events": [
+        {
+          "ts": 1778144350868,
+          "type": "note",
+          "content": "\"lead-architecture-contract\": Read tmp/sage-v2-substrate-workflow/source-context.md and write docs/architecture/sage-v2-substrate-implementation-plan.",
+          "raw": {
+            "agent": "lead-claude"
+          }
+        },
+        {
+          "ts": 1778144616043,
+          "type": "completion-marker",
+          "content": "\"lead-architecture-contract\" marker-based completion — Legacy STEP_COMPLETE marker observed (4 signal(s), 1 relevant channel post(s), 2 file change(s); signals=lead-architecture-contract, COMPLETE, docs/architecture/sage-v2-substrate-implementation-plan.md, COMPLETE; channel=**[lead-architecture-contract] Output:**\n```\nt\n         i  …           almost done thinking with high effort\n                        almost done thinking with h; files=modified:.relay/workspaces.json, created:docs/architecture/sage-v2-substrate-implementation-plan.md)",
+          "raw": {
+            "stepName": "lead-architecture-contract",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 2 file change(s)",
+              "signals": [
+                "lead-architecture-contract",
+                "COMPLETE",
+                "docs/architecture/sage-v2-substrate-implementation-plan.md",
+                "COMPLETE"
+              ],
+              "channelPosts": [
+                "**[lead-architecture-contract] Output:**\n```\nt\n         i  …           almost done thinking with high effort\n                        almost done thinking with h"
+              ],
+              "files": [
+                "modified:.relay/workspaces.json",
+                "created:docs/architecture/sage-v2-substrate-implementation-plan.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778144616044,
+          "type": "finding",
+          "content": "\"lead-architecture-contract\" completed → ✻ Cogitated for 3m 24s                                           \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_8ltqx594jlas",
+      "title": "Execution: lead-self-reflection",
+      "agentName": "lead-claude",
+      "startedAt": "2026-05-07T09:03:36.093Z",
+      "endedAt": "2026-05-07T09:05:57.188Z",
+      "events": [
+        {
+          "ts": 1778144616093,
+          "type": "note",
+          "content": "\"lead-self-reflection\": Write docs/architecture/sage-v2-substrate-lead-reflection.md",
+          "raw": {
+            "agent": "lead-claude"
+          }
+        },
+        {
+          "ts": 1778144757177,
+          "type": "completion-marker",
+          "content": "\"lead-self-reflection\" marker-based completion — Legacy STEP_COMPLETE marker observed (6 signal(s), 2 relevant channel post(s), 1 file change(s); signals=COMPLETE, Agent Relay collects anonymous usage data to improve the product.Run `agent-relay telemetry disable` to opt out.78>0q╭─── Claude Code v2.1.132 ─────────────────────────────────────────────────────╮, docs/architecture/sage-v2-substrate-lead-reflection.md, lead-self-reflection, COMPLETE, **[lead-self-reflection] Output:**; channel=[lead-self-reflection] Wrote docs/architecture/sage-v2-substrate-lead-reflection.md. Three sections: (1) leak risks — drill-or-stop tag enums, default normalize | **[lead-self-reflection] Output:**\n```\nith high effort\n                                 thinking more with high effort\n                                 thinking; files=created:docs/architecture/sage-v2-substrate-lead-reflection.md)",
+          "raw": {
+            "stepName": "lead-self-reflection",
+            "completionMode": "marker",
+            "reason": "Legacy STEP_COMPLETE marker observed",
+            "evidence": {
+              "summary": "6 signal(s), 2 relevant channel post(s), 1 file change(s)",
+              "signals": [
+                "COMPLETE",
+                "Agent Relay collects anonymous usage data to improve the product.Run `agent-relay telemetry disable` to opt out.78>0q╭─── Claude Code v2.1.132 ─────────────────────────────────────────────────────╮",
+                "docs/architecture/sage-v2-substrate-lead-reflection.md",
+                "lead-self-reflection",
+                "COMPLETE",
+                "**[lead-self-reflection] Output:**"
+              ],
+              "channelPosts": [
+                "[lead-self-reflection] Wrote docs/architecture/sage-v2-substrate-lead-reflection.md. Three sections: (1) leak risks — drill-or-stop tag enums, default normalize",
+                "**[lead-self-reflection] Output:**\n```\nith high effort\n                                 thinking more with high effort\n                                 thinking"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-substrate-lead-reflection.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778144757177,
+          "type": "finding",
+          "content": "\"lead-self-reflection\" completed → ✻ Brewed for 1m 47s                                            \r❯",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_c6r4bx8sicll",
+      "title": "Execution: implement-nested-subagent-runner",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:05:57.188Z",
+      "endedAt": "2026-05-07T09:15:56.154Z",
+      "events": [
+        {
+          "ts": 1778144757188,
+          "type": "note",
+          "content": "\"implement-nested-subagent-runner\": Implement the nested subagent runner slice from docs/architecture/sage-v2-substrate-implementation-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778145328741,
+          "type": "completion-evidence",
+          "content": "\"implement-nested-subagent-runner\" verification-based completion — Verification passed (3 signal(s), 6 file change(s), exit=0; signals=0, (node:50858) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0; files=modified:packages/harness/src/index.ts, created:packages/harness/src/nested-subagent-runner.test.ts, created:packages/harness/src/nested-subagent-runner.ts, modified:packages/harness/src/registries/index.ts, modified:packages/harness/src/subagent-registry.test.ts, modified:packages/harness/src/subagent-registry.ts; exit=0)",
+          "raw": {
+            "stepName": "implement-nested-subagent-runner",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "3 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:50858) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0"
+              ],
+              "files": [
+                "modified:packages/harness/src/index.ts",
+                "created:packages/harness/src/nested-subagent-runner.test.ts",
+                "created:packages/harness/src/nested-subagent-runner.ts",
+                "modified:packages/harness/src/registries/index.ts",
+                "modified:packages/harness/src/subagent-registry.test.ts",
+                "modified:packages/harness/src/subagent-registry.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778145328741,
+          "type": "finding",
+          "content": "\"implement-nested-subagent-runner\" completed → - `packages/harness/src/nested-subagent-runner.test.ts`",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_4yasmxjr1mcu",
+      "title": "Execution: fix-harness-after-nested-runner",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:15:56.154Z",
+      "endedAt": "2026-05-07T09:16:31.221Z",
+      "events": [
+        {
+          "ts": 1778145356154,
+          "type": "note",
+          "content": "\"fix-harness-after-nested-runner\": Harness test output after nested runner:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778145368968,
+          "type": "completion-evidence",
+          "content": "\"fix-harness-after-nested-runner\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), exit=0; signals=0, Result, (node:65875) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[fix-harness-after-nested-runner] Output:**; channel=**[fix-harness-after-nested-runner] Output:**\n```\nResult\n`EXIT: 0` was already achieved for the nested runner slice.\nActions taken\nNo code changes were made.\nNo; exit=0)",
+          "raw": {
+            "stepName": "fix-harness-after-nested-runner",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), exit=0",
+              "signals": [
+                "0",
+                "Result",
+                "(node:65875) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[fix-harness-after-nested-runner] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-harness-after-nested-runner] Output:**\n```\nResult\n`EXIT: 0` was already achieved for the nested runner slice.\nActions taken\nNo code changes were made.\nNo"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778145368968,
+          "type": "finding",
+          "content": "\"fix-harness-after-nested-runner\" completed → Result\n\n`EXIT: 0` was already achieved for the nested runner slice.\n\nActions taken\n\nNo code changes were made.\nNo tests ",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_10vgs3xwlagq",
+      "title": "Execution: implement-runtime-budget-policy",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:16:31.221Z",
+      "endedAt": "2026-05-07T09:38:27.278Z",
+      "events": [
+        {
+          "ts": 1778145391221,
+          "type": "note",
+          "content": "\"implement-runtime-budget-policy\": Implement the runtime budget policy slice from docs/architecture/sage-v2-substrate-implementation-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778146684303,
+          "type": "completion-evidence",
+          "content": "\"implement-runtime-budget-policy\" verification-based completion — Verification passed (4 signal(s), 6 file change(s), exit=0; signals=0, (node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, (node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0; files=modified:packages/harness/package.json, modified:packages/harness/src/harness.ts, modified:packages/harness/src/index.ts, created:packages/harness/src/runtime-policy.integration.test.ts, created:packages/harness/src/runtime-policy.test.ts, created:packages/harness/src/runtime-policy/index.ts; exit=0)",
+          "raw": {
+            "stepName": "implement-runtime-budget-policy",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "(node:68556) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0"
+              ],
+              "files": [
+                "modified:packages/harness/package.json",
+                "modified:packages/harness/src/harness.ts",
+                "modified:packages/harness/src/index.ts",
+                "created:packages/harness/src/runtime-policy.integration.test.ts",
+                "created:packages/harness/src/runtime-policy.test.ts",
+                "created:packages/harness/src/runtime-policy/index.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778146684303,
+          "type": "finding",
+          "content": "\"implement-runtime-budget-policy\" completed → - Exported harness runtime-policy public surface and subpath export",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_dau46qv2k35d",
+      "title": "Execution: fix-harness-after-runtime-policy",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T09:38:27.278Z",
+      "endedAt": "2026-05-07T09:38:55.620Z",
+      "events": [
+        {
+          "ts": 1778146707278,
+          "type": "note",
+          "content": "\"fix-harness-after-runtime-policy\": Harness test output after runtime policy:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778146735584,
+          "type": "reflection",
+          "content": "Validated the provided @agent-assistant/harness runtime-policy run. It exited 0 with all 43 test files and 416 tests passing, so no runtime-policy implementation or test changes were required.",
+          "raw": {
+            "focalPoints": [
+              "runtime-policy",
+              "harness",
+              "verification"
+            ],
+            "adjustments": "No code edits or reruns; preserve existing worktree state.",
+            "confidence": 0.99
+          },
+          "significance": "high",
+          "tags": [
+            "focal:runtime-policy",
+            "focal:harness",
+            "focal:verification",
+            "confidence:0.99"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Confirmed the supplied @agent-assistant/harness test run was already green after runtime policy changes (EXIT: 0; 43 files, 416 tests). Made no code changes and did not rerun tests per instruction.",
+    "approach": "Standard approach",
+    "confidence": 0.99
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": []
+}

--- a/.trajectories/completed/2026-05/traj_fnw9bwg7gn4b.md
+++ b/.trajectories/completed/2026-05/traj_fnw9bwg7gn4b.md
@@ -1,0 +1,42 @@
+# Trajectory: sage-v2-substrate-extraction-pr-workflow
+
+> **Status:** ✅ Completed
+> **Task:** 913fd02c040478350280bdc5
+> **Confidence:** 99%
+> **Started:** May 7, 2026 at 10:58 AM
+> **Completed:** May 7, 2026 at 11:38 AM
+
+---
+
+## Summary
+
+Confirmed the supplied @agent-assistant/harness test run was already green after runtime policy changes (EXIT: 0; 43 files, 416 tests). Made no code changes and did not rerun tests per instruction.
+
+**Approach:** Standard approach
+
+---
+
+## Chapters
+
+### 1. Planning
+*Agent: orchestrator*
+
+### 2. Execution: lead-architecture-contract
+*Agent: lead-claude*
+
+### 3. Execution: lead-self-reflection
+*Agent: lead-claude*
+
+### 4. Execution: implement-nested-subagent-runner
+*Agent: executor-codex*
+
+### 5. Execution: fix-harness-after-nested-runner
+*Agent: executor-codex*
+
+### 6. Execution: implement-runtime-budget-policy
+*Agent: executor-codex*
+
+### 7. Execution: fix-harness-after-runtime-policy
+*Agent: executor-codex*
+
+- Validated the provided @agent-assistant/harness runtime-policy run. It exited 0 with all 43 test files and 416 tests passing, so no runtime-policy implementation or test changes were required.

--- a/.trajectories/completed/2026-05/traj_ovjvqb1p5dbj.json
+++ b/.trajectories/completed/2026-05/traj_ovjvqb1p5dbj.json
@@ -1,0 +1,141 @@
+{
+  "id": "traj_ovjvqb1p5dbj",
+  "version": 1,
+  "task": {
+    "title": "sage-v2-nested-subagent-runner-pr-workflow",
+    "description": "First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "c06ac8614ca76fe2aeaa9acf"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-07T11:20:32.676Z",
+  "completedAt": "2026-05-07T11:25:34.967Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-05-07T11:20:32.677Z"
+    },
+    {
+      "name": "lead-claude",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:20:36.242Z"
+    },
+    {
+      "name": "executor-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:23:06.404Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_0xdvjd8njcvi",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T11:20:32.677Z",
+      "endedAt": "2026-05-07T11:20:36.244Z",
+      "events": [
+        {
+          "ts": 1778152832677,
+          "type": "note",
+          "content": "Purpose: First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR."
+        },
+        {
+          "ts": 1778152832677,
+          "type": "note",
+          "content": "Approach: 27-step dag workflow — Parsed 27 steps, 26 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_1mt5mcplbc3c",
+      "title": "Execution: lead-self-reflection",
+      "agentName": "lead-claude",
+      "startedAt": "2026-05-07T11:20:36.244Z",
+      "endedAt": "2026-05-07T11:23:06.405Z",
+      "events": [
+        {
+          "ts": 1778152836244,
+          "type": "note",
+          "content": "\"lead-self-reflection\": Write docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md",
+          "raw": {
+            "agent": "lead-claude"
+          }
+        },
+        {
+          "ts": 1778152986401,
+          "type": "completion-evidence",
+          "content": "\"lead-self-reflection\" verification-based completion — Verification passed (4 signal(s), 1 relevant channel post(s), 2 file change(s); signals=lead-self-reflection, COMPLETE, lead-self-reflection, docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md; channel=Wrote docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md.\n\nVerdict: plan is correctly scoped to PR 1 only — public API, file list, and gates al; files=modified:.relay/workspaces.json, created:docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md)",
+          "raw": {
+            "stepName": "lead-self-reflection",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 2 file change(s)",
+              "signals": [
+                "lead-self-reflection",
+                "COMPLETE",
+                "lead-self-reflection",
+                "docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md"
+              ],
+              "channelPosts": [
+                "Wrote docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md.\n\nVerdict: plan is correctly scoped to PR 1 only — public API, file list, and gates al"
+              ],
+              "files": [
+                "modified:.relay/workspaces.json",
+                "created:docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md"
+              ]
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778152986401,
+          "type": "finding",
+          "content": "\"lead-self-reflection\" completed → Actualizing…",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_6s0acmbt9xu6",
+      "title": "Execution: implement-nested-runner",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T11:23:06.405Z",
+      "endedAt": "2026-05-07T11:25:34.967Z",
+      "events": [
+        {
+          "ts": 1778152986406,
+          "type": "note",
+          "content": "\"implement-nested-runner\": Implement only the nested subagent runner slice using docs/architecture/sage-v2-nested-subagent-runner-plan.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778153095674,
+          "type": "decision",
+          "content": "Keep nested runner public exports to the documented helper surface: Keep nested runner public exports to the documented helper surface",
+          "raw": {
+            "question": "Keep nested runner public exports to the documented helper surface",
+            "chosen": "Keep nested runner public exports to the documented helper surface",
+            "alternatives": [],
+            "reasoning": "The PR plan limits root and /registries changes to createNestedSubagentRunner plus its three option/input types; exporting RunSubagentInput/RunSubagentResult would widen the public API without being required by the helper."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Validated the nested subagent runner slice and narrowed its public API to the documented helper surface; added registries subpath reachability coverage and confirmed targeted tests, typecheck, and build pass.",
+    "approach": "Standard approach",
+    "confidence": 0.91
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": []
+}

--- a/.trajectories/completed/2026-05/traj_ovjvqb1p5dbj.md
+++ b/.trajectories/completed/2026-05/traj_ovjvqb1p5dbj.md
@@ -1,0 +1,38 @@
+# Trajectory: sage-v2-nested-subagent-runner-pr-workflow
+
+> **Status:** ✅ Completed
+> **Task:** c06ac8614ca76fe2aeaa9acf
+> **Confidence:** 91%
+> **Started:** May 7, 2026 at 01:20 PM
+> **Completed:** May 7, 2026 at 01:25 PM
+
+---
+
+## Summary
+
+Validated the nested subagent runner slice and narrowed its public API to the documented helper surface; added registries subpath reachability coverage and confirmed targeted tests, typecheck, and build pass.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Keep nested runner public exports to the documented helper surface
+- **Chose:** Keep nested runner public exports to the documented helper surface
+- **Reasoning:** The PR plan limits root and /registries changes to createNestedSubagentRunner plus its three option/input types; exporting RunSubagentInput/RunSubagentResult would widen the public API without being required by the helper.
+
+---
+
+## Chapters
+
+### 1. Planning
+*Agent: orchestrator*
+
+### 2. Execution: lead-self-reflection
+*Agent: lead-claude*
+
+### 3. Execution: implement-nested-runner
+*Agent: executor-codex*
+
+- Keep nested runner public exports to the documented helper surface: Keep nested runner public exports to the documented helper surface

--- a/.trajectories/completed/2026-05/traj_pxqrlbn2o8yj.json
+++ b/.trajectories/completed/2026-05/traj_pxqrlbn2o8yj.json
@@ -1,0 +1,485 @@
+{
+  "id": "traj_pxqrlbn2o8yj",
+  "version": 1,
+  "task": {
+    "title": "sage-v2-nested-subagent-runner-pr-workflow",
+    "description": "First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR.",
+    "source": {
+      "system": "workflow-runner",
+      "id": "2edf2a0554df4031a019b4eb"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-07T11:47:30.556Z",
+  "completedAt": "2026-05-07T12:09:54.488Z",
+  "agents": [
+    {
+      "name": "orchestrator",
+      "role": "workflow-runner",
+      "joinedAt": "2026-05-07T11:47:30.557Z"
+    },
+    {
+      "name": "executor-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:47:36.734Z"
+    },
+    {
+      "name": "fresh-eyes-codex",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:50:16.264Z"
+    },
+    {
+      "name": "peer-review-claude",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T11:57:05.655Z"
+    },
+    {
+      "name": "validation-claude",
+      "role": "specialist",
+      "joinedAt": "2026-05-07T12:02:55.509Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_s5y7ay63vqbk",
+      "title": "Planning",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T11:47:30.557Z",
+      "endedAt": "2026-05-07T11:47:36.735Z",
+      "events": [
+        {
+          "ts": 1778154450557,
+          "type": "note",
+          "content": "Purpose: First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR."
+        },
+        {
+          "ts": 1778154450557,
+          "type": "note",
+          "content": "Approach: 27-step dag workflow — Parsed 27 steps, 26 dependent steps, DAG validated, no cycles"
+        }
+      ]
+    },
+    {
+      "id": "chap_h9j74ks4v86z",
+      "title": "Execution: fix-targeted-tests",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T11:47:36.735Z",
+      "endedAt": "2026-05-07T11:48:02.592Z",
+      "events": [
+        {
+          "ts": 1778154456735,
+          "type": "note",
+          "content": "\"fix-targeted-tests\": Targeted test/build evidence:",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778154479622,
+          "type": "completion-evidence",
+          "content": "\"fix-targeted-tests\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), exit=0; signals=0, Result, (node:98325) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, 0, **[fix-targeted-tests] Output:**; channel=**[fix-targeted-tests] Output:**\n```\nResult\nNo action taken. The provided evidence showed `TEST_EXIT=0` and `BUILD_EXIT=0`, so the nested-runner slice was left ; exit=0)",
+          "raw": {
+            "stepName": "fix-targeted-tests",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), exit=0",
+              "signals": [
+                "0",
+                "Result",
+                "(node:98325) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "0",
+                "**[fix-targeted-tests] Output:**"
+              ],
+              "channelPosts": [
+                "**[fix-targeted-tests] Output:**\n```\nResult\nNo action taken. The provided evidence showed `TEST_EXIT=0` and `BUILD_EXIT=0`, so the nested-runner slice was left "
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778154479622,
+          "type": "finding",
+          "content": "\"fix-targeted-tests\" completed → Result\n\nNo action taken. The provided evidence showed `TEST_EXIT=0` and `BUILD_EXIT=0`, so the nested-runner slice was l",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_k9gzzabe1h43",
+      "title": "Execution: executor-self-reflection",
+      "agentName": "executor-codex",
+      "startedAt": "2026-05-07T11:48:02.592Z",
+      "endedAt": "2026-05-07T11:50:16.267Z",
+      "events": [
+        {
+          "ts": 1778154482592,
+          "type": "note",
+          "content": "\"executor-self-reflection\": Write docs/architecture/sage-v2-nested-subagent-runner-executor-reflection.md",
+          "raw": {
+            "agent": "executor-codex"
+          }
+        },
+        {
+          "ts": 1778154616252,
+          "type": "completion-evidence",
+          "content": "\"executor-self-reflection\" verification-based completion — Verification passed (3 signal(s), 6 file change(s), exit=0; signals=0, (node:166) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, docs/architecture/sage-v2-nested-subagent-runner-executor-reflection.md; files=created:docs/architecture/sage-v2-nested-subagent-runner-executor-reflection.md, modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts, modified:packages/harness/dist/adapter/agent-relay-adapter.js, modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts, modified:packages/harness/dist/adapter/anthropic-model-adapter.js, modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts; exit=0)",
+          "raw": {
+            "stepName": "executor-self-reflection",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "3 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:166) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "docs/architecture/sage-v2-nested-subagent-runner-executor-reflection.md"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-executor-reflection.md",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.js",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.js",
+                "modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778154616252,
+          "type": "finding",
+          "content": "\"executor-self-reflection\" completed → EXECUTOR_SELF_REFLECTION_COMPLETE",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_4ur38jhg6zij",
+      "title": "Execution: fresh-eyes-review",
+      "agentName": "fresh-eyes-codex",
+      "startedAt": "2026-05-07T11:50:16.267Z",
+      "endedAt": "2026-05-07T11:53:54.995Z",
+      "events": [
+        {
+          "ts": 1778154616268,
+          "type": "note",
+          "content": "\"fresh-eyes-review\": Review only the nested-runner intended diff",
+          "raw": {
+            "agent": "fresh-eyes-codex"
+          }
+        },
+        {
+          "ts": 1778154833943,
+          "type": "completion-evidence",
+          "content": "\"fresh-eyes-review\" verification-based completion — Verification passed (5 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0; signals=0, # Sage v2 Nested Subagent Runner — Fresh Eyes Review, (node:4000) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-review.md, **[fresh-eyes-review] Output:**; channel=**[fresh-eyes-review] Output:**\n```\nath-exports.test.ts](/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/packages/harness/src/subpath-exports.test.ts:; files=created:docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-review.md, modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts, modified:packages/harness/dist/adapter/agent-relay-adapter.js, modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts, modified:packages/harness/dist/adapter/anthropic-model-adapter.js, modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts; exit=0)",
+          "raw": {
+            "stepName": "fresh-eyes-review",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "5 signal(s), 1 relevant channel post(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "# Sage v2 Nested Subagent Runner — Fresh Eyes Review",
+                "(node:4000) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-review.md",
+                "**[fresh-eyes-review] Output:**"
+              ],
+              "channelPosts": [
+                "**[fresh-eyes-review] Output:**\n```\nath-exports.test.ts](/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/packages/harness/src/subpath-exports.test.ts:"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-review.md",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.js",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.js",
+                "modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778154833943,
+          "type": "finding",
+          "content": "\"fresh-eyes-review\" completed → FRESH_EYES_REVIEW_COMPLETE",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_wgr9fw739wmq",
+      "title": "Execution: fresh-eyes-self-reflection",
+      "agentName": "fresh-eyes-codex",
+      "startedAt": "2026-05-07T11:53:54.995Z",
+      "endedAt": "2026-05-07T11:57:05.657Z",
+      "events": [
+        {
+          "ts": 1778154834996,
+          "type": "note",
+          "content": "\"fresh-eyes-self-reflection\": Write docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md",
+          "raw": {
+            "agent": "fresh-eyes-codex"
+          }
+        },
+        {
+          "ts": 1778155025649,
+          "type": "completion-evidence",
+          "content": "\"fresh-eyes-self-reflection\" verification-based completion — Verification passed (3 signal(s), 6 file change(s), exit=0; signals=0, (node:13730) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:, docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md; files=created:docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md, modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts, modified:packages/harness/dist/adapter/agent-relay-adapter.js, modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts, modified:packages/harness/dist/adapter/anthropic-model-adapter.js, modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts; exit=0)",
+          "raw": {
+            "stepName": "fresh-eyes-self-reflection",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "3 signal(s), 6 file change(s), exit=0",
+              "signals": [
+                "0",
+                "(node:13730) ExperimentalWarning: `--experimental-loader` may be removed in the future; instead use `register()`:",
+                "docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/agent-relay-adapter.js",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.d.ts",
+                "modified:packages/harness/dist/adapter/anthropic-model-adapter.js",
+                "modified:packages/harness/dist/adapter/built-in-harness-adapter.d.ts"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778155025649,
+          "type": "finding",
+          "content": "\"fresh-eyes-self-reflection\" completed → Wrote [docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md](/Users/khaliqgant/Projects/AgentWorkfo",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_zsebmodoehpo",
+      "title": "Execution: claude-peer-review",
+      "agentName": "peer-review-claude",
+      "startedAt": "2026-05-07T11:57:05.657Z",
+      "endedAt": "2026-05-07T12:00:49.400Z",
+      "events": [
+        {
+          "ts": 1778155025658,
+          "type": "note",
+          "content": "\"claude-peer-review\": Perform Claude peer review for this one nested-runner PR",
+          "raw": {
+            "agent": "peer-review-claude"
+          }
+        },
+        {
+          "ts": 1778155248335,
+          "type": "completion-evidence",
+          "content": "\"claude-peer-review\" verification-based completion — Verification passed (4 signal(s), 1 relevant channel post(s), 1 file change(s), exit=0; signals=0, The peer review document has been written to `docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md`., docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md, **[claude-peer-review] Output:**; channel=**[claude-peer-review] Output:**\n```\nThe peer review document has been written to `docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md`.\n**Ve; files=created:docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md; exit=0)",
+          "raw": {
+            "stepName": "claude-peer-review",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 1 file change(s), exit=0",
+              "signals": [
+                "0",
+                "The peer review document has been written to `docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md`.",
+                "docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md",
+                "**[claude-peer-review] Output:**"
+              ],
+              "channelPosts": [
+                "**[claude-peer-review] Output:**\n```\nThe peer review document has been written to `docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md`.\n**Ve"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778155248335,
+          "type": "finding",
+          "content": "\"claude-peer-review\" completed → The peer review document has been written to `docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md`.\n\n",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_7y0gtjk9uphg",
+      "title": "Execution: claude-peer-review-self-reflection",
+      "agentName": "peer-review-claude",
+      "startedAt": "2026-05-07T12:00:49.400Z",
+      "endedAt": "2026-05-07T12:02:55.515Z",
+      "events": [
+        {
+          "ts": 1778155249400,
+          "type": "note",
+          "content": "\"claude-peer-review-self-reflection\": Write docs/architecture/sage-v2-nested-subagent-runner-claude-reflection.md",
+          "raw": {
+            "agent": "peer-review-claude"
+          }
+        },
+        {
+          "ts": 1778155375505,
+          "type": "completion-evidence",
+          "content": "\"claude-peer-review-self-reflection\" verification-based completion — Verification passed (2 signal(s), 1 file change(s), exit=0; signals=0, docs/architecture/sage-v2-nested-subagent-runner-claude-reflection.md; files=created:docs/architecture/sage-v2-nested-subagent-runner-claude-reflection.md; exit=0)",
+          "raw": {
+            "stepName": "claude-peer-review-self-reflection",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "2 signal(s), 1 file change(s), exit=0",
+              "signals": [
+                "0",
+                "docs/architecture/sage-v2-nested-subagent-runner-claude-reflection.md"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-claude-reflection.md"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778155375505,
+          "type": "finding",
+          "content": "\"claude-peer-review-self-reflection\" completed → CLAUDE_PEER_REVIEW_SELF_REFLECTION_COMPLETE",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_31oxp71u3yxp",
+      "title": "Execution: claude-80-to-100-validation",
+      "agentName": "validation-claude",
+      "startedAt": "2026-05-07T12:02:55.515Z",
+      "endedAt": "2026-05-07T12:06:55.506Z",
+      "events": [
+        {
+          "ts": 1778155375515,
+          "type": "note",
+          "content": "\"claude-80-to-100-validation\": Apply the relay-80-100-workflow checklist to this nested-runner PR only",
+          "raw": {
+            "agent": "validation-claude"
+          }
+        },
+        {
+          "ts": 1778155612614,
+          "type": "completion-evidence",
+          "content": "\"claude-80-to-100-validation\" verification-based completion — Verification passed (4 signal(s), 1 relevant channel post(s), 1 file change(s), exit=0; signals=0, The validation document has been written to `docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md`., docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md, **[claude-80-to-100-validation] Output:**; channel=**[claude-80-to-100-validation] Output:**\n```\nThe validation document has been written to `docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation; files=created:docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md; exit=0)",
+          "raw": {
+            "stepName": "claude-80-to-100-validation",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "4 signal(s), 1 relevant channel post(s), 1 file change(s), exit=0",
+              "signals": [
+                "0",
+                "The validation document has been written to `docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md`.",
+                "docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md",
+                "**[claude-80-to-100-validation] Output:**"
+              ],
+              "channelPosts": [
+                "**[claude-80-to-100-validation] Output:**\n```\nThe validation document has been written to `docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778155612614,
+          "type": "finding",
+          "content": "\"claude-80-to-100-validation\" completed → CLAUDE_80_TO_100_VALIDATION_COMPLETE",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_nvwwn0fveoxh",
+      "title": "Execution: validation-self-reflection",
+      "agentName": "validation-claude",
+      "startedAt": "2026-05-07T12:06:55.506Z",
+      "endedAt": "2026-05-07T12:09:54.487Z",
+      "events": [
+        {
+          "ts": 1778155615506,
+          "type": "note",
+          "content": "\"validation-self-reflection\": Write docs/architecture/sage-v2-nested-subagent-runner-validation-reflection.md",
+          "raw": {
+            "agent": "validation-claude"
+          }
+        },
+        {
+          "ts": 1778155788729,
+          "type": "completion-evidence",
+          "content": "\"validation-self-reflection\" verification-based completion — Verification passed (2 signal(s), 1 file change(s), exit=0; signals=0, docs/architecture/sage-v2-nested-subagent-runner-validation-reflection.md; files=created:docs/architecture/sage-v2-nested-subagent-runner-validation-reflection.md; exit=0)",
+          "raw": {
+            "stepName": "validation-self-reflection",
+            "completionMode": "verification",
+            "reason": "Verification passed",
+            "evidence": {
+              "summary": "2 signal(s), 1 file change(s), exit=0",
+              "signals": [
+                "0",
+                "docs/architecture/sage-v2-nested-subagent-runner-validation-reflection.md"
+              ],
+              "files": [
+                "created:docs/architecture/sage-v2-nested-subagent-runner-validation-reflection.md"
+              ],
+              "exitCode": 0
+            }
+          },
+          "significance": "medium"
+        },
+        {
+          "ts": 1778155788729,
+          "type": "finding",
+          "content": "\"validation-self-reflection\" completed → VALIDATION_SELF_REFLECTION_COMPLETE",
+          "significance": "medium"
+        }
+      ]
+    },
+    {
+      "id": "chap_tzl7wg2jqi56",
+      "title": "Retrospective",
+      "agentName": "orchestrator",
+      "startedAt": "2026-05-07T12:09:54.487Z",
+      "endedAt": "2026-05-07T12:09:54.488Z",
+      "events": [
+        {
+          "ts": 1778155794488,
+          "type": "reflection",
+          "content": "All 27 steps completed in 22min. (completed in 22 minutes)",
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "All 27 steps completed in 22min.",
+    "approach": "dag workflow (4 agents)",
+    "challenges": [],
+    "learnings": [],
+    "confidence": 0.8518518518518519
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant",
+  "tags": []
+}

--- a/.trajectories/completed/2026-05/traj_pxqrlbn2o8yj.md
+++ b/.trajectories/completed/2026-05/traj_pxqrlbn2o8yj.md
@@ -1,0 +1,51 @@
+# Trajectory: sage-v2-nested-subagent-runner-pr-workflow
+
+> **Status:** ✅ Completed
+> **Task:** 2edf2a0554df4031a019b4eb
+> **Confidence:** 85%
+> **Started:** May 7, 2026 at 01:47 PM
+> **Completed:** May 7, 2026 at 02:09 PM
+
+---
+
+## Summary
+
+All 27 steps completed in 22min.
+
+**Approach:** dag workflow (4 agents)
+
+---
+
+## Chapters
+
+### 1. Planning
+*Agent: orchestrator*
+
+### 2. Execution: fix-targeted-tests
+*Agent: executor-codex*
+
+### 3. Execution: executor-self-reflection
+*Agent: executor-codex*
+
+### 4. Execution: fresh-eyes-review
+*Agent: fresh-eyes-codex*
+
+### 5. Execution: fresh-eyes-self-reflection
+*Agent: fresh-eyes-codex*
+
+### 6. Execution: claude-peer-review
+*Agent: peer-review-claude*
+
+### 7. Execution: claude-peer-review-self-reflection
+*Agent: peer-review-claude*
+
+### 8. Execution: claude-80-to-100-validation
+*Agent: validation-claude*
+
+### 9. Execution: validation-self-reflection
+*Agent: validation-claude*
+
+### 10. Retrospective
+*Agent: orchestrator*
+
+- All 27 steps completed in 22min. (completed in 22 minutes)

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-05T08:18:45.222Z",
+  "lastUpdated": "2026-05-07T12:49:17.219Z",
   "trajectories": {
     "traj_1775887868833_95cb9380": {
       "title": "relay-agent-assistant-connectivity-spike-workflow",
@@ -381,6 +381,50 @@
       "startedAt": "2026-05-05T08:15:38.732Z",
       "completedAt": "2026-05-05T08:18:45.059Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/completed/2026-05/traj_60oxhp8avjun.json"
+    },
+    "traj_vpj3qy73dw45": {
+      "title": "sage-v2-substrate-extraction-pr-workflow",
+      "status": "active",
+      "startedAt": "2026-05-07T08:56:54.493Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/active/traj_vpj3qy73dw45.json"
+    },
+    "traj_fnw9bwg7gn4b": {
+      "title": "sage-v2-substrate-extraction-pr-workflow",
+      "status": "active",
+      "startedAt": "2026-05-07T08:58:53.669Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/active/traj_fnw9bwg7gn4b.json"
+    },
+    "traj_bl065l0xwwoa": {
+      "title": "sage-v2-substrate-extraction-pr-workflow",
+      "status": "completed",
+      "startedAt": "2026-05-07T10:09:14.212Z",
+      "completedAt": "2026-05-07T11:56:49.669Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/completed/2026-05/traj_bl065l0xwwoa.json"
+    },
+    "traj_u8upajzok6vd": {
+      "title": "sage-v2-nested-subagent-runner-pr-workflow",
+      "status": "active",
+      "startedAt": "2026-05-07T11:09:32.508Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/active/traj_u8upajzok6vd.json"
+    },
+    "traj_ovjvqb1p5dbj": {
+      "title": "sage-v2-nested-subagent-runner-pr-workflow",
+      "status": "active",
+      "startedAt": "2026-05-07T11:20:32.676Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/active/traj_ovjvqb1p5dbj.json"
+    },
+    "traj_bpncz0f6thfq": {
+      "title": "sage-v2-nested-subagent-runner-pr-workflow",
+      "status": "active",
+      "startedAt": "2026-05-07T11:30:22.555Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/active/traj_bpncz0f6thfq.json"
+    },
+    "traj_pxqrlbn2o8yj": {
+      "title": "sage-v2-nested-subagent-runner-pr-workflow",
+      "status": "completed",
+      "startedAt": "2026-05-07T11:47:30.556Z",
+      "completedAt": "2026-05-07T12:09:54.488Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/agent-assistant/.trajectories/completed/2026-05/traj_pxqrlbn2o8yj.json"
     }
   }
 }

--- a/docs/architecture/sage-v2-substrate-executor-reflection.md
+++ b/docs/architecture/sage-v2-substrate-executor-reflection.md
@@ -1,0 +1,481 @@
+# Sage v2 Substrate Executor Self-Reflection
+
+Date: 2026-05-07
+
+Audience: workflow owner, lead reviewer, and future agents picking up the Sage
+v2 substrate extraction.
+
+This document reflects on the implementation I landed in Agent Assistant for
+the Sage v2 substrate extraction. It is intentionally about substrate only. I
+am excluding workflow artifacts such as `.trajectories/*`, `.ricky/`, and
+`tmp/`, because they are execution traces rather than reusable runtime code.
+
+## Verification Summary
+
+I verified the implementation with targeted workspace tests and builds:
+
+- `npm test -w @agent-assistant/harness` -> 43 files, 416 tests passed
+- `npm test -w @agent-assistant/telemetry` -> 12 files, 47 tests passed
+- `npm test -w @agent-assistant/turn-context` -> 3 files, 9 tests passed
+- `npm test -w @agent-assistant/vfs` -> 6 files, 44 tests passed
+- `npm run build -w @agent-assistant/harness` -> passed
+- `npm run build -w @agent-assistant/telemetry` -> passed
+- `npm run build -w @agent-assistant/turn-context` -> passed
+- `npm run build -w @agent-assistant/vfs` -> passed
+
+## Exact Files Changed By Slice
+
+### Slice 1: Nested subagent runner substrate
+
+Production files:
+
+- `packages/harness/src/nested-subagent-runner.ts`
+- `packages/harness/src/subagent-registry.ts`
+- `packages/harness/src/registries/index.ts`
+
+Package/export wiring:
+
+- `packages/harness/src/index.ts`
+
+Tests:
+
+- `packages/harness/src/nested-subagent-runner.test.ts`
+- `packages/harness/src/subagent-registry.test.ts`
+
+### Slice 2: Runtime budget policy primitives
+
+Production files:
+
+- `packages/harness/src/runtime-policy/index.ts`
+- `packages/harness/src/harness.ts`
+- `packages/harness/src/types.ts`
+
+Package/export wiring:
+
+- `packages/harness/package.json`
+- `packages/harness/src/index.ts`
+
+Tests:
+
+- `packages/harness/src/runtime-policy.test.ts`
+- `packages/harness/src/runtime-policy.integration.test.ts`
+- `packages/harness/src/subpath-exports.test.ts`
+
+### Slice 3: Subagent and runtime-policy telemetry vocabulary
+
+Production files:
+
+- `packages/telemetry/src/events.ts`
+- `packages/telemetry/src/harness-bridge.ts`
+- `packages/telemetry/src/sinks/console.ts`
+- `packages/telemetry/src/sinks/types.ts`
+
+Package/export wiring:
+
+- `packages/telemetry/package.json`
+- `packages/telemetry/src/index.ts`
+
+Tests:
+
+- `packages/telemetry/test/harness-bridge.test.ts`
+- `packages/telemetry/test/private_content_never_leaks.test.ts`
+- `packages/telemetry/test/runtime-policy-events.test.ts`
+- `packages/telemetry/test/subagent-events.test.ts`
+
+### Slice 4: Eval substrate
+
+Production files:
+
+- `packages/telemetry/src/evals/eval-checks.ts`
+- `packages/telemetry/src/evals/eval-runner.ts`
+- `packages/telemetry/src/evals/index.ts`
+- `packages/telemetry/src/evals/pr-comment-format.ts`
+
+Package/export wiring:
+
+- `packages/telemetry/package.json`
+- `packages/telemetry/src/index.ts`
+
+Tests:
+
+- `packages/telemetry/test/eval-runner.test.ts`
+- `packages/telemetry/test/pr-comment-format.test.ts`
+
+### Slice 5: Insight envelope and reader helpers
+
+Production files in `@agent-assistant/vfs`:
+
+- `packages/vfs/src/insight/envelope.ts`
+- `packages/vfs/src/insight/index.ts`
+- `packages/vfs/src/insight/reader.ts`
+- `packages/vfs/src/index.ts`
+
+Production files in `@agent-assistant/turn-context`:
+
+- `packages/turn-context/src/insight-projection.ts`
+- `packages/turn-context/src/projection.ts`
+- `packages/turn-context/src/types.ts`
+- `packages/turn-context/src/index.ts`
+- `packages/turn-context/src/vfs-insight-types.d.ts`
+
+Package wiring:
+
+- `packages/turn-context/package.json`
+
+Tests:
+
+- `packages/vfs/src/insight/reader.test.ts`
+- `packages/turn-context/src/insight-projection.test.ts`
+
+### Shared support changes around the slice rollout
+
+These were not substrate primitives themselves, but they were part of the
+extraction delivery:
+
+- `package-lock.json`
+- `workflows/generated/sage-v2-substrate-extraction-pr.ts`
+- `workflows/lib/agent-assistant-repo-setup.ts`
+- `docs/architecture/sage-v2-substrate-implementation-plan.md`
+- `docs/architecture/sage-v2-substrate-lead-reflection.md`
+
+## Tests Added Or Updated
+
+### Added
+
+- `packages/harness/src/nested-subagent-runner.test.ts`
+- `packages/harness/src/runtime-policy.test.ts`
+- `packages/harness/src/runtime-policy.integration.test.ts`
+- `packages/telemetry/test/eval-runner.test.ts`
+- `packages/telemetry/test/pr-comment-format.test.ts`
+- `packages/telemetry/test/private_content_never_leaks.test.ts`
+- `packages/telemetry/test/runtime-policy-events.test.ts`
+- `packages/telemetry/test/subagent-events.test.ts`
+- `packages/turn-context/src/insight-projection.test.ts`
+- `packages/vfs/src/insight/reader.test.ts`
+
+### Updated
+
+- `packages/harness/src/subagent-registry.test.ts`
+- `packages/harness/src/subpath-exports.test.ts`
+- `packages/telemetry/test/harness-bridge.test.ts`
+
+## Acceptance Coverage
+
+### PR 1: Nested subagent runner helper
+
+Acceptance item: a product can create a `task` tool with
+`createSubagentToolRegistry` and a first-party nested runner helper.
+
+Coverage:
+
+- `packages/harness/src/nested-subagent-runner.ts` provides
+  `createNestedSubagentRunner`.
+- `packages/harness/src/registries/index.ts` and `packages/harness/src/index.ts`
+  export it as first-party API.
+- `packages/harness/src/nested-subagent-runner.test.ts` covers the happy-path
+  registry integration in `success_returns_flat_result`.
+
+Acceptance item: the nested runner starts a fresh harness turn with filtered
+parent context.
+
+Coverage:
+
+- `createNestedSubagentRunner` calls `filterParentContextForSubagent` before
+  creating the child harness.
+- `nested-subagent-runner.test.ts` verifies filtered context in
+  `success_returns_flat_result` and `parent_context_is_filtered`.
+
+Acceptance item: the subagent sees only its allowlisted tools.
+
+Coverage:
+
+- The runner passes `allowedToolNames` into the child `HarnessTurnInput`.
+- `tool_allowlist_enforced` proves the child harness only receives
+  `memory_recall`.
+
+Acceptance item: parent cancellation cancels nested turns.
+
+Coverage:
+
+- The runner forwards `signal` to child harness construction and execution.
+- `parent_cancellation_propagates` verifies the nested run resolves as
+  cancelled when the parent aborts.
+
+Acceptance item: tests prove success, unknown subagent, subagent failure,
+max-iteration failure, and parallel task batches.
+
+Coverage:
+
+- `success_returns_flat_result`
+- `unknown_subagent_returns_ok_false`
+- `subagent_failure_is_isolated`
+- `max_iterations_failure`
+- `parallel_task_batch`
+
+I also added a Workers-specific construction guard test and an explicit
+allowlist enforcement test, both of which were useful extra coverage beyond the
+acceptance list.
+
+### PR 2: Runtime budget policy
+
+Acceptance item: duplicate tool calls can return cached turn-scoped results.
+
+Coverage:
+
+- `packages/harness/src/runtime-policy/index.ts` implements turn-local stable
+  cache keys and cloned cached results.
+- `runtime-policy.test.ts` covers cache behavior directly.
+- `runtime-policy.integration.test.ts` proves cache hits avoid extra upstream
+  tool execution and logical budget burn.
+
+Acceptance item: todo rewrites can be capped.
+
+Coverage:
+
+- `todoRewriteCap` is implemented in `runtime-policy/index.ts`.
+- `runtime-policy.integration.test.ts` verifies only two writes execute while
+  the turn still reaches final synthesis.
+
+Acceptance item: reserve-floor policy can stop broad tool calls while allowing
+synthesis.
+
+Coverage:
+
+- `reserveFloor` is implemented in `runtime-policy/index.ts`.
+- `runtime-policy.integration.test.ts` verifies broad enumeration stops at the
+  floor and the harness emits salvaged synthesis.
+
+Acceptance item: drill-or-stop policy can reject repeated broad listing after
+candidate results.
+
+Coverage:
+
+- Candidate extraction and drilldown detection live in
+  `runtime-policy/index.ts`.
+- `runtime-policy.test.ts` covers the primitive directly.
+- `runtime-policy.integration.test.ts` verifies a second broad list is blocked
+  until the model drills into `package.json`.
+
+Acceptance item: output sanitizer removes raw pseudo-tool XML from final text.
+
+Coverage:
+
+- `sanitizePseudoToolBlocks` and the final-output sanitizer live in
+  `runtime-policy/index.ts`.
+- `runtime-policy.test.ts` covers nested pseudo-tool markup and fenced payloads.
+- `runtime-policy.integration.test.ts` proves the final assistant text is
+  rewritten before result publication.
+
+Acceptance item: every policy intervention emits a structured trace or
+telemetry event.
+
+Coverage:
+
+- `packages/harness/src/types.ts` adds runtime policy trace-event shapes.
+- `packages/harness/src/harness.ts` emits policy events during tool execution
+  and final synthesis salvage.
+- `runtime-policy.integration.test.ts` asserts those trace emissions.
+- Slice 3 then bridges those trace events into typed telemetry payloads.
+
+### PR 3: Telemetry event vocabulary
+
+Acceptance item: typed event constructors exist for subagent lifecycle and
+runtime-policy events.
+
+Coverage:
+
+- `packages/telemetry/src/events.ts` implements constructors for
+  `subagent.started`, `subagent.finished`, `subagent.failed`,
+  `subagent.batch.started`, `runtime_policy.blocked`,
+  `runtime_policy.cache_hit`, `runtime_policy.output_sanitized`, and
+  `synthesis.salvaged`.
+- `runtime-policy-events.test.ts` and `subagent-events.test.ts` assert stable,
+  frozen payloads.
+
+Acceptance item: harness bridge can include policy/subagent metadata without
+logging raw private content.
+
+Coverage:
+
+- `packages/telemetry/src/harness-bridge.ts` maps subagent trace metadata and
+  runtime-policy trace events into privacy-safe telemetry.
+- `harness-bridge.test.ts` covers subagent lifecycle mapping and policy-event
+  bridging.
+- `private_content_never_leaks.test.ts` verifies forbidden metadata keys are
+  rejected or stripped rather than serialized.
+
+Acceptance item: memory and console sinks can receive the new events.
+
+Coverage:
+
+- `packages/telemetry/src/sinks/types.ts` widens the sink contract to the new
+  event union.
+- `packages/telemetry/src/sinks/console.ts` treats non-`turn.finished` events
+  as first-class payloads instead of special-casing them away.
+- `runtime-policy-events.test.ts` proves the in-memory sink round-trips the new
+  event kinds.
+
+This is covered functionally for the generic sink contract, although I did not
+add a console-specific regression that snapshots a new runtime-policy or
+subagent event line.
+
+Acceptance item: tests assert event shape stability.
+
+Coverage:
+
+- `runtime-policy-events.test.ts`
+- `subagent-events.test.ts`
+- `harness-bridge.test.ts`
+- `private_content_never_leaks.test.ts`
+
+### PR 4: Eval runner substrate
+
+Acceptance item: a local fixture runner can execute assistant turn cases with
+mocked providers.
+
+Coverage:
+
+- `packages/telemetry/src/evals/eval-runner.ts` defines the runner contract and
+  suite execution.
+- `eval-runner.test.ts` uses a synthetic runner backed by fixture data rather
+  than real providers.
+
+Acceptance item: result JSON includes pass/fail, score components, required
+evidence checks, forbidden behavior checks, cost, latency, and tool-call
+counts.
+
+Coverage:
+
+- `EvalResult` in `eval-runner.ts` includes all of those fields.
+- `eval-checks.ts` implements required-evidence, forbidden-fanout, budget, and
+  final-output-clean checks.
+- `eval-runner.test.ts` asserts success, evidence failure, fanout failure,
+  budget failure, dirty-output failure, and deterministic ordering.
+
+Acceptance item: the runner can produce a compact PR-comment summary.
+
+Coverage:
+
+- `packages/telemetry/src/evals/pr-comment-format.ts` formats summary output.
+- `pr-comment-format.test.ts` asserts the summary stays under the size cap,
+  uses compact failure details, and orders failures before passes.
+
+The eval substrate is intentionally generic. It does not encode Sage fixtures,
+Sage scoring thresholds, or Sage workspace evidence paths.
+
+### PR 5: Insight envelope and reader helpers
+
+Acceptance item: `InsightEnvelope` parses valid and partial artifacts.
+
+Coverage:
+
+- `packages/vfs/src/insight/envelope.ts` defines the substrate envelope shape.
+- `packages/vfs/src/insight/reader.ts` handles valid, missing, malformed, and
+  unsupported-schema cases, including partial-field salvage from malformed
+  JSON.
+- `reader.test.ts` covers each of those paths.
+
+Acceptance item: reader helpers preserve `generatedAt`, `sourceProvider`, and
+`sourcePaths`.
+
+Coverage:
+
+- `reader.test.ts` verifies those fields survive parsing.
+- `packages/turn-context/src/insight-projection.ts` preserves them when
+  converting the envelope into a prepared context block.
+- `insight-projection.test.ts` verifies provenance metadata and freshness are
+  retained.
+
+Acceptance item: turn-context can accept selected insights as prepared context
+blocks with provenance.
+
+Coverage:
+
+- `projectInsightAsContextBlock` returns a `TurnPreparedContextBlock` with
+  provenance in `metadata`.
+- `packages/turn-context/src/projection.ts` now preserves block metadata when
+  projecting to the canonical execution-request shape.
+- `packages/turn-context/src/types.ts` now allows prepared-context block
+  metadata.
+
+Acceptance item: tests prove malformed insight JSON fails gracefully.
+
+Coverage:
+
+- `reader.test.ts` includes malformed JSON and partial-artifact cases that
+  return structured failure instead of throwing.
+
+## Cloudflare Workers Fetch Compatibility Evidence
+
+The short version is that this implementation did not introduce new HTTP call
+sites in the Sage v2 substrate slices, and I still added explicit protection
+against accidental bare-fetch capture.
+
+Evidence:
+
+1. The new slice implementation files do not contain production `fetch`
+   references. A targeted `rg` across the changed slice files only surfaced
+   fetch mentions in tests:
+   `packages/harness/src/nested-subagent-runner.test.ts` and
+   `packages/harness/src/runtime-policy.test.ts`.
+2. `packages/harness/src/nested-subagent-runner.test.ts` includes
+   `workers_fetch_compatibility`, which replaces `globalThis.fetch` with a
+   throwing getter and proves `createNestedSubagentRunner` does not read fetch
+   at construction time.
+3. `packages/harness/src/runtime-policy.test.ts` includes
+   `does not capture bare fetch in runtime-policy modules`, which scans the
+   runtime-policy source and rejects `= fetch` and `?? fetch` patterns.
+4. The pre-existing harness Workers regression suite also stayed green inside
+   the full harness run, including
+   `packages/harness/src/adapter/openrouter-model-adapter.workers-fetch.test.ts`
+   and the direct-provider streaming Workers-fetch tests.
+5. The repo rule in `.claude/rules/workers-fetch.md` remained satisfied: when a
+   fetch override is needed elsewhere in the repo, the existing approved
+   pattern is the call-time lambda
+   `((input, init) => globalThis.fetch(input, init))`, not a stored bare
+   reference.
+
+Because the substrate slices themselves are fetch-free, the compatibility
+evidence here is mainly negative proof plus regression coverage, not a new HTTP
+path-specific swap test.
+
+## Residual Risks And Deferred Sage-Owned Behavior
+
+### Residual substrate risks
+
+- `subagent.batch.started` exists as typed telemetry vocabulary, but it is not
+  yet emitted automatically by the harness or the telemetry bridge. The
+  constructor and sink support are in place; the trace source is not.
+- Console-sink compatibility for new event kinds is implemented generically,
+  but I did not add a console-specific assertion that snapshots emitted
+  subagent/runtime-policy log lines.
+- The eval substrate is fixture-oriented, not a full end-to-end harness runner
+  that boots real model adapters, tool registries, or workspace fixtures.
+- Insight parsing is schema-tolerant and provenance-preserving, but it does not
+  decide relevance ranking, stale-data wording, or insight selection policy.
+
+### Deliberately deferred Sage-owned behavior
+
+- No Sage subagent roster, prompts, tone, or delegation heuristics were moved
+  into `@agent-assistant/*`.
+- No Sage-specific runtime categories such as a baked-in definition of
+  "broad", "planner", or "competitor research" were added. Consumers must
+  supply tool names, categories, candidate extraction, and guard logic.
+- No Sage workspace fixtures, eval thresholds, or expected evidence paths were
+  added to the eval substrate.
+- No Sage-specific insight selection or fallback ordering was added to
+  `@agent-assistant/vfs` or `@agent-assistant/turn-context`.
+- No `SAGE_*` flags or downstream workflow semantics were introduced into the
+  substrate packages.
+
+## Summary
+
+I completed all five extraction slices as reusable Agent Assistant substrate,
+kept the product boundary intact, and verified the result with passing tests and
+builds across `harness`, `telemetry`, `turn-context`, and `vfs`.
+
+Artifacts produced:
+
+- `docs/architecture/sage-v2-substrate-executor-reflection.md`
+
+EXECUTOR_SELF_REFLECTION_COMPLETE

--- a/docs/architecture/sage-v2-substrate-fresh-eyes-review.md
+++ b/docs/architecture/sage-v2-substrate-fresh-eyes-review.md
@@ -1,0 +1,24 @@
+FAIL
+
+## Findings
+
+1. `workflows/generated/sage-v2-substrate-extraction-pr.ts:25-27`, `workflows/generated/sage-v2-substrate-extraction-pr.ts:295-379`, and `workflows/generated/sage-v2-substrate-extraction-pr.ts:601-648` collapse the extraction into one implementation PR, but `docs/architecture/sage-v2-substrate-extraction-map.md:184-250` explicitly defines a follow-up PR series with separate slices for nested runner, runtime policy, telemetry, evals, and insight contracts. That is workflow scope creep, not just presentation drift. It removes the documented slice boundaries, forces a single commit/PR across multiple packages, and makes it impossible to land or revert substrate pieces independently if one later slice fails review or validation.
+
+2. `workflows/generated/sage-v2-substrate-extraction-pr.ts:303`, `workflows/generated/sage-v2-substrate-extraction-pr.ts:317`, `workflows/generated/sage-v2-substrate-extraction-pr.ts:326-375`, and `workflows/generated/sage-v2-substrate-extraction-pr.ts:543` allow the plan to choose a new `@agent-assistant/evals` package, but the deterministic targeted-test loop never runs that package's tests or captures an `EVALS_EXIT`. The workflow only spot-checks for eval-related source text, then jumps to workspace-wide tests. That weakens the promised slice-by-slice fix-rerun gate for the eval substrate and makes failures harder to localize.
+
+## Notes
+
+- I did not find any Cloudflare Workers bare-`fetch` violations in the reviewed diff. The diff adds docs plus a generated workflow artifact; it does not add new `fetch()` call sites in shared packages.
+- I did not find a public API breakage in the reviewed diff itself. The blocking issues are workflow-shape and validation-coverage problems.
+- `docs/index.md` is a straightforward index update and is not part of the failure.
+
+## Verdict
+
+The extraction map is directionally sound, but the generated implementation workflow does not honor that map's own scope contract. Before this is mergeable, the workflow should either:
+
+1. be split so each substrate slice lands as its own PR/workflow stage boundary, matching the documented PR series, or
+2. the extraction map should be intentionally revised to justify a single bundled PR and the workflow should still add targeted eval-package test execution when `packages/evals` is chosen.
+
+Reviewed `git diff origin/main...HEAD` and wrote this verdict to `docs/architecture/sage-v2-substrate-fresh-eyes-review.md`.
+
+FRESH_EYES_REVIEW_COMPLETE

--- a/docs/architecture/sage-v2-substrate-implementation-plan.md
+++ b/docs/architecture/sage-v2-substrate-implementation-plan.md
@@ -1,0 +1,583 @@
+# Sage v2 Substrate Implementation Plan
+
+Date: 2026-05-07
+
+Status: IMPLEMENTATION_READY. This is an Agent Assistant implementation contract,
+not a Sage product roadmap.
+
+Source: `tmp/sage-v2-substrate-workflow/source-context.md`, plus the published
+`docs/architecture/sage-v2-substrate-extraction-map.md`.
+
+## Scope And Ownership Boundary
+
+This plan describes only the substrate work that lands in this repo. Anything
+that encodes Sage product behavior is **out of scope** for Agent Assistant and
+remains in the Sage repo.
+
+### Out of scope (stays in Sage)
+
+The following must not appear in any package under `packages/` in this repo, in
+any prompt fragment, in any default registry, or in any test fixture that ships
+as a public export:
+
+- Sage product prompts, tone, capability matrix language, delegation
+  heuristics, and `slack-runner` clauses.
+- The Sage specialist roster: `slack-researcher`, `competitor-researcher`,
+  `github-investigator`, `linear-investigator`, `planner`, `doc-drafter`,
+  `notion-librarian`, `notion-page-writer`, `web-researcher`,
+  `repo-sandbox-researcher`, `qa-verifier`.
+- Slack channel semantics (`#competitors`, `#general`), Notion page/database
+  semantics (`notion_create_page`, page block rendering), GitHub/Linear
+  product workflows.
+- `SAGE_HARNESS_SUBAGENTS_ENABLED` and any other `SAGE_*` flag.
+- Sage open-issue numbers (#107, #172, #180, #189, #203, …) as identifiers in
+  shared code, fixtures, or tests. They may appear only as motivation in this
+  doc and PR descriptions.
+- Sage workspace fixtures, scoring rubrics, or expected evidence paths.
+
+### In scope (Agent Assistant deliverables)
+
+Five vertical slices, each shipped as its own PR:
+
+1. Nested subagent runner helper (`@agent-assistant/harness`).
+2. Runtime budget policy primitives (`@agent-assistant/harness`).
+3. Telemetry event vocabulary for subagents and runtime policy
+   (`@agent-assistant/telemetry`).
+4. Eval substrate for assistant turns (new `@agent-assistant/evals` or scoped
+   module under telemetry — choice deferred to PR 4).
+5. Insight envelope and reader helpers (`@agent-assistant/vfs` +
+   `@agent-assistant/turn-context`).
+
+A sixth follow-up (Sage re-adoption) lives in the Sage repo and is tracked here
+only as a downstream consumer constraint.
+
+## Cross-Cutting Constraints
+
+These apply to every slice below.
+
+### Cloudflare Workers fetch compatibility
+
+Workers rebinds `fetch` per request. Modules that capture `fetch` at import
+time crash in Workers. Therefore:
+
+- **No bare `fetch` storage.** Do not write `const fetchImpl = fetch` or
+  `import { fetch } from ...` at module top level. Do not pass `fetch` into a
+  constructor and store it on `this`.
+- **Call `globalThis.fetch` at invocation time.** Every HTTP boundary must
+  resolve `globalThis.fetch` inside the function body of the call. The pattern
+  already exists in `packages/harness/src/adapter/openrouter-model-adapter.ts`
+  and the direct-provider adapters; new code must match.
+- **Inject through a lambda when overrides are needed.** Tests and adapters
+  pass `fetch?: typeof globalThis.fetch` as an option and call
+  `(options.fetch ?? globalThis.fetch)(url, init)` at call time, never
+  earlier.
+- **Test coverage.** Every PR that touches an HTTP path must add or extend a
+  Workers-fetch test that swaps `globalThis.fetch` after module load and
+  asserts the swapped impl is used. Mirror
+  `packages/harness/src/adapter/openrouter-model-adapter.workers-fetch.test.ts`.
+
+### Substrate vs product discipline
+
+Reviewers must reject any PR whose diff:
+
+- Imports a Sage-named symbol into an `@agent-assistant/*` package.
+- Adds a default tool roster, default subagent list, or default prompt
+  clause that names a provider product behavior.
+- Couples a primitive to a single product's flag, env var, or ID space.
+
+### Lead/execute/review flow
+
+Every slice follows the same agent flow:
+
+- **Claude leads.** Claude owns the architecture contract for the slice,
+  writes this plan section, defines the public type surface, and signs off
+  on 80-to-100 before PR publication.
+- **Codex executes.** Codex writes the production code, the unit tests, and
+  the test-fix-rerun loop. Codex must self-reflect at end of each step
+  (what was done, what was skipped, what is uncertain) before handing back.
+- **Every agent self-reflects.** Each agent ends its turn with a short
+  "what I did / what I am unsure about / what I left for the next step"
+  note posted to the workflow channel. No silent handoffs.
+- **Codex fresh-eyes review.** A second Codex agent (no prior turn context)
+  reads the diff against this plan and posts a fresh-eyes review:
+  contract-fit, dead code, missed Workers-fetch sites, missing tests.
+- **Claude peer review.** Claude reads the diff, the fresh-eyes review,
+  and the test output, and either accepts, requests changes, or escalates
+  to the owner.
+- **Claude signs off on 80-to-100.** Before PR publication, Claude verifies
+  the 80-to-100 contract below has been satisfied and posts the sign-off
+  decision. No PR is published without this.
+
+## Slice 1 — Nested Subagent Runner Helper
+
+### Deliverable
+
+A first-party helper in `@agent-assistant/harness` that constructs a
+`runSubagent` implementation for `createSubagentToolRegistry`. The helper runs
+an isolated nested harness turn, preserves parent trace ids, applies the
+subagent tool allowlist, and returns a flat `TaskToolResult`-compatible
+result. The helper does not own selection, prompts, or roster.
+
+### Public API contract
+
+```ts
+// packages/harness/src/nested-subagent-runner.ts
+
+export interface CreateNestedHarnessInput {
+  subagent: HarnessSubagent;
+  parentContext: HarnessTurnContext;
+  parentTraceId: string;
+  filteredParentContext: HarnessTurnContext;
+  toolAllowlist: ReadonlySet<string>;
+  signal?: AbortSignal;
+}
+
+export interface ComposeNestedSubagentInstructionsInput {
+  subagent: HarnessSubagent;
+  taskInput: TaskToolInput;
+  parentContext: HarnessTurnContext;
+}
+
+export interface CreateNestedSubagentRunnerOptions {
+  createHarness(input: CreateNestedHarnessInput): HarnessRuntime;
+  composeInstructions(
+    input: ComposeNestedSubagentInstructionsInput,
+  ): HarnessInstructions;
+  now?(): string;
+}
+
+export function createNestedSubagentRunner(
+  options: CreateNestedSubagentRunnerOptions,
+): CreateSubagentToolRegistryOptions["runSubagent"];
+```
+
+### Behavioral requirements
+
+- Calls `filterParentContextForSubagent` and passes the filtered context to
+  `createHarness`. Never leaks the parent's full context object.
+- Generates a child trace id derived from `parentTraceId` (e.g.
+  `${parentTraceId}.sa-${index}`) so telemetry can correlate.
+- Forwards `signal` from the parent execution context. Parent cancellation
+  cancels the nested turn within one iteration boundary.
+- Applies `toolAllowlist` — the nested harness must not see any tool not in
+  the subagent's `allowedTools` list.
+- Returns a `TaskToolResult` with `{ ok, output, error, iterations, subagent }`.
+  On failure (unknown subagent, max iterations, runtime error) returns
+  `ok: false` with a typed error code; never throws to the parent loop.
+- Default `SUBAGENT_DEFAULT_MAX_ITERATIONS` is honored unless `taskInput`
+  overrides.
+
+### Files to change
+
+- New: `packages/harness/src/nested-subagent-runner.ts`
+- New: `packages/harness/src/nested-subagent-runner.test.ts`
+- Edit: `packages/harness/src/index.ts` — export the new symbols.
+- Edit: `packages/harness/src/subagent-registry.ts` — only if needed to widen
+  `CreateSubagentToolRegistryOptions["runSubagent"]` typing; do not add Sage
+  semantics here.
+
+### Tests required
+
+In `nested-subagent-runner.test.ts`:
+
+- `success_returns_flat_result` — happy path with stub harness.
+- `unknown_subagent_returns_ok_false` — registry lookup miss.
+- `subagent_failure_is_isolated` — nested harness throws; parent gets
+  `ok: false`, parent loop continues.
+- `max_iterations_failure` — nested run exceeds limit; result reports it
+  with structured reason.
+- `parallel_task_batch` — two `task` invocations resolve concurrently when
+  the registry advertises `executionMode: "parallel"`.
+- `parent_cancellation_propagates` — abort the parent signal mid-turn;
+  nested turn aborts within one iteration.
+- `tool_allowlist_enforced` — nested harness offered a tool outside the
+  allowlist receives no such tool in its registry snapshot.
+- `parent_context_is_filtered` — nested harness sees only filtered keys;
+  excluded keys (per `SUBAGENT_EXCLUDED_PARENT_KEYS`) are absent.
+- `workers_fetch_compatibility` — if the runner ever resolves a fetch (it
+  shouldn't, but stubbed harness may), assert no top-level capture.
+
+## Slice 2 — Runtime Budget Policy Primitives
+
+### Deliverable
+
+A small policy layer in `@agent-assistant/harness` for turn-scoped enforcement.
+Off by default or conservatively defaulted; emits structured events on every
+intervention. No product semantics ("broad", "deep", "planner") encoded —
+products inject the rules.
+
+### Primitives
+
+1. **Todo rewrite cap.** Configurable max number of `write_todos`-class
+   calls per turn. Beyond cap, returns a successful no-op tool result with
+   a "use existing plan" advisory string. Product names the tool; substrate
+   does not hardcode `write_todos`.
+2. **Turn-scoped tool result cache.** Keyed on `(toolName, normalizedInput)`.
+   Identical calls within the same turn return cached result with
+   `cacheHit: true` metadata. Product supplies the input normalizer per
+   tool (default: stable JSON stringify).
+3. **Reserved synthesis budget.** Configurable reserve floor `N` of the
+   per-turn tool budget. Once `remainingBudget <= reserveFloor`, calls to
+   tools tagged `category: "planning" | "broad"` are blocked with a
+   structured advisory. Synthesis text generation always passes.
+4. **Drill-or-stop validator.** After a tool result tagged
+   `produces: "candidates"`, the next call to a tool tagged
+   `category: "broad"` is rejected unless its input includes one of the
+   prior candidate ids/paths. Product tags tools; substrate validates.
+5. **Final output pseudo-tool sanitizer.** Strips tokens matching
+   `/<(function_calls|invoke|parameter)\b[^>]*>[\s\S]*?<\/\1>/g` and
+   markdown fences containing tool-pseudosyntax from the harness's final
+   text output. Emits a structured event with stripped token classes; never
+   logs raw stripped content.
+
+### Public API contract
+
+```ts
+// packages/harness/src/runtime-policy/index.ts
+
+export interface RuntimePolicyConfig {
+  todoRewriteCap?: { toolNames: string[]; max: number };
+  toolResultCache?: { enabled: boolean; normalize?: (toolName: string, input: unknown) => string };
+  reserveFloor?: { floor: number; blockedCategories: readonly string[] };
+  drillOrStop?: { candidateProducingTools: string[]; broadTools: string[] };
+  outputSanitizer?: { enabled: boolean };
+  emit?(event: RuntimePolicyEvent): void;
+}
+
+export interface RuntimePolicyEvent {
+  kind:
+    | "runtime_policy.blocked"
+    | "runtime_policy.cache_hit"
+    | "runtime_policy.todo_rewrite_blocked"
+    | "runtime_policy.output_sanitized";
+  turnId: string;
+  toolName?: string;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+export function createRuntimePolicy(config: RuntimePolicyConfig): RuntimePolicy;
+
+export interface RuntimePolicy {
+  wrapTool(tool: HarnessToolDefinition): HarnessToolDefinition;
+  sanitizeFinalOutput(text: string): { text: string; sanitized: boolean };
+  reset(turnId: string): void;
+}
+```
+
+### Behavioral requirements
+
+- Defaults: every primitive is **off** unless explicitly configured. A
+  consumer that does not pass `RuntimePolicyConfig` sees zero behavior change.
+- All advisory results are valid `HarnessToolResult`s — never throws.
+- Cache key normalization is pure and deterministic.
+- Sanitizer regex is anchored, bounded, and tested against pathological
+  inputs (nested tags, partial tags, code fences inside JSON strings).
+- Every intervention calls `emit(event)`. Events are typed and stable.
+- No knowledge of Sage tool names. The Sage repo wires its tool list into
+  config at the consuming product layer.
+
+### Files to change
+
+- New: `packages/harness/src/runtime-policy/index.ts`
+- New: `packages/harness/src/runtime-policy/cache.ts`
+- New: `packages/harness/src/runtime-policy/reserve-floor.ts`
+- New: `packages/harness/src/runtime-policy/drill-or-stop.ts`
+- New: `packages/harness/src/runtime-policy/sanitizer.ts`
+- New: `packages/harness/src/runtime-policy/*.test.ts` (one per primitive
+  plus an integration test).
+- Edit: `packages/harness/src/index.ts` — export the policy surface.
+
+### Tests required
+
+- Each primitive has unit tests covering: enabled/disabled, default no-op,
+  trigger condition, advisory shape, event emission shape.
+- `runtime-policy.integration.test.ts` — wraps a fake tool registry with
+  the policy, runs a synthetic turn, asserts cache hits, blocked calls,
+  and sanitization all fire.
+- `output-sanitizer.fuzz.test.ts` — table-driven cases for nested tags,
+  partial tags, code-fence interleaving, unicode in tag attributes.
+- `workers-fetch.test.ts` — confirms no module-level fetch capture in any
+  policy file (`grep` test or import-time spy).
+
+## Slice 3 — Telemetry Event Vocabulary
+
+### Deliverable
+
+Typed event constructors and harness-bridge metadata extensions in
+`@agent-assistant/telemetry` for the new substrate events. No product
+dashboards, no alert thresholds, no workspace slicing.
+
+### Event kinds
+
+Add these kinds to the telemetry event union:
+
+- `subagent.batch.started`
+- `subagent.started`
+- `subagent.finished`
+- `subagent.failed`
+- `runtime_policy.blocked`
+- `runtime_policy.cache_hit`
+- `runtime_policy.output_sanitized`
+- `synthesis.salvaged`
+
+### Payload shape (each event)
+
+Every event carries: `{ kind, turnId, parentTraceId?, timestamp,
+durationMs?, ... }`. Subagent events also carry: `{ subagentName,
+childTraceId, iterations?, stopReason?, toolCallCount? }`. Policy events
+carry: `{ toolName?, reason, metadata }`. Subagent names are opaque
+strings — substrate does not enumerate them.
+
+### Privacy rule
+
+No event payload may contain raw provider message content, raw tool
+inputs, or raw tool outputs. Metadata is bounded scalars and short
+identifiers. Each event constructor enforces this with a runtime assertion
+that rejects payloads exceeding a configurable size cap (default 4 KB).
+
+### Files to change
+
+- Edit: `packages/telemetry/src/index.ts` — extend the event union and
+  exported constructors.
+- Edit: `packages/telemetry/src/harness-bridge.ts` — propagate
+  policy/subagent metadata when present on the harness trace.
+- Edit: `packages/telemetry/src/sinks/memory.ts` — accept the new kinds
+  without filtering.
+- New: `packages/telemetry/test/subagent-events.test.ts`
+- New: `packages/telemetry/test/runtime-policy-events.test.ts`
+- Edit: `packages/telemetry/test/harness-bridge.test.ts` — extend with
+  the new metadata.
+
+### Tests required
+
+- Event constructor returns frozen, schema-validated payloads.
+- Oversize payloads are rejected at construction (no truncation surprise).
+- Memory sink round-trips every new kind.
+- Harness bridge emits policy and subagent kinds when the harness trace
+  surfaces the new metadata.
+- `private_content_never_leaks.test.ts` — fuzz event constructors with
+  payloads containing fake message content; assert constructors strip or
+  reject.
+
+## Slice 4 — Eval Substrate
+
+### Deliverable
+
+A fixture-oriented eval runner for assistant turns. Decision on package
+location: prefer a new `@agent-assistant/evals` if scope justifies it;
+otherwise scope under `@agent-assistant/telemetry/evals`. Defer to the
+implementing PR; the contract below does not depend on the choice.
+
+### Public API contract
+
+```ts
+export interface EvalCase {
+  name: string;
+  fixture: { providerResponses: ProviderFixture[]; tools: ToolFixture[] };
+  checks: {
+    requiredEvidence?: string[];   // substrings/regexes that must appear
+    forbiddenFanout?: { toolName: string; max: number }[];
+    budget?: { maxToolCalls: number; maxLatencyMs: number };
+    finalOutputClean?: boolean;    // sanitizer must not have triggered on real text
+  };
+}
+
+export interface EvalResult {
+  name: string;
+  passed: boolean;
+  score: { components: Record<string, number>; total: number };
+  evidence: { matched: string[]; missing: string[] };
+  forbiddenFanoutViolations: string[];
+  budget: { toolCalls: number; latencyMs: number; cost?: number };
+  finalOutputCleanResult: { clean: boolean; sanitizedKinds: string[] };
+}
+
+export function runEvalSuite(
+  cases: EvalCase[],
+  runner: EvalTurnRunner,
+): Promise<EvalResult[]>;
+
+export function formatPrCommentSummary(results: EvalResult[]): string;
+```
+
+### Behavioral requirements
+
+- Runner is mockable: `EvalTurnRunner` accepts injected provider and tool
+  fixtures; no network calls during eval execution.
+- Result JSON is stable: field ordering is canonicalized so PR-comment
+  diffs are clean.
+- `formatPrCommentSummary` produces under 4 KB of markdown — collapsed
+  details for failures, single-line summary for passes.
+- No Sage prompts, no Sage workspace fixtures, no Sage scoring rubric in
+  the package or its tests. Tests use a synthetic "echo assistant" fixture.
+
+### Files to change
+
+- New package skeleton (or new module): `packages/evals/` (or
+  `packages/telemetry/src/evals/`).
+- New: `eval-runner.ts`, `eval-checks.ts`, `pr-comment-format.ts`.
+- New: matching `*.test.ts` files for each.
+
+### Tests required
+
+- `runEvalSuite_passes_for_synthetic_happy_path`.
+- `runEvalSuite_fails_on_missing_required_evidence`.
+- `runEvalSuite_fails_on_fanout_overshoot`.
+- `runEvalSuite_fails_on_budget_exceed`.
+- `runEvalSuite_marks_dirty_output_when_sanitizer_fires`.
+- `formatPrCommentSummary_under_size_cap`.
+- `formatPrCommentSummary_deterministic_ordering`.
+
+## Slice 5 — Insight Envelope And Reader Helpers
+
+### Deliverable
+
+A schema-tolerant `InsightEnvelope` type plus reader helpers in
+`@agent-assistant/vfs`, and projection helpers in
+`@agent-assistant/turn-context` so a product can include selected insights
+as prepared context blocks with provenance. Substrate decides nothing about
+which insights to include or when.
+
+### Public API contract
+
+```ts
+// packages/vfs/src/insight/envelope.ts
+export interface InsightEnvelope<TBody = unknown> {
+  schemaVersion: string;        // e.g. "insight/v1"
+  generatedAt: string;          // ISO-8601
+  sourceProvider: string;       // opaque string, no enum
+  sourcePaths: string[];        // VFS paths
+  freshness?: { ttlSeconds?: number; staleAt?: string };
+  body: TBody;                  // product-defined, validated by product
+}
+
+export function readInsightEnvelope(
+  vfs: VirtualFileSystem,
+  path: string,
+): Promise<InsightReadResult>;
+
+export type InsightReadResult =
+  | { ok: true; envelope: InsightEnvelope }
+  | { ok: false; reason: "missing" | "malformed" | "unsupported_schema"; partial?: Partial<InsightEnvelope> };
+```
+
+```ts
+// packages/turn-context/src/insight-projection.ts
+export interface InsightProjectionInput {
+  envelope: InsightEnvelope;
+  preview?: { maxChars: number };
+}
+
+export function projectInsightAsContextBlock(
+  input: InsightProjectionInput,
+): PreparedContextBlock; // existing turn-context type
+```
+
+### Behavioral requirements
+
+- `readInsightEnvelope` never throws on malformed JSON. Returns
+  `{ ok: false, reason, partial }` and preserves whatever fields parsed
+  cleanly.
+- Provenance always survives projection: `sourceProvider`, `generatedAt`,
+  and `sourcePaths` appear in the rendered context block metadata.
+- Stale-data wording is **not** generated by the helper — it returns
+  freshness fields and lets the product render any user-facing string.
+- All file reads go through `VirtualFileSystem`; no direct `fs` access,
+  no Workers-incompatible APIs.
+- No `fetch` capture (insights are local; if a future variant fetches
+  remote envelopes, it must use call-time `globalThis.fetch`).
+
+### Files to change
+
+- New: `packages/vfs/src/insight/envelope.ts`
+- New: `packages/vfs/src/insight/reader.ts`
+- New: `packages/vfs/src/insight/*.test.ts`
+- Edit: `packages/vfs/src/index.ts` — export the insight module.
+- New: `packages/turn-context/src/insight-projection.ts`
+- New: `packages/turn-context/src/insight-projection.test.ts`
+- Edit: `packages/turn-context/src/index.ts` — export the projector.
+
+### Tests required
+
+- Valid envelope round-trip.
+- Missing file → `reason: "missing"`.
+- Malformed JSON → `reason: "malformed"` with `partial` carrying any
+  successfully parsed prefix fields.
+- Unknown `schemaVersion` → `reason: "unsupported_schema"`.
+- Projection preserves all provenance fields.
+- Projection respects `preview.maxChars`.
+
+## 80-To-100 Validation Contract
+
+Each slice goes through this gate before its PR is published. Claude is the
+sign-off owner; Codex executes; both review.
+
+### 1. Targeted tests (per slice)
+
+- Every test listed under that slice's "Tests required" section must exist
+  and pass on the slice branch.
+- Every new public type has at least one type-level test (compilation
+  asserts via a `.types.test-d.ts` or equivalent if a tool exists in the
+  repo; otherwise a runtime smoke import).
+
+### 2. Final hard gates (deterministic, fail-fast)
+
+Run as a single deterministic step, no agent in the loop:
+
+- `npm run -w @agent-assistant/<pkg> typecheck`
+- `npm run -w @agent-assistant/<pkg> test`
+- `npm run lint -w @agent-assistant/<pkg>`
+- `npm run build -w @agent-assistant/<pkg>`
+- A grep gate: `! grep -rE "^(import|const).*\\bfetch\\b.*=.*$" packages/<pkg>/src` — no top-level fetch capture.
+- A grep gate: `! grep -rE "(slack-researcher|competitor-researcher|github-investigator|linear-investigator|notion[_-]create[_-]page|SAGE_)" packages/<pkg>/src` — no Sage product names in substrate.
+
+### 3. Regression suite
+
+After per-slice gates pass, run the full repo suite:
+
+- `npm run typecheck`
+- `npm run test`
+- `npm run build`
+
+Fail the slice if any previously-green test goes red.
+
+### 4. Review gates
+
+In order, each blocking the next:
+
+1. Codex self-reflection note posted on the slice channel.
+2. Codex fresh-eyes review against this plan (separate Codex agent, no
+   prior context). Output: APPROVE / REQUEST_CHANGES with a numbered
+   diff-line list.
+3. Claude peer review: reads the diff, the fresh-eyes review, and the
+   final-gate output. Verifies the contract and substrate-vs-product
+   discipline.
+4. Claude 80-to-100 sign-off: posts `SLICE_<n>_80_100_SIGNOFF` on the
+   workflow channel with a one-line decision and the SHA.
+
+### 5. PR publication
+
+Only after sign-off:
+
+- Open the PR with title `feat(<pkg>): <slice title>`.
+- Body links this plan and lists the gates that ran.
+- PR description copies the slice's "Tests required" list as a checklist
+  with each item checked.
+- No `--no-verify`, no force pushes, no skipped hooks.
+
+## Sequencing And Dependencies
+
+- Slices 1, 2, 3, 5 are independent and can run in parallel waves.
+- Slice 4 depends on the event vocabulary from Slice 3 for any shared
+  metadata fields it consumes.
+- Sage re-adoption (out of scope here) starts after Slices 1–5 publish a
+  release.
+
+## Acceptance For This Plan
+
+This plan is accepted when a reader who has not seen Sage PR #208 can
+read it, build any one slice in isolation, and ship it without pulling
+Sage product context into Agent Assistant.
+
+SAGE_V2_SUBSTRATE_PLAN_READY

--- a/docs/architecture/sage-v2-substrate-lead-reflection.md
+++ b/docs/architecture/sage-v2-substrate-lead-reflection.md
@@ -1,0 +1,134 @@
+# Sage v2 Substrate — Lead Self-Reflection
+
+Date: 2026-05-07
+
+Audience: Codex (executor) and the workflow owner. This is a candid review of
+the architecture contract in
+`docs/architecture/sage-v2-substrate-implementation-plan.md` against the source
+extraction map (`sage-v2-substrate-extraction-map.md`), the ownership rule in
+`runtime-primitives-vs-product-intelligence.md`, and the 80-to-100 skill.
+
+The plan is implementation-ready, but several risks deserve to be called out
+before code is written.
+
+## 1. Risks That Sage Product Intelligence Leaks Into Agent Assistant
+
+The plan names the boundary loudly ("Out of scope (stays in Sage)") and adds a
+grep gate against `slack-researcher|competitor-researcher|...|SAGE_`. Even so,
+there are residual ways Sage intelligence could ride into the substrate:
+
+- **Drill-or-stop tags become a product taxonomy.** Slice 2 introduces tool
+  tags `category: "planning" | "broad"` and `produces: "candidates"`. If
+  substrate ships an enum or a "blessed" set of categories, the substrate
+  starts encoding what counts as broad — that is product judgment. Mitigation:
+  keep the tag values as opaque strings supplied per consumer, validate only
+  shape, and add a test that asserts no enum is exported. Reject any PR that
+  adds a default category list.
+- **Default normalizers and tool name lists.** `todoRewriteCap.toolNames` and
+  `toolResultCache.normalize` are configurable, but if the implementer adds a
+  "sensible default" (e.g. `["write_todos"]`) for ergonomics, the harness now
+  knows a Claude Code-shaped tool name. Mitigation: defaults must remain
+  empty/disabled. Add a unit test that an unconfigured policy is a no-op for
+  every primitive.
+- **Eval fixtures shaped like Sage turns.** Slice 4 says "synthetic echo
+  assistant," but it is easy to slip toward fixtures that mirror Sage's real
+  flow (Slack research → Notion write). Mitigation: fixtures must reference
+  fictional providers/tools (`provider-a`, `tool-x`) and the test file must
+  not contain Slack/Notion/GitHub strings — add a grep gate to the eval
+  package the same way Slice 1/2 have one.
+- **Insight envelope `sourceProvider` becoming an enum.** Slice 5 keeps it as
+  an opaque string, but TypeScript ergonomics may tempt a literal union.
+  Mitigation: keep `sourceProvider: string` and add a type-level test that the
+  field accepts any string.
+- **Telemetry payload shapes that smuggle product semantics.** If
+  `subagent.started` accumulates fields like `roster`, `specialty`, or
+  `domain`, those fields become a soft schema for product behavior even if
+  named generically. Mitigation: keep payloads to bounded scalars and opaque
+  ids, and assert in tests that no telemetry event has a field named after a
+  Sage role.
+- **Sanitizer regex tuned to Sage's specific leak patterns.** The sanitizer
+  must be motivated by general pseudo-tool syntax, not a particular Sage
+  prompt artifact. Mitigation: fuzz table must include non-Sage shapes
+  (XML-ish, markdown-fenced, JSON-embedded) and reject any test name that
+  references a Sage incident.
+
+## 2. Risks The Workflow Misses An 80-To-100 Gate
+
+The plan's 80-to-100 validation contract is strong on the deterministic gates
+(typecheck, test, lint, build, two grep gates, regression run) and on the
+review chain. The places it can still fall short of the 80-to-100 standard
+("feature works, tested E2E locally," not just "code compiles"):
+
+- **No cross-package integration evidence.** Each slice gates on its own
+  package. The point of substrate is consumption — there is no gate that
+  imports the new symbol from a sibling package and exercises it end to end.
+  Mitigation: add an integration smoke test (per slice) that imports the new
+  symbol from `@agent-assistant/harness` (or wherever) into a tiny consumer
+  fixture and runs a synthetic turn. Make it part of the per-slice "Tests
+  required" list.
+- **Workers-fetch enforcement is grep-only at the substrate boundary.** The
+  grep `! grep -rE "^(import|const).*\bfetch\b.*=.*$"` catches the obvious
+  shape but not, e.g., destructured `const { fetch } = globalThis` or a class
+  field initializer. Mitigation: add the runtime swap test
+  (`workers-fetch.test.ts`) to every slice that touches an HTTP-capable file,
+  not only Slice 1; today it is only required as a stub assertion in Slice 1
+  and as a grep test in Slice 2.
+- **No "publish dry-run" gate.** 80-to-100 for a published package includes
+  ensuring the build artifact actually exposes the new symbols and that
+  `package.json` exports map them. Mitigation: add `npm pack --dry-run` (or an
+  equivalent "consume the built dist from a sibling package" smoke) as a
+  hard gate before sign-off.
+- **No telemetry-private-content gate at the integration layer.** Slice 3
+  has `private_content_never_leaks.test.ts` at the unit level. The runtime
+  policy events (Slice 2) feed telemetry but are tested in isolation.
+  Mitigation: the integration smoke from the first bullet should also
+  confirm policy events never carry raw tool inputs/outputs end to end.
+- **Sign-off is an agent-driven step, not a deterministic gate.** "Claude
+  80-to-100 sign-off" depends on Claude posting `SLICE_<n>_80_100_SIGNOFF`.
+  If the agent skips a check, the gate still passes. Mitigation: the
+  deterministic step in §2 of the validation contract should be the source
+  of truth — sign-off is a wrapper that verifies the deterministic step's
+  output exists and matches the SHA, not a freeform reading.
+- **Regression suite runs at slice end, not after merge into the integration
+  branch.** If two slices merge in sequence, the second slice's regression
+  run does not exercise the first slice's new code paths together until both
+  are landed. Mitigation: define the integration branch and require the
+  regression suite to run on the integration HEAD, not on each slice branch
+  in isolation, before PR publication of the second-and-later slices.
+
+## 3. Scope-Control Adjustments Codex Should Honor Before Implementation
+
+These are the concrete asks from this reflection. Codex should treat them as
+binding for the slice PRs.
+
+1. **No default values that name a product.** Every config field listed in
+   Slice 2 (`todoRewriteCap.toolNames`, `toolResultCache.normalize`,
+   `reserveFloor.blockedCategories`, `drillOrStop.candidateProducingTools`,
+   `drillOrStop.broadTools`) ships with `[]` / `undefined` defaults. The
+   policy is a no-op until a consumer configures it.
+2. **Tag values are opaque strings.** No `type Category = "planning" | "broad"`
+   union exported from substrate. Tag schemas live in product packages.
+3. **Insight `sourceProvider` and `schemaVersion` stay opaque.** No literal
+   union, no enum, no registry. Only shape validation.
+4. **Eval fixtures use fictional names.** No `slack-*`, `notion-*`,
+   `github-*`, `linear-*`, `competitor-*` strings anywhere in the eval
+   package — extend the grep gate to cover the eval package once it exists.
+5. **Add an integration smoke per slice.** A minimal cross-package test that
+   imports the new public symbol and runs a synthetic happy path. Add it to
+   the slice's "Tests required" list before opening the PR.
+6. **Workers-fetch swap test is mandatory for any file with an HTTP path.**
+   Not just Slice 1. Mirror
+   `packages/harness/src/adapter/openrouter-model-adapter.workers-fetch.test.ts`.
+7. **Treat sign-off as verification of deterministic output.** The Claude
+   sign-off message must quote the deterministic gate output (commands and
+   exit codes) and the SHA. No freehand "looks good" sign-offs.
+8. **Run the regression suite on the integration HEAD for slices ≥ 2.** The
+   first slice can run on its own branch; subsequent slices must rebase onto
+   the integration branch and rerun the regression suite there before
+   sign-off.
+
+If Codex hits a case where any of the above forces an awkward shape, escalate
+back to Claude rather than relaxing the rule locally — the boundary is the
+whole point of the extraction.
+
+LEAD_SELF_REFLECTION_COMPLETE

--- a/docs/consumer/evals-adoption-guide.md
+++ b/docs/consumer/evals-adoption-guide.md
@@ -1,0 +1,67 @@
+# Human-Driven Eval Adoption Guide
+
+Agent Assistant exposes reusable eval primitives through
+`@agent-assistant/telemetry/evals`. Products should keep their domain-specific
+cases, rubrics, fixtures, and executors in their own repos, then use these
+helpers for shared mechanics:
+
+- loading human-authored `cases.jsonl` suites,
+- filtering by suite, case id, and tags,
+- applying deterministic expectation checks,
+- marking cases that need human review,
+- writing `result.json`, `summary.md`, and `human-review.md` artifacts.
+
+The package intentionally does not decide what "good" means for a product. A
+planning assistant, Slack coworker, coding assistant, or support agent should
+encode that in product-owned `cases.jsonl` files and `rubric.md` documents.
+
+## Product Layout
+
+```text
+evals/
+  README.md
+  suites/
+    planning/
+      cases.jsonl
+      rubric.md
+    routing/
+      cases.jsonl
+      rubric.md
+  fixtures/
+scripts/evals/
+  run-product-evals.mjs
+  summarize-product-evals.mjs
+  compare-product-evals.mjs
+```
+
+## Case Shape
+
+```json
+{"id":"planning.example","suite":"planning","executor":"manual","kind":"capability","input":{"message":"Plan the feature"},"expected":{"must":["Includes validation gates"],"mustNot":["Claims implementation is complete"],"humanReviewRequired":true},"tags":["planning"]}
+```
+
+## Runner Shape
+
+Products provide executors and call the shared helpers:
+
+```js
+import {
+  assertHumanEvalExpected,
+  createHumanEvalRunRecord,
+  humanEvalNeedsReview,
+  loadHumanEvalCasesFromSuitesDir,
+  matchesHumanEvalFilters,
+  validateHumanEvalCase,
+  writeHumanEvalRunArtifacts,
+} from "@agent-assistant/telemetry/evals";
+```
+
+Manual and transcript cases can often use only the shared helpers. Product
+runtime cases usually need product-specific executors because routing, tool
+registries, provider configuration, and sandbox setup are product-owned.
+
+## Practice
+
+Start with 20-50 cases. Keep capability cases separate from regression cases.
+Prefer deterministic checks first, require human review for subjective planning
+quality, and add LLM judges only after calibration against human verdicts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,6 +413,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -3663,7 +3664,7 @@
     },
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -3746,7 +3747,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3758,7 +3759,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -4025,7 +4026,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -4048,7 +4049,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -4081,7 +4082,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -4249,7 +4250,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -5037,7 +5038,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^6.0.9",
@@ -5050,7 +5051,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -5062,7 +5063,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/coordination": "^0.4.25",
@@ -5085,7 +5086,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -5102,7 +5103,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5110,7 +5111,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -5149,7 +5150,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5157,7 +5158,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -5430,7 +5431,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5439,12 +5440,13 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
         "@agent-assistant/memory": "^0.2.0",
-        "@agent-assistant/traits": "^0.2.0"
+        "@agent-assistant/traits": "^0.2.0",
+        "@agent-assistant/vfs": "^0.4.0 || ^0.6.0"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5505,12 +5507,6 @@
       "version": "0.2.24",
       "resolved": "https://registry.npmjs.org/@agent-assistant/traits/-/traits-0.2.24.tgz",
       "integrity": "sha512-oopf1b1qO3PS9Yp+XJZFH6r7mSdKMfsdqQBz+pSFI9pcJacL0j1Jo8ECmmzwOP+3kUcudmK9SerLMQIs64Qh0Q==",
-      "license": "MIT"
-    },
-    "packages/turn-context/node_modules/@agent-assistant/vfs": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@agent-assistant/vfs/-/vfs-0.2.24.tgz",
-      "integrity": "sha512-yRT0YMMwskDg5aEvwn6iUDQZxgYqD8AtbIL3dnb+cdHkyd5hoKDi9rQiHq7Mi+yBg/s9ja4cGks9kI1pNLemQA==",
       "license": "MIT"
     },
     "packages/turn-context/node_modules/@agent-relay/config": {
@@ -5604,7 +5600,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -5631,7 +5627,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.4.25",
+      "version": "0.4.28",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@agent-assistant/surfaces": "^0.3.0",

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -23,6 +23,8 @@ import type {
   HarnessToolRegistry,
   HarnessToolResult,
   HarnessToolRetryConfig,
+  HarnessRuntimePolicy,
+  HarnessRuntimePolicyEvent,
   HarnessTraceEvent,
   HarnessTraceSummary,
   HarnessTranscriptItem,
@@ -31,6 +33,7 @@ import type {
 } from './types.js';
 import { HarnessConfigError } from './types.js';
 import { exceedsEvidenceBudget } from './claim-density.js';
+import { createRuntimePolicy } from './runtime-policy/index.js';
 
 const DEFAULT_LIMITS: Required<Pick<HarnessLimits, 'maxIterations' | 'maxToolCalls' | 'maxElapsedMs' | 'maxConsecutiveInvalidModelOutputs'>> = {
   maxIterations: 6,
@@ -65,11 +68,15 @@ type MutableState = {
   finalEventType: string;
 };
 
-type NormalizedConfig = {
+type NormalizedConfig = Omit<
+  HarnessConfig,
+  'clock' | 'limits' | 'toolRetryConfig' | 'runtimePolicy'
+> & {
   limits: Required<Pick<HarnessLimits, 'maxIterations' | 'maxToolCalls' | 'maxElapsedMs' | 'maxConsecutiveInvalidModelOutputs'>> & Pick<HarnessLimits, 'budgetLimit'>;
   clock: HarnessClock;
   toolRetryConfig: HarnessToolRetryConfig;
-} & HarnessConfig;
+  runtimePolicy?: HarnessRuntimePolicy;
+};
 
 export function createHarness(config: HarnessConfig): HarnessRuntime {
   const normalized = normalizeConfig(config);
@@ -253,13 +260,46 @@ function normalizeConfig(config: HarnessConfig): NormalizedConfig {
   }
 
   const toolRetryConfig = normalizeToolRetryConfig(config.toolRetryConfig);
+  const runtimePolicy = normalizeRuntimePolicy(config.runtimePolicy);
 
   return {
     ...config,
     clock: config.clock ?? defaultClock,
     limits,
     toolRetryConfig,
+    runtimePolicy,
   };
+}
+
+function normalizeRuntimePolicy(
+  runtimePolicy: HarnessConfig['runtimePolicy'],
+): HarnessRuntimePolicy | undefined {
+  if (!runtimePolicy) {
+    return undefined;
+  }
+
+  if (isHarnessRuntimePolicy(runtimePolicy)) {
+    return runtimePolicy;
+  }
+
+  return createRuntimePolicy(runtimePolicy);
+}
+
+function isHarnessRuntimePolicy(value: unknown): value is HarnessRuntimePolicy {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'beforeToolCall' in value &&
+    typeof value.beforeToolCall === 'function' &&
+    'afterToolResult' in value &&
+    typeof value.afterToolResult === 'function' &&
+    'sanitizeFinalOutput' in value &&
+    typeof value.sanitizeFinalOutput === 'function' &&
+    'finalizeTurn' in value &&
+    typeof value.finalizeTurn === 'function' &&
+    'reset' in value &&
+    typeof value.reset === 'function'
+  );
 }
 
 function normalizeToolRetryConfig(
@@ -315,15 +355,18 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
   let finalResult: HarnessResult | null = null;
 
   try {
+    config.runtimePolicy?.reset(input.turnId);
     const availableTools = config.tools
-      ? await config.tools.listAvailable({
-          assistantId: input.assistantId,
-          turnId: input.turnId,
-          workspaceId: input.workspaceId,
-          sessionId: input.sessionId,
-          userId: input.userId,
-          allowedToolNames: input.allowedToolNames,
-        })
+      ? (
+          await config.tools.listAvailable({
+            assistantId: input.assistantId,
+            turnId: input.turnId,
+            workspaceId: input.workspaceId,
+            sessionId: input.sessionId,
+            userId: input.userId,
+            allowedToolNames: input.allowedToolNames,
+          })
+        ).map((tool) => config.runtimePolicy?.wrapTool(tool) ?? tool)
       : [];
 
     await emit(config, input, state, { type: 'turn_started' });
@@ -412,45 +455,62 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
       state.transcript.push(assistantStep);
 
       switch (output.type) {
-        case 'final_answer':
+        case 'final_answer': {
+          const sanitizedText = await applyRuntimePolicyToText(
+            config,
+            input,
+            state,
+            output.text,
+            readModelId(output),
+          );
+          replaceLatestAssistantText(state, sanitizedText);
           if (!streamingHandled) {
             await emitStream(config, {
               type: 'text_delta',
               iteration,
-              text: output.text,
+              text: sanitizedText,
               outputType: 'final_answer',
             });
           }
-          finalResult = buildAnswerResult(input, state, output.text);
+          finalResult = buildAnswerResult(input, state, sanitizedText);
           return finalResult;
+        }
 
         case 'clarification': {
+          const sanitizedQuestion = await applyRuntimePolicyToText(
+            config,
+            input,
+            state,
+            output.question,
+            readModelId(output),
+          );
+          replaceLatestAssistantText(state, sanitizedQuestion);
           const continuation = createContinuation(config, input, 'clarification', {
             stopReason: 'clarification_required',
-            question: output.question,
+            question: sanitizedQuestion,
             transcript: summarizeTranscript(state.transcript),
           });
           state.transcript.push({
             type: 'clarification_request',
             iteration,
-            question: output.question,
+            question: sanitizedQuestion,
           });
           await emit(config, input, state, {
             type: 'clarification_requested',
-            question: output.question,
+            question: sanitizedQuestion,
           });
           if (!streamingHandled) {
             await emitStream(config, {
               type: 'text_delta',
               iteration,
-              text: output.question,
+              text: sanitizedQuestion,
               outputType: 'clarification',
             });
           }
           finalResult = buildResult(input, state, {
             outcome: 'needs_clarification',
             stopReason: 'clarification_required',
-            assistantMessage: { text: output.question },
+            assistantMessage: { text: sanitizedQuestion },
             continuation,
           });
           return finalResult;
@@ -488,11 +548,19 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
             type: 'approval_requested',
             request: prepared.request,
           });
+          const sanitizedSummary = await applyRuntimePolicyToText(
+            config,
+            input,
+            state,
+            prepared.request.summary,
+            readModelId(output),
+          );
+          replaceLatestAssistantText(state, sanitizedSummary);
           if (!streamingHandled) {
             await emitStream(config, {
               type: 'text_delta',
               iteration,
-              text: prepared.request.summary,
+              text: sanitizedSummary,
               outputType: 'approval_request',
             });
           }
@@ -556,21 +624,30 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
           continue;
         }
 
-        case 'refusal':
+        case 'refusal': {
+          const sanitizedReason = await applyRuntimePolicyToText(
+            config,
+            input,
+            state,
+            output.reason,
+            readModelId(output),
+          );
+          replaceLatestAssistantText(state, sanitizedReason);
           if (!streamingHandled) {
             await emitStream(config, {
               type: 'text_delta',
               iteration,
-              text: output.reason,
+              text: sanitizedReason,
               outputType: 'refusal',
             });
           }
           finalResult = buildResult(input, state, {
             outcome: 'failed',
             stopReason: 'model_refused',
-            assistantMessage: { text: output.reason },
+            assistantMessage: { text: sanitizedReason },
           });
           return finalResult;
+        }
 
         case 'invalid':
           finalResult = await handleInvalidOutput(config, input, state, startedAt, output);
@@ -596,6 +673,16 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
     return finalResult;
   } finally {
     if (finalResult) {
+      await emitRuntimePolicyEvents(
+        config,
+        input,
+        state,
+        config.runtimePolicy?.finalizeTurn({
+          turnId: input.turnId,
+          outcome: finalResult.outcome,
+          stopReason: finalResult.stopReason,
+        }) ?? [],
+      );
       await emitFinishedSafely(config, input, state, finalResult);
       try {
         await config.hooks?.onTurnFinished?.(
@@ -606,6 +693,7 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
         console.error('Harness onTurnFinished hook failed', error);
       }
     }
+    config.runtimePolicy?.reset(input.turnId);
   }
 }
 
@@ -696,6 +784,7 @@ async function executeToolBatch(
   iteration: number,
 ): Promise<HarnessResult | null> {
   const mode = resolveToolBatchMode(calls, availableTools);
+  const toolDefinitions = new Map(availableTools.map((tool) => [tool.name, tool]));
   await emit(config, input, state, {
     type: 'tool_batch_started',
     mode,
@@ -704,8 +793,8 @@ async function executeToolBatch(
 
   const results =
     mode === 'parallel'
-      ? await executeParallelToolBatch(config, input, state, calls, iteration)
-      : await executeSequentialToolBatch(config, input, state, calls, iteration);
+      ? await executeParallelToolBatch(config, input, state, calls, toolDefinitions, iteration)
+      : await executeSequentialToolBatch(config, input, state, calls, toolDefinitions, iteration);
 
   const cancelled = buildCancelledResult(input, state);
   if (cancelled) {
@@ -723,7 +812,12 @@ async function executeToolBatch(
       recordToolResultSignature(state, result);
     }
 
-    const text = results.map(readTerminatingToolText).join('');
+    const text = await applyRuntimePolicyToText(
+      config,
+      input,
+      state,
+      results.map(readTerminatingToolText).join(''),
+    );
     state.transcript.push({
       type: 'assistant_step',
       iteration,
@@ -765,11 +859,22 @@ async function executeSequentialToolBatch(
   input: HarnessTurnInput,
   state: MutableState,
   calls: HarnessToolCall[],
+  toolDefinitions: Map<string, HarnessToolDefinition>,
   iteration: number,
 ): Promise<HarnessToolResult[]> {
   const results: HarnessToolResult[] = [];
   for (const [index, call] of calls.entries()) {
-    results.push(await executeSingleToolCall(config, input, state, call, iteration, index));
+    results.push(
+      await executeSingleToolCall(
+        config,
+        input,
+        state,
+        call,
+        toolDefinitions.get(call.name),
+        iteration,
+        index,
+      ),
+    );
     if (input.signal?.aborted) {
       break;
     }
@@ -782,11 +887,20 @@ async function executeParallelToolBatch(
   input: HarnessTurnInput,
   state: MutableState,
   calls: HarnessToolCall[],
+  toolDefinitions: Map<string, HarnessToolDefinition>,
   iteration: number,
 ): Promise<HarnessToolResult[]> {
   const completed: HarnessToolResult[] = [];
   const tasks = calls.map(async (call, index) => {
-    const result = await executeSingleToolCall(config, input, state, call, iteration, index);
+    const result = await executeSingleToolCall(
+      config,
+      input,
+      state,
+      call,
+      toolDefinitions.get(call.name),
+      iteration,
+      index,
+    );
     completed.push(result);
   });
 
@@ -799,15 +913,28 @@ async function executeSingleToolCall(
   input: HarnessTurnInput,
   state: MutableState,
   call: HarnessToolCall,
+  tool: HarnessToolDefinition | undefined,
   iteration: number,
   index: number,
 ): Promise<HarnessToolResult> {
+  const decision = config.runtimePolicy?.beforeToolCall({
+    turnId: input.turnId,
+    call,
+    tool,
+    toolCallCount: state.toolCallCount,
+    maxToolCalls: config.limits.maxToolCalls,
+  });
+  if (decision && decision.action !== 'allow') {
+    await emitRuntimePolicyEvents(config, input, state, decision.events);
+    return decision.result;
+  }
+
   const nextToolCallCount = state.toolCallCount + 1;
   state.toolCallCount = nextToolCallCount;
   state.usage.toolCalls = nextToolCallCount;
   await emit(config, input, state, { type: 'tool_started', call });
   await emitStream(config, { type: 'tool_started', iteration, call });
-  return executeToolWithRetry(config, input, state, call, {
+  const result = await executeToolWithRetry(config, input, state, call, {
     assistantId: input.assistantId,
     turnId: input.turnId,
     workspaceId: input.workspaceId,
@@ -818,6 +945,18 @@ async function executeSingleToolCall(
     toolCallIndex: index,
     signal: input.signal,
   });
+  await emitRuntimePolicyEvents(
+    config,
+    input,
+    state,
+    config.runtimePolicy?.afterToolResult({
+      turnId: input.turnId,
+      call,
+      tool,
+      result,
+    }) ?? [],
+  );
+  return result;
 }
 
 async function processToolResult(
@@ -864,6 +1003,16 @@ async function processToolResult(
 }
 
 function recordToolResultSignature(state: MutableState, result: HarnessToolResult): boolean {
+  const runtimePolicyMeta = result.metadata?.runtimePolicy;
+  if (
+    typeof runtimePolicyMeta === 'object' &&
+    runtimePolicyMeta !== null &&
+    'synthetic' in runtimePolicyMeta &&
+    runtimePolicyMeta.synthetic === true
+  ) {
+    return false;
+  }
+
   const signature = computeToolResultSignature(result);
   if (signature === null) {
     return false;
@@ -1108,6 +1257,33 @@ function buildAnswerResult(
     stopReason: 'answer_finalized',
     assistantMessage: { text },
   });
+}
+
+async function applyRuntimePolicyToText(
+  config: NormalizedConfig,
+  input: HarnessTurnInput,
+  state: MutableState,
+  text: string,
+  modelId?: string,
+): Promise<string> {
+  if (!config.runtimePolicy) {
+    return text;
+  }
+
+  const sanitized = config.runtimePolicy.sanitizeFinalOutput({
+    turnId: input.turnId,
+    text,
+    modelId,
+  });
+  await emitRuntimePolicyEvents(config, input, state, sanitized.events);
+  return sanitized.text;
+}
+
+function replaceLatestAssistantText(state: MutableState, text: string): void {
+  const latest = state.transcript[state.transcript.length - 1];
+  if (latest?.type === 'assistant_step') {
+    latest.text = text;
+  }
 }
 
 function buildEvidenceDensityViolation(
@@ -1380,6 +1556,22 @@ async function emit(
     await config.trace.emit(event);
   } catch {
     // Observability failures should not change turn execution semantics.
+  }
+}
+
+async function emitRuntimePolicyEvents(
+  config: NormalizedConfig,
+  input: HarnessTurnInput,
+  state: MutableState,
+  events: HarnessRuntimePolicyEvent[],
+): Promise<void> {
+  for (const event of events) {
+    await emit(config, input, state, {
+      type: event.kind,
+      reason: event.reason,
+      ...(event.toolName ? { toolName: event.toolName } : {}),
+      ...(event.metadata ? { metadata: event.metadata } : {}),
+    });
   }
 }
 

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -517,10 +517,21 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
         }
 
         case 'approval_request': {
+          const sanitizedSummary = await applyRuntimePolicyToText(
+            config,
+            input,
+            state,
+            output.request.summary,
+            readModelId(output),
+          );
+          const sanitizedRequest =
+            sanitizedSummary === output.request.summary
+              ? output.request
+              : { ...output.request, summary: sanitizedSummary };
           state.transcript.push({
             type: 'approval_request',
             iteration,
-            request: output.request,
+            request: sanitizedRequest,
           });
           const prepared = config.approvals
             ? await config.approvals.prepareRequest({
@@ -529,14 +540,14 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
                 workspaceId: input.workspaceId,
                 sessionId: input.sessionId,
                 userId: input.userId,
-                request: output.request,
+                request: sanitizedRequest,
                 signal: input.signal,
               })
             : {
-                request: output.request,
+                request: sanitizedRequest,
                 continuation: createContinuation(config, input, 'approval', {
                   stopReason: 'approval_required',
-                  request: output.request,
+                  request: sanitizedRequest,
                   transcript: summarizeTranscript(state.transcript),
                 }),
               };
@@ -548,19 +559,12 @@ async function runTurn(config: NormalizedConfig, input: HarnessTurnInput): Promi
             type: 'approval_requested',
             request: prepared.request,
           });
-          const sanitizedSummary = await applyRuntimePolicyToText(
-            config,
-            input,
-            state,
-            prepared.request.summary,
-            readModelId(output),
-          );
-          replaceLatestAssistantText(state, sanitizedSummary);
+          replaceLatestAssistantText(state, prepared.request.summary);
           if (!streamingHandled) {
             await emitStream(config, {
               type: 'text_delta',
               iteration,
-              text: sanitizedSummary,
+              text: prepared.request.summary,
               outputType: 'approval_request',
             });
           }
@@ -1570,7 +1574,9 @@ async function emitRuntimePolicyEvents(
       type: event.kind,
       reason: event.reason,
       ...(event.toolName ? { toolName: event.toolName } : {}),
-      ...(event.metadata ? { metadata: event.metadata } : {}),
+      ...(event.metadata
+        ? { metadata: { ...(input.metadata ?? {}), ...event.metadata } }
+        : {}),
     });
   }
 }

--- a/packages/harness/src/runtime-policy.integration.test.ts
+++ b/packages/harness/src/runtime-policy.integration.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createHarness,
+  type HarnessModelOutput,
+  type HarnessTraceEvent,
+} from './index.js';
+
+function createInput() {
+  return {
+    assistantId: 'assistant-1',
+    turnId: 'turn-1',
+    workspaceId: 'workspace-1',
+    sessionId: 'session-1',
+    userId: 'user-1',
+    threadId: 'thread-1',
+    message: {
+      id: 'msg-1',
+      text: 'Investigate the repo.',
+      receivedAt: '2026-05-07T12:00:00.000Z',
+    },
+    instructions: {
+      systemPrompt: 'You are helpful.',
+    },
+  };
+}
+
+function createClock(times: number[]) {
+  let index = 0;
+  return {
+    now: () => times[Math.min(index++, times.length - 1)] ?? 0,
+    nowIso: () => new Date(times[Math.min(index, times.length - 1)] ?? 0).toISOString(),
+  };
+}
+
+function toolRequest(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): HarnessModelOutput {
+  return {
+    type: 'tool_request',
+    calls: [{ id, name, input }],
+  };
+}
+
+describe('runtime policy integration', () => {
+  it('caps repeated todo rewrites and still reaches final synthesis', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    let writesExecuted = 0;
+    const steps: HarnessModelOutput[] = Array.from({ length: 6 }, (_, index) =>
+      toolRequest(`write-${index + 1}`, 'write_todos', {
+        todos: [{ content: `step-${index + 1}`, status: 'pending' }],
+      }),
+    );
+    steps.push({ type: 'final_answer', text: 'Used the surviving plan and completed the turn.' });
+
+    const harness = createHarness({
+      model: {
+        nextStep: vi.fn(async () => steps.shift() as HarnessModelOutput),
+      },
+      tools: {
+        listAvailable: async () => [{ name: 'write_todos', description: 'Write todos' }],
+        execute: async (call) => {
+          writesExecuted += 1;
+          return {
+            callId: call.id,
+            toolName: call.name,
+            status: 'success',
+            output: JSON.stringify({ ok: true, rewrittenTo: call.input }),
+          };
+        },
+      },
+      runtimePolicy: {
+        todoRewriteCap: {
+          toolNames: ['write_todos'],
+          max: 2,
+        },
+      },
+      limits: { maxIterations: 8 },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock(Array.from({ length: 64 }, (_, index) => index)),
+    });
+
+    const result = await harness.runTurn(createInput());
+
+    expect(result.outcome).toBe('completed');
+    expect(result.assistantMessage?.text).toContain('completed the turn');
+    expect(writesExecuted).toBe(2);
+    expect(
+      trace.filter((event) => event.type === 'runtime_policy.todo_rewrite_blocked'),
+    ).toHaveLength(4);
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.synthesis_salvaged',
+      }),
+    );
+  });
+
+  it('caches duplicate tool calls without extra upstream reads or budget burn', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    let upstreamReads = 0;
+    const steps: HarnessModelOutput[] = [
+      toolRequest('list-1', 'workspace_list', { path: '/github/repos/AgentWorkforce/relaycast', depth: 2 }),
+      toolRequest('list-2', 'workspace_list', { depth: 2, path: '/github/repos/AgentWorkforce/relaycast' }),
+      { type: 'final_answer', text: 'The repo has a package.json and src directory.' },
+    ];
+
+    const harness = createHarness({
+      model: {
+        nextStep: vi.fn(async () => steps.shift() as HarnessModelOutput),
+      },
+      tools: {
+        listAvailable: async () => [{ name: 'workspace_list', description: 'List workspace' }],
+        execute: async (call) => {
+          upstreamReads += 1;
+          return {
+            callId: call.id,
+            toolName: call.name,
+            status: 'success',
+            output: 'package.json\nsrc',
+            structuredOutput: { candidates: [{ path: 'package.json' }, { path: 'src/index.ts' }] },
+          };
+        },
+      },
+      runtimePolicy: {
+        toolResultCache: { enabled: true },
+      },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock(Array.from({ length: 32 }, (_, index) => index)),
+    });
+
+    const result = await harness.runTurn(createInput());
+
+    expect(result.outcome).toBe('completed');
+    expect(upstreamReads).toBe(1);
+    expect(result.traceSummary.toolCallCount).toBe(1);
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.cache_hit',
+        toolName: 'workspace_list',
+      }),
+    );
+  });
+
+  it('reserves synthesis budget by blocking broad enumeration at the floor', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    let broadReads = 0;
+    const steps: HarnessModelOutput[] = [
+      toolRequest('list-1', 'repo_list', { path: '/repo', depth: 1 }),
+      toolRequest('list-2', 'repo_list', { path: '/repo/src', depth: 1 }),
+      toolRequest('list-3', 'repo_list', { path: '/repo/docs', depth: 1 }),
+      toolRequest('list-4', 'repo_list', { path: '/repo/examples', depth: 1 }),
+      toolRequest('list-5', 'repo_list', { path: '/repo/tests', depth: 1 }),
+      { type: 'final_answer', text: 'Summarized the architecture from the existing evidence.' },
+    ];
+
+    const harness = createHarness({
+      model: {
+        nextStep: vi.fn(async () => steps.shift() as HarnessModelOutput),
+      },
+      tools: {
+        listAvailable: async () => [
+          {
+            name: 'repo_list',
+            description: 'List repository contents',
+            metadata: { runtimePolicyCategories: ['broad'] },
+          },
+        ],
+        execute: async (call) => {
+          broadReads += 1;
+          return {
+            callId: call.id,
+            toolName: call.name,
+            status: 'success',
+            output: `listed ${String(call.input.path)}`,
+          };
+        },
+      },
+      limits: { maxToolCalls: 7 },
+      runtimePolicy: {
+        reserveFloor: {
+          floor: 3,
+          blockedCategories: ['broad'],
+        },
+      },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock(Array.from({ length: 48 }, (_, index) => index)),
+    });
+
+    const result = await harness.runTurn(createInput());
+
+    expect(result.outcome).toBe('completed');
+    expect(broadReads).toBe(4);
+    expect(result.traceSummary.toolCallCount).toBe(4);
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.blocked',
+        reason: 'reserve_floor_reached',
+      }),
+    );
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.synthesis_salvaged',
+      }),
+    );
+  });
+
+  it('enforces drill-or-stop by blocking repeated listing until a concrete path is read', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    const executed: string[] = [];
+    const steps: HarnessModelOutput[] = [
+      toolRequest('list-1', 'repo_list', { path: '/repo' }),
+      toolRequest('list-2', 'repo_list', { path: '/repo' }),
+      toolRequest('read-1', 'repo_read', { path: 'package.json' }),
+      { type: 'final_answer', text: 'The repo root includes package.json, which defines the package entrypoints.' },
+    ];
+
+    const harness = createHarness({
+      model: {
+        nextStep: vi.fn(async () => steps.shift() as HarnessModelOutput),
+      },
+      tools: {
+        listAvailable: async () => [
+          {
+            name: 'repo_list',
+            description: 'List repository contents',
+            metadata: { runtimePolicyCategories: ['broad'] },
+          },
+          {
+            name: 'repo_read',
+            description: 'Read repository file',
+          },
+        ],
+        execute: async (call) => {
+          executed.push(call.id);
+          if (call.name === 'repo_list') {
+            return {
+              callId: call.id,
+              toolName: call.name,
+              status: 'success',
+              output: 'package.json\nsrc/index.ts',
+              structuredOutput: {
+                candidates: [{ path: 'package.json' }, { path: 'src/index.ts' }],
+              },
+            };
+          }
+          return {
+            callId: call.id,
+            toolName: call.name,
+            status: 'success',
+            output: '{"name":"relaycast"}',
+          };
+        },
+      },
+      runtimePolicy: {
+        drillOrStop: {
+          candidateProducingTools: ['repo_list'],
+          broadTools: ['repo_list'],
+        },
+      },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock(Array.from({ length: 40 }, (_, index) => index)),
+    });
+
+    const result = await harness.runTurn(createInput());
+
+    expect(result.outcome).toBe('completed');
+    expect(executed).toEqual(['list-1', 'read-1']);
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.blocked',
+        reason: 'drill_or_stop_required',
+      }),
+    );
+  });
+
+  it('sanitizes final pseudo-tool output and emits sanitizer telemetry', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    const harness = createHarness({
+      model: {
+        nextStep: async () => ({
+          type: 'final_answer',
+          text: 'Answer first.\n<function_calls><invoke name="workspace_list"><parameter name="path">/repo</parameter></invoke></function_calls>\nAnswer last.',
+          metadata: { modelId: 'openrouter/test-model' },
+        }),
+      },
+      runtimePolicy: {
+        outputSanitizer: { enabled: true },
+      },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock([0, 1, 2, 3, 4, 5, 6]),
+    });
+
+    const result = await harness.runTurn(createInput());
+
+    expect(result.outcome).toBe('completed');
+    expect(result.assistantMessage?.text).toBe('Answer first.\n\nAnswer last.');
+    expect(result.assistantMessage?.text).not.toMatch(
+      /<(function_calls|invoke|parameter)\b/iu,
+    );
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.output_sanitized',
+        reason: 'pseudo_tool_syntax_removed',
+        metadata: expect.objectContaining({
+          modelId: 'openrouter/test-model',
+        }),
+      }),
+    );
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.synthesis_salvaged',
+      }),
+    );
+  });
+});

--- a/packages/harness/src/runtime-policy.integration.test.ts
+++ b/packages/harness/src/runtime-policy.integration.test.ts
@@ -314,4 +314,85 @@ describe('runtime policy integration', () => {
       }),
     );
   });
+
+  it('sanitizes approval_request summaries before emitting and returning them', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    const harness = createHarness({
+      model: {
+        nextStep: async () => ({
+          type: 'approval_request',
+          request: {
+            id: 'apr-1',
+            kind: 'tool_use',
+            summary:
+              'Please approve.\n<function_calls><invoke name="db_drop"><parameter name="table">users</parameter></invoke></function_calls>\nThanks.',
+          },
+          metadata: { modelId: 'openrouter/test-model' },
+        }),
+      },
+      runtimePolicy: {
+        outputSanitizer: { enabled: true },
+      },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock([0, 1, 2, 3, 4, 5, 6]),
+    });
+
+    const result = await harness.runTurn(createInput());
+
+    expect(result.outcome).toBe('awaiting_approval');
+    const emitted = trace.find((event) => event.type === 'approval_requested') as
+      | (HarnessTraceEvent & { request?: { summary?: string } })
+      | undefined;
+    expect(emitted?.request?.summary).toBe('Please approve.\n\nThanks.');
+    expect(emitted?.request?.summary).not.toMatch(
+      /<(function_calls|invoke|parameter)\b/iu,
+    );
+    const approvalRequest =
+      (result.metadata as { approvalRequest?: { summary?: string } } | undefined)
+        ?.approvalRequest;
+    expect(approvalRequest?.summary).toBe('Please approve.\n\nThanks.');
+    expect(approvalRequest?.summary).not.toMatch(
+      /<(function_calls|invoke|parameter)\b/iu,
+    );
+  });
+
+  it('preserves input.metadata trace correlation on runtime-policy events', async () => {
+    const trace: HarnessTraceEvent[] = [];
+    const harness = createHarness({
+      model: {
+        nextStep: async () => ({
+          type: 'final_answer',
+          text: 'Done.\n<function_calls><invoke name="x"><parameter name="y">z</parameter></invoke></function_calls>',
+          metadata: { modelId: 'openrouter/test-model' },
+        }),
+      },
+      runtimePolicy: {
+        outputSanitizer: { enabled: true },
+      },
+      trace: { emit: (event) => trace.push(event) },
+      clock: createClock([0, 1, 2, 3, 4, 5, 6]),
+    });
+
+    const result = await harness.runTurn({
+      ...createInput(),
+      metadata: {
+        parentTraceId: 'parent-trace-1',
+        childTraceId: 'child-trace-1',
+        subagentName: 'reviewer',
+      },
+    });
+
+    expect(result.outcome).toBe('completed');
+    expect(trace).toContainEqual(
+      expect.objectContaining({
+        type: 'runtime_policy.output_sanitized',
+        metadata: expect.objectContaining({
+          modelId: 'openrouter/test-model',
+          parentTraceId: 'parent-trace-1',
+          childTraceId: 'child-trace-1',
+          subagentName: 'reviewer',
+        }),
+      }),
+    );
+  });
 });

--- a/packages/harness/src/runtime-policy.test.ts
+++ b/packages/harness/src/runtime-policy.test.ts
@@ -1,0 +1,237 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { createRuntimePolicy, type HarnessToolResult } from './index.js';
+
+function makeCall(
+  name: string,
+  input: Record<string, unknown> = {},
+  id = `${name}-call`,
+) {
+  return { id, name, input };
+}
+
+describe('createRuntimePolicy', () => {
+  it('defaults to a no-op policy', () => {
+    const policy = createRuntimePolicy();
+    const decision = policy.beforeToolCall({
+      turnId: 'turn-1',
+      call: makeCall('lookup', { q: 'alpha' }),
+      tool: { name: 'lookup', description: 'Lookup' },
+      toolCallCount: 0,
+      maxToolCalls: 8,
+    });
+
+    expect(decision).toEqual({ action: 'allow', consumeToolCall: true });
+    expect(
+      policy.sanitizeFinalOutput({
+        turnId: 'turn-1',
+        text: 'plain final answer',
+      }),
+    ).toMatchObject({
+      text: 'plain final answer',
+      sanitized: false,
+      strippedTokenClasses: [],
+      events: [],
+    });
+  });
+
+  it('returns cached results without consuming logical budget', () => {
+    const policy = createRuntimePolicy({
+      toolResultCache: { enabled: true },
+    });
+    const call = makeCall('workspace_list', { path: '/repo', depth: 2 });
+    const result: HarnessToolResult = {
+      callId: call.id,
+      toolName: call.name,
+      status: 'success',
+      output: '["package.json"]',
+    };
+
+    expect(
+      policy.beforeToolCall({
+        turnId: 'turn-1',
+        call,
+        tool: { name: call.name, description: 'List workspace' },
+        toolCallCount: 0,
+        maxToolCalls: 8,
+      }),
+    ).toMatchObject({ action: 'allow', consumeToolCall: true });
+
+    policy.afterToolResult({
+      turnId: 'turn-1',
+      call,
+      tool: { name: call.name, description: 'List workspace' },
+      result,
+    });
+
+    const duplicate = policy.beforeToolCall({
+      turnId: 'turn-1',
+      call: makeCall('workspace_list', { depth: 2, path: '/repo' }, 'dup-call'),
+      tool: { name: call.name, description: 'List workspace' },
+      toolCallCount: 1,
+      maxToolCalls: 8,
+    });
+
+    expect(duplicate).toMatchObject({
+      action: 'cached',
+      consumeToolCall: false,
+      result: {
+        callId: 'dup-call',
+        toolName: 'workspace_list',
+        output: '["package.json"]',
+        metadata: {
+          runtimePolicy: {
+            synthetic: true,
+            cacheHit: true,
+          },
+        },
+      },
+      events: [
+        expect.objectContaining({
+          kind: 'runtime_policy.cache_hit',
+          reason: 'duplicate_tool_call_cached',
+        }),
+      ],
+    });
+  });
+
+  it('blocks repeated broad listing until the model drills into a candidate', () => {
+    const policy = createRuntimePolicy({
+      drillOrStop: {
+        candidateProducingTools: ['repo_list'],
+        broadTools: ['repo_list'],
+      },
+    });
+
+    policy.afterToolResult({
+      turnId: 'turn-1',
+      call: makeCall('repo_list', { path: '/repo' }),
+      tool: { name: 'repo_list', description: 'List repo', metadata: { runtimePolicyCategories: ['broad'] } },
+      result: {
+        callId: 'list-1',
+        toolName: 'repo_list',
+        status: 'success',
+        structuredOutput: {
+          candidates: [{ path: 'package.json' }, { path: 'src/index.ts' }],
+        },
+      },
+    });
+
+    const blocked = policy.beforeToolCall({
+      turnId: 'turn-1',
+      call: makeCall('repo_list', { path: '/repo' }, 'list-2'),
+      tool: { name: 'repo_list', description: 'List repo', metadata: { runtimePolicyCategories: ['broad'] } },
+      toolCallCount: 1,
+      maxToolCalls: 8,
+    });
+    expect(blocked).toMatchObject({
+      action: 'blocked',
+      consumeToolCall: false,
+      events: [
+        expect.objectContaining({
+          kind: 'runtime_policy.blocked',
+          reason: 'drill_or_stop_required',
+        }),
+      ],
+    });
+
+    const drilled = policy.beforeToolCall({
+      turnId: 'turn-1',
+      call: makeCall('repo_read', { path: 'package.json' }, 'read-1'),
+      tool: { name: 'repo_read', description: 'Read repo file' },
+      toolCallCount: 1,
+      maxToolCalls: 8,
+    });
+    expect(drilled).toEqual({ action: 'allow', consumeToolCall: true });
+  });
+
+  it('strips nested pseudo-tool XML and fenced pseudo-tool payloads', () => {
+    const policy = createRuntimePolicy({
+      outputSanitizer: { enabled: true },
+    });
+
+    const sanitized = policy.sanitizeFinalOutput({
+      turnId: 'turn-1',
+      modelId: 'model-1',
+      text: [
+        'Before',
+        '<function_calls><invoke name="workspace_list"><parameter name="path">/repo</parameter></invoke></function_calls>',
+        '```xml',
+        '<invoke name="workspace_read"><parameter name="path">package.json</parameter></invoke>',
+        '```',
+        'After',
+      ].join('\n'),
+    });
+
+    expect(sanitized.text).toBe('Before\n\nAfter');
+    expect(sanitized.sanitized).toBe(true);
+    expect(sanitized.strippedTokenClasses).toEqual(
+      expect.arrayContaining(['function_calls', 'invoke', 'parameter', 'pseudo_tool_fence']),
+    );
+    expect(sanitized.events).toEqual([
+      expect.objectContaining({
+        kind: 'runtime_policy.output_sanitized',
+        reason: 'pseudo_tool_syntax_removed',
+        metadata: expect.objectContaining({
+          modelId: 'model-1',
+        }),
+      }),
+    ]);
+  });
+
+  it('supports a generic custom guard hook for future deep-repo funnel rules', () => {
+    const policy = createRuntimePolicy({
+      customGuards: [
+        {
+          name: 'deep_repo_funnel',
+          evaluate(input) {
+            if (input.call.name !== 'repo_traverse') return null;
+            return {
+              advisory: 'Use the repo architecture summary first, then drill into one or two files.',
+              reason: 'deep_repo_funnel',
+              metadata: { repo: 'AgentWorkforce/relaycast' },
+            };
+          },
+        },
+      ],
+    });
+
+    const decision = policy.beforeToolCall({
+      turnId: 'turn-1',
+      call: makeCall('repo_traverse', { repo: 'AgentWorkforce/relaycast', recursive: true }),
+      tool: { name: 'repo_traverse', description: 'Traverse repo' },
+      toolCallCount: 0,
+      maxToolCalls: 8,
+    });
+
+    expect(decision).toMatchObject({
+      action: 'blocked',
+      consumeToolCall: false,
+      result: {
+        output: 'Use the repo architecture summary first, then drill into one or two files.',
+      },
+      events: [
+        expect.objectContaining({
+          kind: 'runtime_policy.blocked',
+          reason: 'deep_repo_funnel',
+          metadata: expect.objectContaining({
+            repo: 'AgentWorkforce/relaycast',
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('does not capture bare fetch in runtime-policy modules', () => {
+    const runtimePolicySource = readFileSync(
+      resolve(fileURLToPath(new URL('runtime-policy', import.meta.url)), 'index.ts'),
+      'utf8',
+    );
+
+    expect(runtimePolicySource).not.toMatch(/=\s*fetch\b/u);
+    expect(runtimePolicySource).not.toMatch(/\?\?\s*fetch\b/u);
+  });
+});

--- a/packages/harness/src/runtime-policy.test.ts
+++ b/packages/harness/src/runtime-policy.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { createRuntimePolicy, type HarnessToolResult } from './index.js';
+import { createRuntimePolicy, type HarnessToolResult } from './runtime-policy/index.js';
 
 function makeCall(
   name: string,

--- a/packages/harness/src/runtime-policy/index.ts
+++ b/packages/harness/src/runtime-policy/index.ts
@@ -1,0 +1,626 @@
+import type {
+  HarnessRuntimePolicy,
+  HarnessRuntimePolicyConfig,
+  HarnessRuntimePolicyDecision,
+  HarnessRuntimePolicyEvent,
+  HarnessRuntimePolicyGuardDecision,
+  HarnessRuntimePolicySanitizeResult,
+  HarnessToolCall,
+  HarnessToolDefinition,
+  HarnessToolResult,
+} from '../types.js';
+export type {
+  HarnessRuntimePolicy,
+  HarnessRuntimePolicyConfig,
+  HarnessRuntimePolicyDecision,
+  HarnessRuntimePolicyEvent,
+  HarnessRuntimePolicyEventKind,
+  HarnessRuntimePolicyGuard,
+  HarnessRuntimePolicyGuardDecision,
+  HarnessRuntimePolicyGuardInput,
+  HarnessRuntimePolicySanitizeResult,
+} from '../types.js';
+
+interface CachedToolResult {
+  result: HarnessToolResult;
+}
+
+interface TurnPolicyState {
+  todoWrites: number;
+  cache: Map<string, CachedToolResult>;
+  pendingCandidates: string[];
+  blockedCalls: number;
+  cacheHits: number;
+  todoRewriteBlocks: number;
+  sanitizerHits: number;
+}
+
+const CODE_FENCE_RE = /```[^\n]*\n[\s\S]*?```/gu;
+const PSEUDO_TOOL_TAG_RE = /<\/?(function_calls|invoke|parameter)\b[^>]*>/giu;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeStable(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeStable(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.keys(value)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = normalizeStable(value[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeStable(value));
+}
+
+function normalizePositiveInteger(value: number | undefined): number {
+  if (!Number.isInteger(value) || value === undefined || value < 0) {
+    return 0;
+  }
+  return value;
+}
+
+function toolNamesSet(names: readonly string[] | undefined): Set<string> {
+  return new Set((names ?? []).filter((name) => typeof name === 'string' && name.length > 0));
+}
+
+function categoriesFor(
+  config: HarnessRuntimePolicyConfig['reserveFloor'],
+  tool: HarnessToolDefinition | undefined,
+  call: HarnessToolCall,
+): string[] {
+  const configured = config?.getCategories?.(tool, call);
+  if (configured && configured.length > 0) {
+    return [...configured];
+  }
+
+  const raw = tool?.metadata?.runtimePolicyCategories ?? tool?.metadata?.categories;
+  if (typeof raw === 'string' && raw.length > 0) {
+    return [raw];
+  }
+  if (Array.isArray(raw)) {
+    return raw.filter((item): item is string => typeof item === 'string' && item.length > 0);
+  }
+  return [];
+}
+
+function defaultExtractCandidates(result: HarnessToolResult): string[] {
+  const structured = result.structuredOutput;
+  if (!isRecord(structured)) {
+    return [];
+  }
+
+  const rawCandidates =
+    structured.candidates ??
+    structured.paths ??
+    structured.ids ??
+    structured.items;
+
+  if (!Array.isArray(rawCandidates)) {
+    return [];
+  }
+
+  return rawCandidates
+    .map((candidate) => {
+      if (typeof candidate === 'string') {
+        return candidate.trim();
+      }
+      if (isRecord(candidate)) {
+        const id = candidate.id;
+        if (typeof id === 'string' && id.trim().length > 0) return id.trim();
+        const path = candidate.path;
+        if (typeof path === 'string' && path.trim().length > 0) return path.trim();
+      }
+      return '';
+    })
+    .filter((candidate) => candidate.length > 0);
+}
+
+function defaultIsDrilldown(call: HarnessToolCall, pendingCandidates: readonly string[]): boolean {
+  const serialized = stableStringify(call.input ?? {});
+  return pendingCandidates.some((candidate) => candidate.length > 0 && serialized.includes(candidate));
+}
+
+function createTurnState(): TurnPolicyState {
+  return {
+    todoWrites: 0,
+    cache: new Map(),
+    pendingCandidates: [],
+    blockedCalls: 0,
+    cacheHits: 0,
+    todoRewriteBlocks: 0,
+    sanitizerHits: 0,
+  };
+}
+
+function runtimePolicyMetadata(
+  extra: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    runtimePolicy: {
+      synthetic: true,
+      ...extra,
+    },
+  };
+}
+
+function advisoryResult(
+  call: HarnessToolCall,
+  advisory: string,
+  metadata: Record<string, unknown>,
+  structuredOutput?: Record<string, unknown>,
+): HarnessToolResult {
+  return {
+    callId: call.id,
+    toolName: call.name,
+    status: 'success',
+    output: advisory,
+    structuredOutput,
+    metadata: runtimePolicyMetadata(metadata),
+  };
+}
+
+function cloneCachedResult(
+  call: HarnessToolCall,
+  cached: HarnessToolResult,
+): HarnessToolResult {
+  return {
+    ...cached,
+    callId: call.id,
+    metadata: {
+      ...(cached.metadata ?? {}),
+      ...runtimePolicyMetadata({
+        cacheHit: true,
+        source: 'turn_cache',
+      }),
+    },
+  };
+}
+
+function buildBlockedDecision(
+  turnId: string,
+  call: HarnessToolCall,
+  reason: string,
+  advisory: string,
+  metadata: Record<string, unknown>,
+  structuredOutput?: Record<string, unknown>,
+): HarnessRuntimePolicyDecision {
+  return {
+    action: 'blocked',
+    consumeToolCall: false,
+    result: advisoryResult(call, advisory, { blocked: true, reason, ...metadata }, structuredOutput),
+    events: [
+      {
+        kind: 'runtime_policy.blocked',
+        turnId,
+        toolName: call.name,
+        reason,
+        metadata,
+      },
+    ],
+  };
+}
+
+function buildGuardDecision(
+  turnId: string,
+  call: HarnessToolCall,
+  guardName: string,
+  decision: HarnessRuntimePolicyGuardDecision,
+): HarnessRuntimePolicyDecision {
+  return buildBlockedDecision(
+    turnId,
+    call,
+    decision.reason ?? guardName,
+    decision.advisory,
+    {
+      guard: guardName,
+      ...(decision.metadata ?? {}),
+    },
+    decision.structuredOutput,
+  );
+}
+
+function buildCacheKey(
+  normalize: ((toolName: string, input: unknown) => string) | undefined,
+  toolName: string,
+  input: unknown,
+): string {
+  const normalized = normalize?.(toolName, input) ?? stableStringify(input ?? {});
+  return `${toolName}::${normalized}`;
+}
+
+function sanitizePseudoToolBlocks(text: string): {
+  text: string;
+  strippedTokenClasses: string[];
+} {
+  const stripped = new Set<string>();
+  let sanitized = text;
+  let changed = false;
+
+  sanitized = sanitized.replace(CODE_FENCE_RE, (block) => {
+    const inner = block.replace(/^```[^\n]*\n?/u, '').replace(/```$/u, '');
+    PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+    if (!PSEUDO_TOOL_TAG_RE.test(inner)) {
+      PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+      return block;
+    }
+    PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+    changed = true;
+    stripped.add('pseudo_tool_fence');
+    return '';
+  });
+
+  const withoutNestedBlocks = stripNestedPseudoToolBlocks(sanitized, stripped);
+  changed = changed || withoutNestedBlocks !== sanitized;
+  sanitized = withoutNestedBlocks;
+
+  if (!changed) {
+    return { text, strippedTokenClasses: [] };
+  }
+
+  const compacted = sanitized.replace(/\n{3,}/gu, '\n\n').trim();
+  return {
+    text: compacted.length > 0 ? compacted : 'I removed raw tool syntax from the draft. Summarize the evidence in plain language.',
+    strippedTokenClasses: [...stripped],
+  };
+}
+
+function stripNestedPseudoToolBlocks(text: string, stripped: Set<string>): string {
+  let cursor = 0;
+  let output = '';
+
+  while (cursor < text.length) {
+    PSEUDO_TOOL_TAG_RE.lastIndex = cursor;
+    const match = PSEUDO_TOOL_TAG_RE.exec(text);
+    if (!match) {
+      output += text.slice(cursor);
+      break;
+    }
+
+    const [rawTag, tokenClass] = match;
+    const tagStart = match.index;
+    const isClosingTag = rawTag.startsWith('</');
+
+    if (isClosingTag) {
+      output += text.slice(cursor, PSEUDO_TOOL_TAG_RE.lastIndex);
+      cursor = PSEUDO_TOOL_TAG_RE.lastIndex;
+      continue;
+    }
+
+    const blockEnd = findPseudoToolBlockEnd(text, PSEUDO_TOOL_TAG_RE.lastIndex, stripped);
+    if (blockEnd === -1) {
+      output += text.slice(cursor, PSEUDO_TOOL_TAG_RE.lastIndex);
+      cursor = PSEUDO_TOOL_TAG_RE.lastIndex;
+      continue;
+    }
+
+    stripped.add(String(tokenClass));
+    output += text.slice(cursor, tagStart);
+    cursor = blockEnd;
+  }
+
+  PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+  return output;
+}
+
+function findPseudoToolBlockEnd(
+  text: string,
+  cursor: number,
+  stripped: Set<string>,
+): number {
+  let depth = 1;
+
+  while (cursor < text.length) {
+    PSEUDO_TOOL_TAG_RE.lastIndex = cursor;
+    const match = PSEUDO_TOOL_TAG_RE.exec(text);
+    if (!match) {
+      PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+      return -1;
+    }
+
+    const [rawTag, tokenClass] = match;
+    stripped.add(String(tokenClass));
+    depth += rawTag.startsWith('</') ? -1 : 1;
+    cursor = PSEUDO_TOOL_TAG_RE.lastIndex;
+    if (depth === 0) {
+      PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+      return cursor;
+    }
+  }
+
+  PSEUDO_TOOL_TAG_RE.lastIndex = 0;
+  return -1;
+}
+
+export function createRuntimePolicy(
+  config: HarnessRuntimePolicyConfig = {},
+): HarnessRuntimePolicy {
+  const todoToolNames = toolNamesSet(config.todoRewriteCap?.toolNames);
+  const candidateToolNames = toolNamesSet(config.drillOrStop?.candidateProducingTools);
+  const broadToolNames = toolNamesSet(config.drillOrStop?.broadTools);
+  const blockedCategories = new Set(config.reserveFloor?.blockedCategories ?? []);
+  const cacheEnabled = config.toolResultCache?.enabled === true;
+  const todoMax = normalizePositiveInteger(config.todoRewriteCap?.max);
+  const reserveFloor = normalizePositiveInteger(config.reserveFloor?.floor);
+  const turns = new Map<string, TurnPolicyState>();
+
+  function stateFor(turnId: string): TurnPolicyState {
+    const existing = turns.get(turnId);
+    if (existing) return existing;
+    const created = createTurnState();
+    turns.set(turnId, created);
+    return created;
+  }
+
+  return {
+    wrapTool(tool) {
+      return tool;
+    },
+
+    beforeToolCall(input) {
+      const state = stateFor(input.turnId);
+
+      if (todoMax > 0 && todoToolNames.has(input.call.name)) {
+        state.todoWrites += 1;
+        if (state.todoWrites > todoMax) {
+          state.blockedCalls += 1;
+          state.todoRewriteBlocks += 1;
+          return {
+            action: 'blocked',
+            consumeToolCall: false,
+            result: advisoryResult(
+              input.call,
+              'Todo plan unchanged. Continue with the existing plan unless new evidence or a user redirect requires a rewrite.',
+              {
+                blocked: true,
+                code: 'todo_rewrite_cap_reached',
+                noop: true,
+                writesAccepted: todoMax,
+              },
+              {
+                ok: true,
+                noop: true,
+                reason: 'todo_rewrite_cap_reached',
+              },
+            ),
+            events: [
+              {
+                kind: 'runtime_policy.todo_rewrite_blocked',
+                turnId: input.turnId,
+                toolName: input.call.name,
+                reason: 'todo_rewrite_cap_reached',
+                metadata: {
+                  max: todoMax,
+                  attemptedWrite: state.todoWrites,
+                },
+              },
+            ],
+          };
+        }
+      }
+
+      const remainingToolCalls = Math.max(0, input.maxToolCalls - input.toolCallCount);
+      for (const guard of config.customGuards ?? []) {
+        const decision = guard.evaluate({
+          turnId: input.turnId,
+          call: input.call,
+          tool: input.tool,
+          toolCallCount: input.toolCallCount,
+          maxToolCalls: input.maxToolCalls,
+          remainingToolCalls,
+        });
+        if (decision) {
+          state.blockedCalls += 1;
+          return buildGuardDecision(input.turnId, input.call, guard.name, decision);
+        }
+      }
+
+      const categories = categoriesFor(config.reserveFloor, input.tool, input.call);
+      if (
+        reserveFloor > 0 &&
+        remainingToolCalls <= reserveFloor &&
+        categories.some((category) => blockedCategories.has(category))
+      ) {
+        state.blockedCalls += 1;
+        return buildBlockedDecision(
+          input.turnId,
+          input.call,
+          'reserve_floor_reached',
+          'The turn is at its reserved synthesis budget. Synthesize from existing evidence or ask one targeted clarifying question.',
+          {
+            floor: reserveFloor,
+            remainingToolCalls,
+            categories,
+          },
+          {
+            ok: true,
+            blocked: true,
+            reason: 'reserve_floor_reached',
+          },
+        );
+      }
+
+      if (state.pendingCandidates.length > 0) {
+        const isDrilldown =
+          config.drillOrStop?.isDrilldown?.({
+            call: input.call,
+            tool: input.tool,
+            pendingCandidates: state.pendingCandidates,
+          }) ?? defaultIsDrilldown(input.call, state.pendingCandidates);
+
+        if (isDrilldown) {
+          state.pendingCandidates = [];
+        } else if (broadToolNames.has(input.call.name)) {
+          state.blockedCalls += 1;
+          return buildBlockedDecision(
+            input.turnId,
+            input.call,
+            'drill_or_stop_required',
+            'Drill into one of the concrete candidates you already have, delegate a bounded follow-up with those candidates, or answer with the evidence already gathered.',
+            {
+              pendingCandidateCount: state.pendingCandidates.length,
+            },
+            {
+              ok: true,
+              blocked: true,
+              reason: 'drill_or_stop_required',
+            },
+          );
+        }
+      }
+
+      if (cacheEnabled) {
+        const cacheKey = buildCacheKey(
+          config.toolResultCache?.normalize,
+          input.call.name,
+          input.call.input,
+        );
+        const cached = state.cache.get(cacheKey);
+        if (cached) {
+          state.cacheHits += 1;
+          return {
+            action: 'cached',
+            consumeToolCall: false,
+            result: cloneCachedResult(input.call, cached.result),
+            events: [
+              {
+                kind: 'runtime_policy.cache_hit',
+                turnId: input.turnId,
+                toolName: input.call.name,
+                reason: 'duplicate_tool_call_cached',
+                metadata: {
+                  cached: true,
+                },
+              },
+            ],
+          };
+        }
+      }
+
+      return {
+        action: 'allow',
+        consumeToolCall: true,
+      };
+    },
+
+    afterToolResult(input) {
+      const state = stateFor(input.turnId);
+      const events: HarnessRuntimePolicyEvent[] = [];
+
+      if (input.result.status !== 'success') {
+        return events;
+      }
+
+      const runtimePolicyMeta = input.result.metadata?.runtimePolicy;
+      if (isRecord(runtimePolicyMeta) && runtimePolicyMeta.synthetic === true) {
+        return events;
+      }
+
+      if (cacheEnabled) {
+        const cacheKey = buildCacheKey(
+          config.toolResultCache?.normalize,
+          input.call.name,
+          input.call.input,
+        );
+        state.cache.set(cacheKey, {
+          result: {
+            ...input.result,
+            metadata: { ...(input.result.metadata ?? {}) },
+          },
+        });
+      }
+
+      if (candidateToolNames.has(input.call.name)) {
+        const candidates =
+          config.drillOrStop?.extractCandidates?.({
+            call: input.call,
+            result: input.result,
+            tool: input.tool,
+          }) ?? defaultExtractCandidates(input.result);
+        state.pendingCandidates = [...candidates];
+      }
+
+      return events;
+    },
+
+    sanitizeFinalOutput(input): HarnessRuntimePolicySanitizeResult {
+      if (config.outputSanitizer?.enabled !== true) {
+        return {
+          text: input.text,
+          sanitized: false,
+          strippedTokenClasses: [],
+          events: [],
+        };
+      }
+
+      const state = stateFor(input.turnId);
+      const sanitized = sanitizePseudoToolBlocks(input.text);
+      if (sanitized.strippedTokenClasses.length === 0) {
+        return {
+          text: input.text,
+          sanitized: false,
+          strippedTokenClasses: [],
+          events: [],
+        };
+      }
+
+      state.sanitizerHits += 1;
+      return {
+        text: sanitized.text,
+        sanitized: true,
+        strippedTokenClasses: sanitized.strippedTokenClasses,
+        events: [
+          {
+            kind: 'runtime_policy.output_sanitized',
+            turnId: input.turnId,
+            reason: 'pseudo_tool_syntax_removed',
+            metadata: {
+              modelId: input.modelId,
+              strippedTokenClasses: sanitized.strippedTokenClasses,
+            },
+          },
+        ],
+      };
+    },
+
+    finalizeTurn(input) {
+      const state = stateFor(input.turnId);
+      if (
+        !['completed', 'needs_clarification'].includes(input.outcome) ||
+        state.blockedCalls + state.todoRewriteBlocks + state.sanitizerHits === 0
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          kind: 'runtime_policy.synthesis_salvaged',
+          turnId: input.turnId,
+          reason: 'completed_after_runtime_policy_intervention',
+          metadata: {
+            outcome: input.outcome,
+            stopReason: input.stopReason,
+            blockedCalls: state.blockedCalls,
+            todoRewriteBlocks: state.todoRewriteBlocks,
+            cacheHits: state.cacheHits,
+            sanitizerHits: state.sanitizerHits,
+          },
+        },
+      ];
+    },
+
+    reset(turnId) {
+      turns.delete(turnId);
+    },
+  };
+}

--- a/packages/harness/src/types.ts
+++ b/packages/harness/src/types.ts
@@ -66,6 +66,7 @@ export interface HarnessConfig {
    * error and the existing tool-error handling kicks in.
    */
   toolRetryConfig?: HarnessToolRetryConfig;
+  runtimePolicy?: HarnessRuntimePolicy | HarnessRuntimePolicyConfig;
 }
 
 export interface HarnessToolRetryConfig {
@@ -521,7 +522,12 @@ export type HarnessTraceEvent =
   | HarnessToolRetriedEvent
   | HarnessClarificationEvent
   | HarnessApprovalEvent
-  | HarnessLimitReachedEvent;
+  | HarnessLimitReachedEvent
+  | HarnessRuntimePolicyBlockedTraceEvent
+  | HarnessRuntimePolicyCacheHitTraceEvent
+  | HarnessRuntimePolicyTodoRewriteBlockedTraceEvent
+  | HarnessRuntimePolicyOutputSanitizedTraceEvent
+  | HarnessRuntimePolicySynthesisSalvagedTraceEvent;
 
 export interface HarnessBaseTraceEvent {
   type: string;
@@ -613,6 +619,158 @@ export interface HarnessLimitReachedEvent extends HarnessBaseTraceEvent {
     | 'redundant_tool_loop'
     | 'timeout_reached'
     | 'budget_reached';
+}
+
+export interface HarnessRuntimePolicyTraceEvent extends HarnessBaseTraceEvent {
+  reason: string;
+  toolName?: string;
+}
+
+export interface HarnessRuntimePolicyBlockedTraceEvent
+  extends HarnessRuntimePolicyTraceEvent {
+  type: 'runtime_policy.blocked';
+}
+
+export interface HarnessRuntimePolicyCacheHitTraceEvent
+  extends HarnessRuntimePolicyTraceEvent {
+  type: 'runtime_policy.cache_hit';
+}
+
+export interface HarnessRuntimePolicyTodoRewriteBlockedTraceEvent
+  extends HarnessRuntimePolicyTraceEvent {
+  type: 'runtime_policy.todo_rewrite_blocked';
+}
+
+export interface HarnessRuntimePolicyOutputSanitizedTraceEvent
+  extends HarnessRuntimePolicyTraceEvent {
+  type: 'runtime_policy.output_sanitized';
+}
+
+export interface HarnessRuntimePolicySynthesisSalvagedTraceEvent
+  extends HarnessRuntimePolicyTraceEvent {
+  type: 'runtime_policy.synthesis_salvaged';
+}
+
+export interface HarnessRuntimePolicyConfig {
+  todoRewriteCap?: {
+    toolNames: string[];
+    max: number;
+  };
+  toolResultCache?: {
+    enabled: boolean;
+    normalize?: (toolName: string, input: unknown) => string;
+  };
+  reserveFloor?: {
+    floor: number;
+    blockedCategories: readonly string[];
+    getCategories?: (
+      tool: HarnessToolDefinition | undefined,
+      call: HarnessToolCall,
+    ) => readonly string[];
+  };
+  drillOrStop?: {
+    candidateProducingTools: readonly string[];
+    broadTools: readonly string[];
+    extractCandidates?: (input: {
+      call: HarnessToolCall;
+      result: HarnessToolResult;
+      tool: HarnessToolDefinition | undefined;
+    }) => readonly string[];
+    isDrilldown?: (input: {
+      call: HarnessToolCall;
+      tool: HarnessToolDefinition | undefined;
+      pendingCandidates: readonly string[];
+    }) => boolean;
+  };
+  customGuards?: readonly HarnessRuntimePolicyGuard[];
+  outputSanitizer?: {
+    enabled: boolean;
+  };
+}
+
+export interface HarnessRuntimePolicyGuard {
+  name: string;
+  evaluate(input: HarnessRuntimePolicyGuardInput): HarnessRuntimePolicyGuardDecision | null;
+}
+
+export interface HarnessRuntimePolicyGuardInput {
+  turnId: string;
+  call: HarnessToolCall;
+  tool: HarnessToolDefinition | undefined;
+  toolCallCount: number;
+  maxToolCalls: number;
+  remainingToolCalls: number;
+}
+
+export interface HarnessRuntimePolicyGuardDecision {
+  advisory: string;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+  structuredOutput?: Record<string, unknown>;
+  countsAgainstBudget?: boolean;
+}
+
+export type HarnessRuntimePolicyEventKind =
+  | 'runtime_policy.blocked'
+  | 'runtime_policy.cache_hit'
+  | 'runtime_policy.todo_rewrite_blocked'
+  | 'runtime_policy.output_sanitized'
+  | 'runtime_policy.synthesis_salvaged';
+
+export interface HarnessRuntimePolicyEvent {
+  kind: HarnessRuntimePolicyEventKind;
+  turnId: string;
+  toolName?: string;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type HarnessRuntimePolicyDecision =
+  | {
+      action: 'allow';
+      consumeToolCall: true;
+      events?: HarnessRuntimePolicyEvent[];
+    }
+  | {
+      action: 'cached' | 'blocked';
+      consumeToolCall: boolean;
+      result: HarnessToolResult;
+      events: HarnessRuntimePolicyEvent[];
+    };
+
+export interface HarnessRuntimePolicySanitizeResult {
+  text: string;
+  sanitized: boolean;
+  strippedTokenClasses: string[];
+  events: HarnessRuntimePolicyEvent[];
+}
+
+export interface HarnessRuntimePolicy {
+  wrapTool(tool: HarnessToolDefinition): HarnessToolDefinition;
+  beforeToolCall(input: {
+    turnId: string;
+    call: HarnessToolCall;
+    tool: HarnessToolDefinition | undefined;
+    toolCallCount: number;
+    maxToolCalls: number;
+  }): HarnessRuntimePolicyDecision;
+  afterToolResult(input: {
+    turnId: string;
+    call: HarnessToolCall;
+    tool: HarnessToolDefinition | undefined;
+    result: HarnessToolResult;
+  }): HarnessRuntimePolicyEvent[];
+  sanitizeFinalOutput(input: {
+    turnId: string;
+    text: string;
+    modelId?: string;
+  }): HarnessRuntimePolicySanitizeResult;
+  finalizeTurn(input: {
+    turnId: string;
+    outcome: HarnessOutcome;
+    stopReason: HarnessStopReason;
+  }): HarnessRuntimePolicyEvent[];
+  reset(turnId: string): void;
 }
 
 export interface HarnessHooks {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -25,6 +25,10 @@
     "./bridge": {
       "import": "./dist/harness-bridge.js",
       "types": "./dist/harness-bridge.d.ts"
+    },
+    "./evals": {
+      "import": "./dist/evals/index.js",
+      "types": "./dist/evals/index.d.ts"
     }
   },
   "files": [

--- a/packages/telemetry/src/evals/eval-checks.ts
+++ b/packages/telemetry/src/evals/eval-checks.ts
@@ -1,0 +1,115 @@
+const REGEX_LITERAL_PATTERN = /^\/(.+)\/([a-z]*)$/u;
+
+export interface EvalEvidenceResult {
+  matched: string[];
+  missing: string[];
+}
+
+export interface EvalForbiddenFanoutLimit {
+  toolName: string;
+  max: number;
+}
+
+export interface EvalBudgetCheck {
+  maxToolCalls: number;
+  maxLatencyMs: number;
+}
+
+export interface EvalBudgetSnapshot {
+  toolCalls: number;
+  latencyMs: number;
+}
+
+export interface EvalFinalOutputCheckResult {
+  clean: boolean;
+  sanitizedKinds: string[];
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right, 'en');
+}
+
+function patternToMatcher(pattern: string): (text: string) => boolean {
+  const regexMatch = REGEX_LITERAL_PATTERN.exec(pattern);
+
+  if (regexMatch === null) {
+    return (text) => text.includes(pattern);
+  }
+
+  const source = regexMatch[1] ?? '';
+  const flags = regexMatch[2] ?? '';
+  const regex = new RegExp(source, flags);
+  return (text) => regex.test(text);
+}
+
+export function evaluateRequiredEvidence(
+  finalOutput: string,
+  requiredEvidence: readonly string[] | undefined,
+): EvalEvidenceResult {
+  if (requiredEvidence === undefined || requiredEvidence.length === 0) {
+    return { matched: [], missing: [] };
+  }
+
+  const matched: string[] = [];
+  const missing: string[] = [];
+
+  for (const pattern of requiredEvidence) {
+    const matcher = patternToMatcher(pattern);
+    if (matcher(finalOutput)) {
+      matched.push(pattern);
+    } else {
+      missing.push(pattern);
+    }
+  }
+
+  return {
+    matched: [...matched].sort(compareStrings),
+    missing: [...missing].sort(compareStrings),
+  };
+}
+
+export function evaluateForbiddenFanout(
+  toolCalls: readonly { toolName: string }[],
+  limits: readonly EvalForbiddenFanoutLimit[] | undefined,
+): string[] {
+  if (limits === undefined || limits.length === 0) {
+    return [];
+  }
+
+  const callCountByTool = new Map<string, number>();
+  for (const toolCall of toolCalls) {
+    callCountByTool.set(toolCall.toolName, (callCountByTool.get(toolCall.toolName) ?? 0) + 1);
+  }
+
+  const violations: string[] = [];
+  for (const limit of limits) {
+    const observed = callCountByTool.get(limit.toolName) ?? 0;
+    if (observed > limit.max) {
+      violations.push(
+        `${limit.toolName} called ${observed} times (max ${limit.max})`,
+      );
+    }
+  }
+
+  return violations.sort(compareStrings);
+}
+
+export function evaluateBudget(
+  budget: EvalBudgetSnapshot,
+  limit: EvalBudgetCheck | undefined,
+): boolean {
+  if (limit === undefined) {
+    return true;
+  }
+
+  return budget.toolCalls <= limit.maxToolCalls && budget.latencyMs <= limit.maxLatencyMs;
+}
+
+export function evaluateFinalOutputClean(
+  sanitizedKinds: readonly string[],
+): EvalFinalOutputCheckResult {
+  return {
+    clean: sanitizedKinds.length === 0,
+    sanitizedKinds: [...sanitizedKinds].sort(compareStrings),
+  };
+}

--- a/packages/telemetry/src/evals/eval-runner.ts
+++ b/packages/telemetry/src/evals/eval-runner.ts
@@ -1,0 +1,245 @@
+import {
+  evaluateBudget,
+  evaluateFinalOutputClean,
+  evaluateForbiddenFanout,
+  evaluateRequiredEvidence,
+  type EvalBudgetCheck,
+  type EvalForbiddenFanoutLimit,
+} from './eval-checks.js';
+
+export interface ProviderFixture {
+  outputText: string;
+  modelId?: string;
+  latencyMs?: number;
+  cost?: number;
+}
+
+export interface ToolFixture {
+  name: string;
+  input?: unknown;
+  outputText: string;
+  latencyMs?: number;
+  cost?: number;
+}
+
+export interface EvalCase {
+  name: string;
+  fixture: { providerResponses: ProviderFixture[]; tools: ToolFixture[] };
+  checks: {
+    requiredEvidence?: string[];
+    forbiddenFanout?: EvalForbiddenFanoutLimit[];
+    budget?: EvalBudgetCheck;
+    finalOutputClean?: boolean;
+  };
+}
+
+export interface EvalToolCallRecord {
+  toolName: string;
+  latencyMs?: number;
+  cost?: number;
+}
+
+export interface EvalTurnRunnerInput {
+  caseName: string;
+  fixture: EvalCase['fixture'];
+}
+
+export interface EvalTurnRunResult {
+  finalOutput: string;
+  toolCalls?: EvalToolCallRecord[];
+  latencyMs?: number;
+  cost?: number;
+  sanitizedKinds?: string[];
+}
+
+export type EvalTurnRunner = (input: EvalTurnRunnerInput) => Promise<EvalTurnRunResult>;
+
+export interface EvalResult {
+  name: string;
+  passed: boolean;
+  score: { components: Record<string, number>; total: number };
+  evidence: { matched: string[]; missing: string[] };
+  forbiddenFanoutViolations: string[];
+  budget: { toolCalls: number; latencyMs: number; cost?: number };
+  finalOutputCleanResult: { clean: boolean; sanitizedKinds: string[] };
+}
+
+const SCORE_COMPONENT_KEYS = [
+  'requiredEvidence',
+  'forbiddenFanout',
+  'budget',
+  'finalOutputClean',
+] as const;
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right, 'en');
+}
+
+function sumDefinedNumbers(values: readonly (number | undefined)[]): number {
+  return values.reduce<number>((sum, value) => sum + (value ?? 0), 0);
+}
+
+function deriveToolCalls(fixture: EvalCase['fixture'], run: EvalTurnRunResult): EvalToolCallRecord[] {
+  if (run.toolCalls !== undefined) {
+    return run.toolCalls.map((toolCall) => ({
+      toolName: toolCall.toolName,
+      latencyMs: toolCall.latencyMs,
+      cost: toolCall.cost,
+    }));
+  }
+
+  return fixture.tools.map((tool) => ({
+    toolName: tool.name,
+    latencyMs: tool.latencyMs,
+    cost: tool.cost,
+  }));
+}
+
+function deriveLatencyMs(fixture: EvalCase['fixture'], run: EvalTurnRunResult): number {
+  if (run.latencyMs !== undefined) {
+    return run.latencyMs;
+  }
+
+  return (
+    sumDefinedNumbers(fixture.providerResponses.map((response) => response.latencyMs)) +
+    sumDefinedNumbers(fixture.tools.map((tool) => tool.latencyMs))
+  );
+}
+
+function deriveCost(fixture: EvalCase['fixture'], run: EvalTurnRunResult, toolCalls: readonly EvalToolCallRecord[]): number {
+  if (run.cost !== undefined) {
+    return run.cost;
+  }
+
+  return (
+    sumDefinedNumbers(fixture.providerResponses.map((response) => response.cost)) +
+    sumDefinedNumbers(toolCalls.map((toolCall) => toolCall.cost))
+  );
+}
+
+function buildScoreComponents(input: {
+  evidenceMissingCount: number;
+  forbiddenFanoutViolationCount: number;
+  budgetPassed: boolean;
+  finalOutputCleanPassed: boolean;
+}): Record<string, number> {
+  return {
+    requiredEvidence: input.evidenceMissingCount === 0 ? 1 : 0,
+    forbiddenFanout: input.forbiddenFanoutViolationCount === 0 ? 1 : 0,
+    budget: input.budgetPassed ? 1 : 0,
+    finalOutputClean: input.finalOutputCleanPassed ? 1 : 0,
+  };
+}
+
+function computeScoreTotal(components: Record<string, number>): number {
+  const total =
+    SCORE_COMPONENT_KEYS.reduce((sum, key) => sum + (components[key] ?? 0), 0) /
+    SCORE_COMPONENT_KEYS.length;
+
+  return Math.round(total * 1000) / 1000;
+}
+
+function canonicalizeScore(components: Record<string, number>): EvalResult['score'] {
+  const orderedComponents: Record<string, number> = {};
+  for (const key of SCORE_COMPONENT_KEYS) {
+    orderedComponents[key] = components[key] ?? 0;
+  }
+
+  return {
+    components: orderedComponents,
+    total: computeScoreTotal(orderedComponents),
+  };
+}
+
+function canonicalizeResult(input: {
+  name: string;
+  passed: boolean;
+  score: Record<string, number>;
+  evidenceMatched: string[];
+  evidenceMissing: string[];
+  forbiddenFanoutViolations: string[];
+  toolCalls: number;
+  latencyMs: number;
+  cost: number;
+  finalOutputCleanResult: { clean: boolean; sanitizedKinds: string[] };
+}): EvalResult {
+  return {
+    name: input.name,
+    passed: input.passed,
+    score: canonicalizeScore(input.score),
+    evidence: {
+      matched: [...input.evidenceMatched].sort(compareStrings),
+      missing: [...input.evidenceMissing].sort(compareStrings),
+    },
+    forbiddenFanoutViolations: [...input.forbiddenFanoutViolations].sort(compareStrings),
+    budget: {
+      toolCalls: input.toolCalls,
+      latencyMs: input.latencyMs,
+      cost: input.cost,
+    },
+    finalOutputCleanResult: {
+      clean: input.finalOutputCleanResult.clean,
+      sanitizedKinds: [...input.finalOutputCleanResult.sanitizedKinds].sort(compareStrings),
+    },
+  };
+}
+
+async function runEvalCase(
+  evalCase: EvalCase,
+  runner: EvalTurnRunner,
+): Promise<EvalResult> {
+  const run = await runner({
+    caseName: evalCase.name,
+    fixture: evalCase.fixture,
+  });
+  const toolCalls = deriveToolCalls(evalCase.fixture, run);
+  const latencyMs = deriveLatencyMs(evalCase.fixture, run);
+  const cost = deriveCost(evalCase.fixture, run, toolCalls);
+  const evidence = evaluateRequiredEvidence(run.finalOutput, evalCase.checks.requiredEvidence);
+  const forbiddenFanoutViolations = evaluateForbiddenFanout(
+    toolCalls,
+    evalCase.checks.forbiddenFanout,
+  );
+  const budgetPassed = evaluateBudget(
+    {
+      toolCalls: toolCalls.length,
+      latencyMs,
+    },
+    evalCase.checks.budget,
+  );
+  const finalOutputCleanResult = evaluateFinalOutputClean(run.sanitizedKinds ?? []);
+  const finalOutputCleanPassed =
+    evalCase.checks.finalOutputClean === true ? finalOutputCleanResult.clean : true;
+  const score = buildScoreComponents({
+    evidenceMissingCount: evidence.missing.length,
+    forbiddenFanoutViolationCount: forbiddenFanoutViolations.length,
+    budgetPassed,
+    finalOutputCleanPassed,
+  });
+  const passed =
+    evidence.missing.length === 0 &&
+    forbiddenFanoutViolations.length === 0 &&
+    budgetPassed &&
+    finalOutputCleanPassed;
+
+  return canonicalizeResult({
+    name: evalCase.name,
+    passed,
+    score,
+    evidenceMatched: evidence.matched,
+    evidenceMissing: evidence.missing,
+    forbiddenFanoutViolations,
+    toolCalls: toolCalls.length,
+    latencyMs,
+    cost,
+    finalOutputCleanResult,
+  });
+}
+
+export async function runEvalSuite(
+  cases: EvalCase[],
+  runner: EvalTurnRunner,
+): Promise<EvalResult[]> {
+  const results = await Promise.all(cases.map((evalCase) => runEvalCase(evalCase, runner)));
+  return [...results].sort((left, right) => compareStrings(left.name, right.name));
+}

--- a/packages/telemetry/src/evals/human-suite.ts
+++ b/packages/telemetry/src/evals/human-suite.ts
@@ -1,0 +1,412 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export type HumanEvalStatus = 'passed' | 'failed' | 'skipped' | 'needs-human';
+
+export interface HumanEvalCase {
+  id: string;
+  suite: string;
+  executor?: string;
+  kind?: 'capability' | 'regression' | string;
+  input: Record<string, unknown>;
+  expected?: HumanEvalExpected;
+  grading?: { humanReview?: boolean; [key: string]: unknown };
+  tags?: string[];
+  trials?: number;
+  mock?: Record<string, unknown>;
+  source?: string;
+  sourceLine?: number;
+}
+
+export interface HumanEvalExpected {
+  ok?: boolean;
+  tier?: string;
+  reasonIncludes?: string;
+  stopReason?: string;
+  contentIncludes?: string[];
+  contentMatches?: string[];
+  forbidPhrases?: string[];
+  forbidPatterns?: string[];
+  toolCallsInclude?: string[];
+  toolCallsExclude?: string[];
+  maxToolCalls?: number;
+  minToolCalls?: number;
+  must?: string[];
+  mustNot?: string[];
+  humanReviewRequired?: boolean;
+  [key: string]: unknown;
+}
+
+export interface HumanEvalActual {
+  ok?: boolean;
+  tier?: string;
+  reason?: string;
+  stopReason?: string;
+  status?: string;
+  content: string;
+  toolCalls: Array<{ name: string; [key: string]: unknown }>;
+  notes?: string;
+  [key: string]: unknown;
+}
+
+export interface HumanEvalCheck {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+export interface HumanEvalTrial {
+  id: string;
+  suite: string;
+  kind: string;
+  executor: string;
+  trial: number;
+  tags: string[];
+  status: HumanEvalStatus;
+  duration_ms: number;
+  checks: HumanEvalCheck[];
+  actual?: Partial<HumanEvalActual>;
+  error?: string;
+}
+
+export interface HumanEvalRunRecord {
+  schema_version: number;
+  timestamp: string;
+  branch: string;
+  git_sha: string;
+  mode: 'offline' | 'provider' | string;
+  total_cases: number;
+  tests: HumanEvalTrial[];
+  runDir: string;
+}
+
+export interface HumanEvalRunSummary extends Omit<HumanEvalRunRecord, 'runDir'> {
+  total_trials: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  needs_human: number;
+  total_duration_ms: number;
+  final: boolean;
+}
+
+export interface HumanEvalCaseFilter {
+  suite?: string;
+  caseId?: string;
+  tags?: ReadonlySet<string>;
+}
+
+export interface HumanEvalRunMetadata {
+  branch: string;
+  gitSha: string;
+  mode: 'offline' | 'provider' | string;
+  runDir: string;
+  selectedCaseCount: number;
+  timestamp?: string;
+}
+
+export interface LoadHumanEvalCasesOptions {
+  rootDir?: string;
+}
+
+const SCHEMA_VERSION = 1;
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right, 'en');
+}
+
+function addCheck(checks: HumanEvalCheck[], name: string, passed: boolean, message: string): void {
+  checks.push({ name, passed: Boolean(passed), message });
+}
+
+export function loadHumanEvalCasesFromSuitesDir(
+  suitesDir: string,
+  options: LoadHumanEvalCasesOptions = {},
+): HumanEvalCase[] {
+  if (!existsSync(suitesDir)) return [];
+
+  const cases: HumanEvalCase[] = [];
+  for (const suiteName of readdirSync(suitesDir).sort(compareStrings)) {
+    const casePath = path.join(suitesDir, suiteName, 'cases.jsonl');
+    if (!existsSync(casePath)) continue;
+
+    const lines = readFileSync(casePath, 'utf8').split('\n');
+    lines.forEach((line, lineIndex) => {
+      const trimmed = line.trim();
+      if (trimmed.length === 0 || trimmed.startsWith('#')) return;
+
+      try {
+        const parsed = JSON.parse(trimmed) as Partial<HumanEvalCase>;
+        const { suite: parsedSuite, ...rest } = parsed;
+        cases.push({
+          ...rest,
+          suite: parsedSuite ?? suiteName,
+          source: options.rootDir ? path.relative(options.rootDir, casePath) : casePath,
+          sourceLine: lineIndex + 1,
+        } as HumanEvalCase);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        throw new Error(`${casePath}:${lineIndex + 1}: ${reason}`);
+      }
+    });
+  }
+
+  return cases;
+}
+
+export function matchesHumanEvalFilters(
+  evalCase: HumanEvalCase,
+  filter: HumanEvalCaseFilter,
+): boolean {
+  if (filter.suite !== undefined && evalCase.suite !== filter.suite) return false;
+  if (filter.caseId !== undefined && evalCase.id !== filter.caseId) return false;
+
+  for (const tag of filter.tags ?? []) {
+    if (!Array.isArray(evalCase.tags) || !evalCase.tags.includes(tag)) return false;
+  }
+
+  return true;
+}
+
+export function validateHumanEvalCase(evalCase: HumanEvalCase): void {
+  if (typeof evalCase.id !== 'string' || evalCase.id.length === 0) {
+    throw new Error('case.id must be a non-empty string');
+  }
+  if (typeof evalCase.suite !== 'string' || evalCase.suite.length === 0) {
+    throw new Error('case.suite must be a non-empty string');
+  }
+  if (evalCase.input === null || typeof evalCase.input !== 'object') {
+    throw new Error('case.input must be an object');
+  }
+}
+
+export function normalizeHumanEvalActual(actual: unknown): HumanEvalActual {
+  const record = actual !== null && typeof actual === 'object'
+    ? (actual as Record<string, unknown>)
+    : {};
+  const toolCalls = Array.isArray(record.toolCalls)
+    ? record.toolCalls
+        .filter((call): call is Record<string, unknown> => call !== null && typeof call === 'object')
+        .map((call) => ({
+          ...call,
+          name: String(call.name ?? ''),
+        }))
+    : [];
+
+  return {
+    ...record,
+    ok: typeof record.ok === 'boolean' ? record.ok : undefined,
+    tier: typeof record.tier === 'string' ? record.tier : undefined,
+    reason: typeof record.reason === 'string' ? record.reason : undefined,
+    stopReason: typeof record.stopReason === 'string' ? record.stopReason : undefined,
+    status: typeof record.status === 'string' ? record.status : undefined,
+    content: String(record.content ?? record.responseText ?? record.text ?? ''),
+    toolCalls,
+    notes: typeof record.notes === 'string' ? record.notes : undefined,
+  };
+}
+
+export function assertHumanEvalExpected(
+  evalCase: HumanEvalCase,
+  actualInput: unknown,
+): HumanEvalCheck[] {
+  const expected = evalCase.expected ?? {};
+  const actual = normalizeHumanEvalActual(actualInput);
+  const checks: HumanEvalCheck[] = [];
+
+  addCheck(checks, 'status', true, 'case executed');
+  if ('ok' in expected) {
+    addCheck(checks, 'ok', actual.ok === expected.ok, `expected ok=${expected.ok}, got ${actual.ok}`);
+  }
+  if ('tier' in expected) {
+    addCheck(checks, 'tier', actual.tier === expected.tier, `expected tier=${expected.tier}, got ${actual.tier}`);
+  }
+  if (expected.reasonIncludes !== undefined) {
+    addCheck(
+      checks,
+      'reasonIncludes',
+      String(actual.reason ?? '').includes(expected.reasonIncludes),
+      `expected reason to include "${expected.reasonIncludes}", got "${actual.reason ?? ''}"`,
+    );
+  }
+  if ('stopReason' in expected) {
+    addCheck(
+      checks,
+      'stopReason',
+      actual.stopReason === expected.stopReason,
+      `expected stopReason=${expected.stopReason}, got ${actual.stopReason}`,
+    );
+  }
+
+  for (const phrase of expected.contentIncludes ?? []) {
+    addCheck(
+      checks,
+      `contentIncludes:${phrase}`,
+      actual.content.toLowerCase().includes(String(phrase).toLowerCase()),
+      `expected content to include "${phrase}"`,
+    );
+  }
+  for (const pattern of expected.contentMatches ?? []) {
+    const regex = new RegExp(pattern, 'i');
+    addCheck(checks, `contentMatches:${pattern}`, regex.test(actual.content), `expected content to match /${pattern}/i`);
+  }
+  for (const phrase of expected.forbidPhrases ?? []) {
+    addCheck(
+      checks,
+      `forbidPhrase:${phrase}`,
+      !actual.content.toLowerCase().includes(String(phrase).toLowerCase()),
+      `content must not include "${phrase}"`,
+    );
+  }
+  for (const pattern of expected.forbidPatterns ?? []) {
+    const regex = new RegExp(pattern, 'i');
+    addCheck(checks, `forbidPattern:${pattern}`, !regex.test(actual.content), `content must not match /${pattern}/i`);
+  }
+
+  const toolNames = actual.toolCalls.map((call) => call.name);
+  for (const name of expected.toolCallsInclude ?? []) {
+    addCheck(checks, `toolCallsInclude:${name}`, toolNames.includes(name), `expected tool call "${name}"`);
+  }
+  for (const name of expected.toolCallsExclude ?? []) {
+    addCheck(checks, `toolCallsExclude:${name}`, !toolNames.includes(name), `did not expect tool call "${name}"`);
+  }
+  if (expected.maxToolCalls !== undefined) {
+    addCheck(
+      checks,
+      'maxToolCalls',
+      toolNames.length <= expected.maxToolCalls,
+      `expected <= ${expected.maxToolCalls} tool calls, got ${toolNames.length}`,
+    );
+  }
+  if (expected.minToolCalls !== undefined) {
+    addCheck(
+      checks,
+      'minToolCalls',
+      toolNames.length >= expected.minToolCalls,
+      `expected >= ${expected.minToolCalls} tool calls, got ${toolNames.length}`,
+    );
+  }
+
+  if (Array.isArray(expected.must) && expected.must.length > 0) {
+    addCheck(checks, 'human:must', true, `${expected.must.length} human must criteria recorded`);
+  }
+  if (Array.isArray(expected.mustNot) && expected.mustNot.length > 0) {
+    addCheck(checks, 'human:mustNot', true, `${expected.mustNot.length} human must-not criteria recorded`);
+  }
+
+  return checks;
+}
+
+export function humanEvalNeedsReview(evalCase: HumanEvalCase): boolean {
+  return Boolean(evalCase.expected?.humanReviewRequired || evalCase.grading?.humanReview);
+}
+
+export function createHumanEvalRunRecord(metadata: HumanEvalRunMetadata): HumanEvalRunRecord {
+  return {
+    schema_version: SCHEMA_VERSION,
+    timestamp: metadata.timestamp ?? new Date().toISOString(),
+    branch: metadata.branch,
+    git_sha: metadata.gitSha,
+    mode: metadata.mode,
+    total_cases: metadata.selectedCaseCount,
+    tests: [],
+    runDir: metadata.runDir,
+  };
+}
+
+export function summarizeHumanEvalRun(
+  run: HumanEvalRunRecord,
+  options: { final?: boolean } = {},
+): HumanEvalRunSummary {
+  return {
+    schema_version: run.schema_version,
+    timestamp: run.timestamp,
+    branch: run.branch,
+    git_sha: run.git_sha,
+    mode: run.mode,
+    total_cases: run.total_cases,
+    total_trials: run.tests.length,
+    passed: run.tests.filter((test) => test.status === 'passed').length,
+    failed: run.tests.filter((test) => test.status === 'failed').length,
+    skipped: run.tests.filter((test) => test.status === 'skipped').length,
+    needs_human: run.tests.filter((test) => test.status === 'needs-human').length,
+    total_duration_ms: run.tests.reduce((sum, test) => sum + test.duration_ms, 0),
+    final: Boolean(options.final),
+    tests: run.tests,
+  };
+}
+
+export function renderHumanEvalSummary(result: HumanEvalRunSummary): string {
+  const lines = [
+    '# Agent Assistant Eval Run',
+    '',
+    `- Timestamp: ${result.timestamp}`,
+    `- Branch: ${result.branch}`,
+    `- Git SHA: ${result.git_sha}`,
+    `- Mode: ${result.mode}`,
+    `- Trials: ${result.total_trials}`,
+    `- Passed: ${result.passed}`,
+    `- Needs human: ${result.needs_human}`,
+    `- Failed: ${result.failed}`,
+    `- Skipped: ${result.skipped}`,
+    '',
+    '## Results',
+    '',
+  ];
+
+  for (const test of result.tests) {
+    lines.push(`- ${test.status.toUpperCase()} ${test.id} (${test.suite}/${test.executor}, trial ${test.trial}, ${test.duration_ms}ms)`);
+    for (const check of test.checks) {
+      lines.push(`  - ${check.passed ? 'PASS' : 'FAIL'} ${check.name}: ${check.message}`);
+    }
+    if (test.error !== undefined) lines.push(`  - Error: ${test.error}`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderHumanEvalReview(result: HumanEvalRunSummary): string {
+  const reviewTests = result.tests.filter((test) => test.status === 'needs-human' || test.status === 'failed');
+  const lines = [
+    '# Agent Assistant Eval Human Review',
+    '',
+    'Use this worksheet to decide whether the deterministic result was fair and whether the case/rubric needs adjustment.',
+    '',
+  ];
+
+  if (reviewTests.length === 0) {
+    lines.push('No cases currently require human review.');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const test of reviewTests) {
+    lines.push(`## ${test.id}`);
+    lines.push('');
+    lines.push(`- Status: ${test.status}`);
+    lines.push(`- Suite: ${test.suite}`);
+    lines.push(`- Executor: ${test.executor}`);
+    lines.push('');
+    lines.push('Human verdict: TODO pass / fail / case-bug / grader-bug');
+    lines.push('');
+    lines.push('Notes:');
+    lines.push('');
+    lines.push('```');
+    lines.push((test.actual?.content ?? '').slice(0, 4000));
+    lines.push('```');
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function writeHumanEvalRunArtifacts(
+  run: HumanEvalRunRecord,
+  options: { final?: boolean } = {},
+): HumanEvalRunSummary {
+  mkdirSync(run.runDir, { recursive: true });
+  const summary = summarizeHumanEvalRun(run, options);
+  writeFileSync(path.join(run.runDir, 'result.json'), `${JSON.stringify(summary, null, 2)}\n`);
+  writeFileSync(path.join(run.runDir, 'summary.md'), renderHumanEvalSummary(summary));
+  writeFileSync(path.join(run.runDir, 'human-review.md'), renderHumanEvalReview(summary));
+  return summary;
+}

--- a/packages/telemetry/src/evals/index.ts
+++ b/packages/telemetry/src/evals/index.ts
@@ -1,0 +1,4 @@
+export * from './eval-checks.js';
+export * from './eval-runner.js';
+export * from './human-suite.js';
+export * from './pr-comment-format.js';

--- a/packages/telemetry/src/evals/pr-comment-format.ts
+++ b/packages/telemetry/src/evals/pr-comment-format.ts
@@ -1,0 +1,107 @@
+import type { EvalResult } from './eval-runner.js';
+
+const MAX_PR_COMMENT_BYTES = 4 * 1024;
+const textEncoder = new TextEncoder();
+
+function compareResults(left: EvalResult, right: EvalResult): number {
+  if (left.passed !== right.passed) {
+    return left.passed ? 1 : -1;
+  }
+
+  return left.name.localeCompare(right.name, 'en');
+}
+
+function formatMoney(cost: number | undefined): string {
+  return `$${(cost ?? 0).toFixed(4)}`;
+}
+
+function formatScore(total: number): string {
+  return total.toFixed(2);
+}
+
+function formatPassLine(result: EvalResult): string {
+  return `- PASS \`${result.name}\` | score ${formatScore(result.score.total)} | tools ${result.budget.toolCalls} | latency ${result.budget.latencyMs}ms | cost ${formatMoney(result.budget.cost)}`;
+}
+
+function formatFailureDetails(result: EvalResult): string {
+  const parts: string[] = [];
+
+  if (result.evidence.missing.length > 0) {
+    parts.push(`missing evidence: ${result.evidence.missing.join(', ')}`);
+  }
+  if (result.forbiddenFanoutViolations.length > 0) {
+    parts.push(`forbidden fanout: ${result.forbiddenFanoutViolations.join('; ')}`);
+  }
+  if (result.finalOutputCleanResult.clean === false) {
+    parts.push(
+      `sanitized output: ${result.finalOutputCleanResult.sanitizedKinds.join(', ') || 'unknown'}`,
+    );
+  }
+  const failedComponents = Object.entries(result.score.components)
+    .filter(([, value]) => value === 0)
+    .map(([key]) => key);
+  if (failedComponents.length > 0) {
+    parts.push(`failed checks: ${failedComponents.join(', ')}`);
+  }
+
+  return parts.join(' | ');
+}
+
+function formatFailureBlock(result: EvalResult): string {
+  return [
+    '<details>',
+    `<summary>FAIL \`${result.name}\` | score ${formatScore(result.score.total)} | tools ${result.budget.toolCalls} | latency ${result.budget.latencyMs}ms | cost ${formatMoney(result.budget.cost)}</summary>`,
+    '',
+    formatFailureDetails(result),
+    '',
+    '</details>',
+  ].join('\n');
+}
+
+function byteLength(value: string): number {
+  return textEncoder.encode(value).byteLength;
+}
+
+function joinSections(sections: readonly string[]): string {
+  return sections.filter((section) => section.length > 0).join('\n');
+}
+
+export function formatPrCommentSummary(results: EvalResult[]): string {
+  const ordered = [...results].sort(compareResults);
+  const passedCount = ordered.filter((result) => result.passed).length;
+  const failedCount = ordered.length - passedCount;
+  const header = [
+    '## Eval Summary',
+    '',
+    `- ${passedCount}/${ordered.length} passed`,
+    `- ${failedCount} failed`,
+    '',
+  ].join('\n');
+  const sections = [header];
+
+  for (const result of ordered) {
+    const nextSection = result.passed ? formatPassLine(result) : formatFailureBlock(result);
+    const candidate = joinSections([...sections, nextSection]);
+
+    if (byteLength(candidate) <= MAX_PR_COMMENT_BYTES) {
+      sections.push(nextSection);
+      continue;
+    }
+
+    const truncated = joinSections([
+      ...sections,
+      `- Additional eval detail omitted to stay under ${MAX_PR_COMMENT_BYTES} bytes.`,
+    ]);
+    return byteLength(truncated) <= MAX_PR_COMMENT_BYTES
+      ? truncated
+      : joinSections([
+          '## Eval Summary',
+          '',
+          `- ${passedCount}/${ordered.length} passed`,
+          `- ${failedCount} failed`,
+          '- Additional eval detail omitted to stay under 4096 bytes.',
+        ]);
+  }
+
+  return joinSections(sections);
+}

--- a/packages/telemetry/src/events.ts
+++ b/packages/telemetry/src/events.ts
@@ -1,0 +1,356 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  TelemetryBoundedMetadata,
+  TelemetryEvent,
+  TelemetryEventBase,
+  TelemetryRuntimePolicyEvent,
+  TelemetrySubagentBatchStartedEvent,
+  TelemetrySubagentFailedEvent,
+  TelemetrySubagentFinishedEvent,
+  TelemetrySubagentStartedEvent,
+  TelemetryTurnFinishedEvent,
+} from './sinks/types.js';
+
+const DEFAULT_MAX_PAYLOAD_BYTES = 4 * 1024;
+const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_METADATA_KEY_LENGTH = 64;
+const MAX_METADATA_STRING_LENGTH = 256;
+const MAX_METADATA_ARRAY_LENGTH = 32;
+const textEncoder = new TextEncoder();
+
+const FORBIDDEN_METADATA_KEYS = new Set([
+  'content',
+  'input',
+  'inputs',
+  'message',
+  'messages',
+  'output',
+  'outputs',
+  'prompt',
+  'prompts',
+  'providercontent',
+  'providerresponse',
+  'raw',
+  'response',
+  'text',
+  'toolinput',
+  'tooloutput',
+  'transcript',
+]);
+
+type TelemetryEventWithOptionalId<T extends TelemetryEvent> = Omit<T, 'eventId'> & {
+  eventId?: string;
+};
+
+type TelemetryRuntimePolicyEventInput = Omit<
+  TelemetryRuntimePolicyEvent,
+  'eventId' | 'eventKind'
+> & {
+  eventId?: string;
+};
+
+type TelemetrySubagentEventInput<
+  T extends
+    | TelemetrySubagentStartedEvent
+    | TelemetrySubagentFinishedEvent
+    | TelemetrySubagentFailedEvent,
+> = Omit<T, 'eventId' | 'eventKind'> & {
+  eventId?: string;
+};
+
+type TelemetrySubagentBatchStartedEventInput = Omit<
+  TelemetrySubagentBatchStartedEvent,
+  'eventId' | 'eventKind' | 'batchSize'
+> & {
+  eventId?: string;
+  batchSize?: number;
+};
+
+export interface TelemetryEventConstructorOptions {
+  generateEventId?(): string;
+  maxPayloadBytes?: number;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeMetadataKey(key: string): string {
+  return key.replace(/[^a-z0-9]/giu, '').toLowerCase();
+}
+
+function assertIdentifier(value: unknown, fieldName: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_IDENTIFIER_LENGTH) {
+    throw new Error(`${fieldName} must be a non-empty string <= ${MAX_IDENTIFIER_LENGTH} chars`);
+  }
+}
+
+function assertNonNegativeInteger(
+  value: number | undefined,
+  fieldName: string,
+): void {
+  if (value === undefined) {
+    return;
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${fieldName} must be a non-negative integer when provided`);
+  }
+}
+
+function assertTelemetryTimestamp(value: unknown): asserts value is string {
+  assertIdentifier(value, 'timestamp');
+}
+
+function assertSafeMetadataValue(value: unknown, fieldName: string): void {
+  if (
+    value === null ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    if (value.length > MAX_METADATA_STRING_LENGTH) {
+      throw new Error(
+        `${fieldName} string values must be <= ${MAX_METADATA_STRING_LENGTH} chars`,
+      );
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length > MAX_METADATA_ARRAY_LENGTH) {
+      throw new Error(
+        `${fieldName} arrays must be <= ${MAX_METADATA_ARRAY_LENGTH} items`,
+      );
+    }
+    for (const [index, item] of value.entries()) {
+      assertSafeMetadataValue(item, `${fieldName}[${index}]`);
+      if (Array.isArray(item) || isPlainObject(item)) {
+        throw new Error(`${fieldName} arrays may contain only scalar values`);
+      }
+    }
+    return;
+  }
+
+  throw new Error(`${fieldName} must contain only bounded scalar values`);
+}
+
+function assertSafeMetadata(metadata: unknown): asserts metadata is TelemetryBoundedMetadata {
+  if (metadata === undefined) {
+    return;
+  }
+  if (!isPlainObject(metadata)) {
+    throw new Error('metadata must be a plain object when provided');
+  }
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key.length === 0 || key.length > MAX_METADATA_KEY_LENGTH) {
+      throw new Error(`metadata keys must be 1-${MAX_METADATA_KEY_LENGTH} chars`);
+    }
+    if (FORBIDDEN_METADATA_KEYS.has(normalizeMetadataKey(key))) {
+      throw new Error(`metadata key "${key}" is not allowed in privacy-safe telemetry events`);
+    }
+    assertSafeMetadataValue(value, `metadata.${key}`);
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      deepFreeze(item);
+    }
+    return Object.freeze(value);
+  }
+
+  if (isPlainObject(value)) {
+    for (const nested of Object.values(value)) {
+      deepFreeze(nested);
+    }
+    return Object.freeze(value);
+  }
+
+  return value;
+}
+
+function assertPayloadSize(event: TelemetryEvent, maxPayloadBytes: number): void {
+  const payloadBytes = textEncoder.encode(JSON.stringify(event)).byteLength;
+  if (payloadBytes > maxPayloadBytes) {
+    throw new Error(
+      `Telemetry event payload ${payloadBytes} bytes exceeds max ${maxPayloadBytes} bytes`,
+    );
+  }
+}
+
+function finalizeEvent<T extends TelemetryEvent>(
+  event: T,
+  options: TelemetryEventConstructorOptions = {},
+): T {
+  const maxPayloadBytes = options.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
+  assertPayloadSize(event, maxPayloadBytes);
+  return deepFreeze(event);
+}
+
+function withEventId<T extends TelemetryEventBase>(
+  event: Omit<T, 'eventId'> & { eventId?: string },
+  options: TelemetryEventConstructorOptions,
+): T {
+  const eventId = event.eventId ?? options.generateEventId?.() ?? randomUUID();
+  assertIdentifier(eventId, 'eventId');
+  assertIdentifier(event.assistantId, 'assistantId');
+  assertIdentifier(event.turnId, 'turnId');
+  assertTelemetryTimestamp(event.timestamp);
+  if (event.parentTraceId !== undefined) {
+    assertIdentifier(event.parentTraceId, 'parentTraceId');
+  }
+  assertNonNegativeInteger(event.durationMs, 'durationMs');
+  return {
+    ...event,
+    eventId,
+  } as T;
+}
+
+function finalizeRuntimePolicyEvent<T extends TelemetryRuntimePolicyEvent>(
+  input: TelemetryEventWithOptionalId<T>,
+  options: TelemetryEventConstructorOptions = {},
+): T {
+  assertIdentifier(input.reason, 'reason');
+  if (input.toolName !== undefined) {
+    assertIdentifier(input.toolName, 'toolName');
+  }
+  assertSafeMetadata(input.metadata);
+  return finalizeEvent(withEventId(input, options), options);
+}
+
+function finalizeSubagentEvent<
+  T extends
+    | TelemetrySubagentStartedEvent
+    | TelemetrySubagentFinishedEvent
+    | TelemetrySubagentFailedEvent,
+>(
+  input: TelemetrySubagentEventInput<T>,
+  eventKind: T['eventKind'],
+  options: TelemetryEventConstructorOptions = {},
+): T {
+  assertIdentifier(input.subagentName, 'subagentName');
+  assertIdentifier(input.childTraceId, 'childTraceId');
+  assertNonNegativeInteger(input.iterations, 'iterations');
+  assertNonNegativeInteger(input.toolCallCount, 'toolCallCount');
+  if (input.stopReason !== undefined) {
+    assertIdentifier(input.stopReason, 'stopReason');
+  }
+  return finalizeEvent(
+    withEventId(
+      {
+        ...input,
+        eventKind,
+      } as Omit<T, 'eventId'> & { eventId?: string },
+      options,
+    ),
+    options,
+  );
+}
+
+export function createSubagentBatchStartedEvent(
+  input: TelemetrySubagentBatchStartedEventInput,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetrySubagentBatchStartedEvent {
+  if (input.subagentNames.length === 0) {
+    throw new Error('subagentNames must contain at least one subagent');
+  }
+  if (input.subagentNames.length !== input.childTraceIds.length) {
+    throw new Error('subagentNames and childTraceIds must have the same length');
+  }
+  for (const name of input.subagentNames) {
+    assertIdentifier(name, 'subagentNames[]');
+  }
+  for (const childTraceId of input.childTraceIds) {
+    assertIdentifier(childTraceId, 'childTraceIds[]');
+  }
+  const normalizedInput: Omit<TelemetrySubagentBatchStartedEvent, 'eventId'> & { eventId?: string } = {
+    ...input,
+    eventKind: 'subagent.batch.started',
+    batchSize: input.batchSize ?? input.subagentNames.length,
+  };
+  assertNonNegativeInteger(normalizedInput.batchSize, 'batchSize');
+  if (normalizedInput.batchSize !== input.subagentNames.length) {
+    throw new Error('batchSize must match the number of subagentNames');
+  }
+  return finalizeEvent(withEventId(normalizedInput, options), options);
+}
+
+export function createSubagentStartedEvent(
+  input: TelemetrySubagentEventInput<TelemetrySubagentStartedEvent>,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetrySubagentStartedEvent {
+  return finalizeSubagentEvent(input, 'subagent.started', options);
+}
+
+export function createSubagentFinishedEvent(
+  input: TelemetrySubagentEventInput<TelemetrySubagentFinishedEvent>,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetrySubagentFinishedEvent {
+  return finalizeSubagentEvent(input, 'subagent.finished', options);
+}
+
+export function createSubagentFailedEvent(
+  input: TelemetrySubagentEventInput<TelemetrySubagentFailedEvent>,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetrySubagentFailedEvent {
+  return finalizeSubagentEvent(input, 'subagent.failed', options);
+}
+
+export function createRuntimePolicyBlockedEvent(
+  input: TelemetryRuntimePolicyEventInput,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetryRuntimePolicyEvent {
+  return finalizeRuntimePolicyEvent(
+    {
+      ...input,
+      eventKind: 'runtime_policy.blocked',
+    },
+    options,
+  );
+}
+
+export function createRuntimePolicyCacheHitEvent(
+  input: TelemetryRuntimePolicyEventInput,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetryRuntimePolicyEvent {
+  return finalizeRuntimePolicyEvent(
+    {
+      ...input,
+      eventKind: 'runtime_policy.cache_hit',
+    },
+    options,
+  );
+}
+
+export function createRuntimePolicyOutputSanitizedEvent(
+  input: TelemetryRuntimePolicyEventInput,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetryRuntimePolicyEvent {
+  return finalizeRuntimePolicyEvent(
+    {
+      ...input,
+      eventKind: 'runtime_policy.output_sanitized',
+    },
+    options,
+  );
+}
+
+export function createSynthesisSalvagedEvent(
+  input: TelemetryRuntimePolicyEventInput,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetryRuntimePolicyEvent {
+  return finalizeRuntimePolicyEvent(
+    {
+      ...input,
+      eventKind: 'synthesis.salvaged',
+    },
+    options,
+  );
+}
+
+export type { TelemetryTurnFinishedEvent };

--- a/packages/telemetry/src/harness-bridge.ts
+++ b/packages/telemetry/src/harness-bridge.ts
@@ -3,17 +3,31 @@ import type {
   HarnessExecutionState,
   HarnessModelCallRecord,
   HarnessResult,
+  HarnessTraceEvent,
+  HarnessTraceSink,
   HarnessTranscriptItem,
   HarnessUsage,
 } from '@agent-assistant/harness';
 import { computeCost } from './cost.js';
+import {
+  createRuntimePolicyBlockedEvent,
+  createRuntimePolicyCacheHitEvent,
+  createRuntimePolicyOutputSanitizedEvent,
+  createSubagentFailedEvent,
+  createSubagentFinishedEvent,
+  createSubagentStartedEvent,
+  createSynthesisSalvagedEvent,
+  type TelemetryEventConstructorOptions,
+} from './events.js';
 import { FROZEN_PRICING_TABLE } from './pricing.js';
 import type { PricingTable } from './pricing.js';
 import type {
+  TelemetryBoundedMetadata,
   TelemetryEvent,
   TelemetryEventCost,
   TelemetryOutputKind,
   TelemetrySink,
+  TelemetryTurnFinishedEvent,
 } from './sinks/types.js';
 
 export interface TelemetryHookOptions {
@@ -24,6 +38,34 @@ export interface TelemetryHookOptions {
   generateEventId?(): string;
 }
 
+export interface TelemetryTraceBridgeOptions extends TelemetryEventConstructorOptions {
+  sink: TelemetrySink;
+}
+
+type TelemetryTraceBridgeEvent = Extract<
+  HarnessTraceEvent,
+  | { type: 'turn_started' }
+  | { type: 'turn_finished' }
+>;
+
+interface RuntimePolicyTraceBridgeEvent {
+  type:
+    | 'runtime_policy.blocked'
+    | 'runtime_policy.cache_hit'
+    | 'runtime_policy.todo_rewrite_blocked'
+    | 'runtime_policy.output_sanitized'
+    | 'runtime_policy.synthesis_salvaged';
+  timestamp: string;
+  assistantId: string;
+  turnId: string;
+  elapsedMs?: number;
+  toolName?: string;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+type TelemetryBridgeInputEvent = TelemetryTraceBridgeEvent | RuntimePolicyTraceBridgeEvent;
+
 export function createTelemetryHook(
   options: TelemetryHookOptions,
 ): (result: HarnessResult, state: HarnessExecutionState) => Promise<void> {
@@ -31,7 +73,7 @@ export function createTelemetryHook(
 
   return async (result, state) => {
     try {
-      const event: TelemetryEvent = {
+      const event: TelemetryTurnFinishedEvent = {
         eventId: options.generateEventId?.() ?? randomUUID(),
         eventKind: 'turn.finished',
         timestamp: new Date().toISOString(),
@@ -54,14 +96,132 @@ export function createTelemetryHook(
   };
 }
 
-function defaultInputFor(state: HarnessExecutionState): TelemetryEvent['input'] {
+export function createTelemetryTraceBridge(options: TelemetryTraceBridgeOptions): HarnessTraceSink {
+  return {
+    async emit(event) {
+      try {
+        const telemetryEvents = telemetryEventsFromTraceEvent(event, options);
+        for (const telemetryEvent of telemetryEvents) {
+          await options.sink.emit(telemetryEvent);
+        }
+      } catch (error) {
+        console.warn('Telemetry trace bridge failed to emit telemetry event', error);
+      }
+    },
+  };
+}
+
+export function telemetryEventsFromTraceEvent(
+  event: HarnessTraceEvent | RuntimePolicyTraceBridgeEvent,
+  options: TelemetryEventConstructorOptions = {},
+): TelemetryEvent[] {
+  if (!isBridgeEvent(event)) {
+    return [];
+  }
+
+  if (event.type === 'turn_started') {
+    const subagentMetadata = readSubagentTraceMetadata(event.metadata);
+    if (!subagentMetadata) {
+      return [];
+    }
+
+    return [
+      createSubagentStartedEvent(
+        {
+          timestamp: event.timestamp,
+          assistantId: event.assistantId,
+          turnId: event.turnId,
+          parentTraceId: subagentMetadata.parentTraceId,
+          durationMs: event.elapsedMs,
+          subagentName: subagentMetadata.subagentName,
+          childTraceId: subagentMetadata.childTraceId,
+          toolCallCount: event.toolCallCount,
+        },
+        options,
+      ),
+    ];
+  }
+
+  if (event.type === 'turn_finished') {
+    const subagentMetadata = readSubagentTraceMetadata(event.metadata);
+    if (!subagentMetadata) {
+      return [];
+    }
+
+    return [
+      event.outcome === 'completed' && event.stopReason === 'answer_finalized'
+        ? createSubagentFinishedEvent(
+            {
+              timestamp: event.timestamp,
+              assistantId: event.assistantId,
+              turnId: event.turnId,
+              parentTraceId: subagentMetadata.parentTraceId,
+              durationMs: event.elapsedMs,
+              subagentName: subagentMetadata.subagentName,
+              childTraceId: subagentMetadata.childTraceId,
+              iterations: event.iteration,
+              stopReason: event.stopReason,
+              toolCallCount: event.toolCallCount,
+            },
+            options,
+          )
+        : createSubagentFailedEvent(
+            {
+              timestamp: event.timestamp,
+              assistantId: event.assistantId,
+              turnId: event.turnId,
+              parentTraceId: subagentMetadata.parentTraceId,
+              durationMs: event.elapsedMs,
+              subagentName: subagentMetadata.subagentName,
+              childTraceId: subagentMetadata.childTraceId,
+              iterations: event.iteration,
+              stopReason: event.stopReason,
+              toolCallCount: event.toolCallCount,
+            },
+            options,
+          ),
+    ];
+  }
+
+  if (!isRuntimePolicyBridgeEvent(event)) {
+    return [];
+  }
+
+  const metadata = toBoundedMetadata(event.metadata);
+  const baseInput = {
+    timestamp: event.timestamp,
+    assistantId: event.assistantId,
+    turnId: event.turnId,
+    parentTraceId: readParentTraceId(event.metadata),
+    durationMs: event.elapsedMs,
+    toolName: event.toolName,
+    reason: event.reason,
+    ...(metadata ? { metadata } : {}),
+  } as const;
+
+  switch (event.type) {
+    case 'runtime_policy.blocked':
+    case 'runtime_policy.todo_rewrite_blocked':
+      return [createRuntimePolicyBlockedEvent(baseInput, options)];
+    case 'runtime_policy.cache_hit':
+      return [createRuntimePolicyCacheHitEvent(baseInput, options)];
+    case 'runtime_policy.output_sanitized':
+      return [createRuntimePolicyOutputSanitizedEvent(baseInput, options)];
+    case 'runtime_policy.synthesis_salvaged':
+      return [createSynthesisSalvagedEvent(baseInput, options)];
+    default:
+      return [];
+  }
+}
+
+function defaultInputFor(state: HarnessExecutionState): TelemetryTurnFinishedEvent['input'] {
   const message = state.input?.message?.text ?? '';
   const systemPrompt = state.input?.instructions?.systemPrompt;
 
   return systemPrompt === undefined ? { message } : { message, systemPrompt };
 }
 
-function outputFor(result: HarnessResult): TelemetryEvent['output'] {
+function outputFor(result: HarnessResult): TelemetryTurnFinishedEvent['output'] {
   const text = result.assistantMessage?.text;
   const stopReason = result.stopReason;
 
@@ -168,4 +328,148 @@ function firstString(...values: unknown[]): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeMetadataKey(key: string): string {
+  return key.replace(/[^a-z0-9]/giu, '').toLowerCase();
+}
+
+function isBridgeEvent(
+  event: HarnessTraceEvent | RuntimePolicyTraceBridgeEvent,
+): event is TelemetryBridgeInputEvent {
+  switch (event.type) {
+    case 'turn_started':
+    case 'turn_finished':
+    case 'runtime_policy.blocked':
+    case 'runtime_policy.cache_hit':
+    case 'runtime_policy.todo_rewrite_blocked':
+    case 'runtime_policy.output_sanitized':
+    case 'runtime_policy.synthesis_salvaged':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isRuntimePolicyBridgeEvent(
+  event: TelemetryBridgeInputEvent,
+): event is RuntimePolicyTraceBridgeEvent {
+  switch (event.type) {
+    case 'runtime_policy.blocked':
+    case 'runtime_policy.cache_hit':
+    case 'runtime_policy.todo_rewrite_blocked':
+    case 'runtime_policy.output_sanitized':
+    case 'runtime_policy.synthesis_salvaged':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function readParentTraceId(metadata: Record<string, unknown> | undefined): string | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+  const candidate = metadata.parentTraceId;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : undefined;
+}
+
+function readSubagentTraceMetadata(
+  metadata: Record<string, unknown> | undefined,
+): { parentTraceId?: string; childTraceId: string; subagentName: string } | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const childTraceId = metadata.childTraceId;
+  const subagentName = metadata.subagentName;
+  if (
+    typeof childTraceId !== 'string' ||
+    childTraceId.length === 0 ||
+    typeof subagentName !== 'string' ||
+    subagentName.length === 0
+  ) {
+    return undefined;
+  }
+
+  const parentTraceId = readParentTraceId(metadata);
+  return parentTraceId
+    ? { parentTraceId, childTraceId, subagentName }
+    : { childTraceId, subagentName };
+}
+
+function toBoundedMetadata(
+  metadata: Record<string, unknown> | undefined,
+): TelemetryBoundedMetadata | undefined {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const boundedEntries: Array<[string, TelemetryBoundedMetadata[string]]> = [];
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key === 'parentTraceId' || key === 'childTraceId' || key === 'subagentName') {
+      continue;
+    }
+    if (
+      [
+        'content',
+        'input',
+        'inputs',
+        'message',
+        'messages',
+        'output',
+        'outputs',
+        'prompt',
+        'prompts',
+        'providercontent',
+        'providerresponse',
+        'raw',
+        'response',
+        'text',
+        'toolinput',
+        'tooloutput',
+        'transcript',
+      ].includes(normalizeMetadataKey(key))
+    ) {
+      continue;
+    }
+
+    const boundedValue = toBoundedMetadataValue(value);
+    if (boundedValue !== undefined) {
+      boundedEntries.push([key, boundedValue]);
+    }
+  }
+
+  return boundedEntries.length > 0 ? Object.freeze(Object.fromEntries(boundedEntries)) : undefined;
+}
+
+function toBoundedMetadataValue(
+  value: unknown,
+): TelemetryBoundedMetadata[string] | undefined {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'number'
+  ) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return isSensitiveMetadataKeyValue(value) ? undefined : value;
+  }
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const filtered = value.filter(
+    (item): item is string | number | boolean | null =>
+      item === null ||
+      typeof item === 'boolean' ||
+      typeof item === 'number' ||
+      (typeof item === 'string' && !isSensitiveMetadataKeyValue(item)),
+  );
+  return filtered.length > 0 ? Object.freeze(filtered) : undefined;
+}
+
+function isSensitiveMetadataKeyValue(value: string): boolean {
+  return value.length > 256 || value.includes('\n');
 }

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,4 +1,11 @@
 export * from './pricing.js';
 export * from './cost.js';
+export * from './events.js';
 export * from './sinks/index.js';
-export { createTelemetryHook, type TelemetryHookOptions } from './harness-bridge.js';
+export {
+  createTelemetryHook,
+  createTelemetryTraceBridge,
+  telemetryEventsFromTraceEvent,
+  type TelemetryHookOptions,
+  type TelemetryTraceBridgeOptions,
+} from './harness-bridge.js';

--- a/packages/telemetry/src/sinks/console.ts
+++ b/packages/telemetry/src/sinks/console.ts
@@ -13,7 +13,9 @@ interface ConsoleTelemetrySinkOptions {
 
 type ConsoleTelemetryEvent =
   | TelemetryEvent
-  | (Omit<TelemetryEvent, 'transcript'> & { transcript: typeof OMITTED_TRANSCRIPT });
+  | (Omit<Extract<TelemetryEvent, { eventKind: 'turn.finished' }>, 'transcript'> & {
+      transcript: typeof OMITTED_TRANSCRIPT;
+    });
 
 export class ConsoleTelemetrySink implements TelemetrySink {
   private readonly level: ConsoleTelemetrySinkLevel;
@@ -30,6 +32,10 @@ export class ConsoleTelemetrySink implements TelemetrySink {
   }
 
   private serializeEvent(event: TelemetryEvent): ConsoleTelemetryEvent {
+    if (event.eventKind !== 'turn.finished') {
+      return event;
+    }
+
     if (this.level === 'summary' || isLargeTranscript(event)) {
       return { ...event, transcript: OMITTED_TRANSCRIPT };
     }
@@ -38,7 +44,7 @@ export class ConsoleTelemetrySink implements TelemetrySink {
   }
 }
 
-function isLargeTranscript(event: TelemetryEvent): boolean {
+function isLargeTranscript(event: Extract<TelemetryEvent, { eventKind: 'turn.finished' }>): boolean {
   return (
     textEncoder.encode(JSON.stringify(event.transcript)).byteLength >
     TRANSCRIPT_OMIT_THRESHOLD_BYTES

--- a/packages/telemetry/src/sinks/types.ts
+++ b/packages/telemetry/src/sinks/types.ts
@@ -22,12 +22,35 @@ export interface TelemetryEventCost {
   perModel: TelemetryEventCostBreakdown[];
 }
 
-export interface TelemetryEvent {
+export type TelemetryEventKind =
+  | 'turn.finished'
+  | 'subagent.batch.started'
+  | 'subagent.started'
+  | 'subagent.finished'
+  | 'subagent.failed'
+  | 'runtime_policy.blocked'
+  | 'runtime_policy.cache_hit'
+  | 'runtime_policy.output_sanitized'
+  | 'synthesis.salvaged';
+
+export type TelemetryMetadataScalar = string | number | boolean | null;
+
+export type TelemetryBoundedMetadata = Readonly<
+  Record<string, TelemetryMetadataScalar | readonly TelemetryMetadataScalar[]>
+>;
+
+export interface TelemetryEventBase {
   eventId: string;
-  eventKind: 'turn.finished';
+  eventKind: TelemetryEventKind;
   timestamp: string;
   assistantId: string;
   turnId: string;
+  parentTraceId?: string;
+  durationMs?: number;
+}
+
+export interface TelemetryTurnFinishedEvent extends TelemetryEventBase {
+  eventKind: 'turn.finished';
   threadId?: string;
   userId?: string;
   input: { message: string; systemPrompt?: string };
@@ -37,6 +60,59 @@ export interface TelemetryEvent {
   cost: TelemetryEventCost;
   metadata?: Record<string, unknown>;
 }
+
+export interface TelemetrySubagentBatchStartedEvent extends TelemetryEventBase {
+  eventKind: 'subagent.batch.started';
+  subagentNames: readonly string[];
+  childTraceIds: readonly string[];
+  batchSize: number;
+}
+
+export interface TelemetrySubagentStartedEvent extends TelemetryEventBase {
+  eventKind: 'subagent.started';
+  subagentName: string;
+  childTraceId: string;
+  iterations?: number;
+  stopReason?: string;
+  toolCallCount?: number;
+}
+
+export interface TelemetrySubagentFinishedEvent extends TelemetryEventBase {
+  eventKind: 'subagent.finished';
+  subagentName: string;
+  childTraceId: string;
+  iterations?: number;
+  stopReason?: string;
+  toolCallCount?: number;
+}
+
+export interface TelemetrySubagentFailedEvent extends TelemetryEventBase {
+  eventKind: 'subagent.failed';
+  subagentName: string;
+  childTraceId: string;
+  iterations?: number;
+  stopReason?: string;
+  toolCallCount?: number;
+}
+
+export interface TelemetryRuntimePolicyEvent extends TelemetryEventBase {
+  eventKind:
+    | 'runtime_policy.blocked'
+    | 'runtime_policy.cache_hit'
+    | 'runtime_policy.output_sanitized'
+    | 'synthesis.salvaged';
+  toolName?: string;
+  reason: string;
+  metadata?: TelemetryBoundedMetadata;
+}
+
+export type TelemetryEvent =
+  | TelemetryTurnFinishedEvent
+  | TelemetrySubagentBatchStartedEvent
+  | TelemetrySubagentStartedEvent
+  | TelemetrySubagentFinishedEvent
+  | TelemetrySubagentFailedEvent
+  | TelemetryRuntimePolicyEvent;
 
 export interface TelemetrySink {
   emit(event: TelemetryEvent): Promise<void> | void;

--- a/packages/telemetry/test/eval-runner.test.ts
+++ b/packages/telemetry/test/eval-runner.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  runEvalSuite,
+  type EvalCase,
+  type EvalTurnRunner,
+} from '../src/evals/index.js';
+
+function createSyntheticRunner(): EvalTurnRunner {
+  return async ({ fixture }) => {
+    const providerText = fixture.providerResponses.map((response) => response.outputText).join(' ');
+    const toolText = fixture.tools
+      .map((tool) => `${tool.name}: ${tool.outputText}`)
+      .join(' ');
+
+    return {
+      finalOutput: [providerText, toolText].filter((part) => part.length > 0).join(' ').trim(),
+    };
+  };
+}
+
+function createCase(overrides: Partial<EvalCase> = {}): EvalCase {
+  return {
+    name: overrides.name ?? 'synthetic-happy-path',
+    fixture: overrides.fixture ?? {
+      providerResponses: [
+        {
+          outputText: 'Final answer cites package.json and src/index.ts.',
+          latencyMs: 12,
+          cost: 0.3,
+        },
+      ],
+      tools: [
+        {
+          name: 'workspace_read',
+          outputText: 'package.json',
+          latencyMs: 8,
+          cost: 0.1,
+        },
+        {
+          name: 'workspace_read',
+          outputText: 'src/index.ts',
+          latencyMs: 10,
+          cost: 0.1,
+        },
+      ],
+    },
+    checks: overrides.checks ?? {
+      requiredEvidence: ['package.json', '/src\\/index\\.ts/u'],
+      forbiddenFanout: [{ toolName: 'workspace_read', max: 2 }],
+      budget: { maxToolCalls: 3, maxLatencyMs: 50 },
+      finalOutputClean: true,
+    },
+  };
+}
+
+describe('runEvalSuite', () => {
+  it('passes for a synthetic happy path and derives budget totals from fixtures', async () => {
+    const [result] = await runEvalSuite([createCase()], createSyntheticRunner());
+
+    expect(result).toEqual({
+      name: 'synthetic-happy-path',
+      passed: true,
+      score: {
+        components: {
+          requiredEvidence: 1,
+          forbiddenFanout: 1,
+          budget: 1,
+          finalOutputClean: 1,
+        },
+        total: 1,
+      },
+      evidence: {
+        matched: ['/src\\/index\\.ts/u', 'package.json'],
+        missing: [],
+      },
+      forbiddenFanoutViolations: [],
+      budget: {
+        toolCalls: 2,
+        latencyMs: 30,
+        cost: 0.5,
+      },
+      finalOutputCleanResult: {
+        clean: true,
+        sanitizedKinds: [],
+      },
+    });
+  });
+
+  it('fails on missing required evidence', async () => {
+    const [result] = await runEvalSuite(
+      [
+        createCase({
+          name: 'missing-evidence',
+          checks: {
+            requiredEvidence: ['docs/architecture.md'],
+            finalOutputClean: true,
+          },
+        }),
+      ],
+      createSyntheticRunner(),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.evidence).toEqual({
+      matched: [],
+      missing: ['docs/architecture.md'],
+    });
+    expect(result.score.components.requiredEvidence).toBe(0);
+  });
+
+  it('fails on fanout overshoot', async () => {
+    const [result] = await runEvalSuite(
+      [
+        createCase({
+          name: 'fanout-overshoot',
+          checks: {
+            forbiddenFanout: [{ toolName: 'workspace_read', max: 1 }],
+          },
+        }),
+      ],
+      createSyntheticRunner(),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.forbiddenFanoutViolations).toEqual([
+      'workspace_read called 2 times (max 1)',
+    ]);
+    expect(result.score.components.forbiddenFanout).toBe(0);
+  });
+
+  it('fails on budget exceed', async () => {
+    const [result] = await runEvalSuite(
+      [
+        createCase({
+          name: 'budget-exceed',
+          checks: {
+            budget: { maxToolCalls: 1, maxLatencyMs: 20 },
+          },
+        }),
+      ],
+      createSyntheticRunner(),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.budget).toEqual({
+      toolCalls: 2,
+      latencyMs: 30,
+      cost: 0.5,
+    });
+    expect(result.score.components.budget).toBe(0);
+  });
+
+  it('marks dirty output when the sanitizer fires', async () => {
+    const dirtyRunner: EvalTurnRunner = async ({ fixture }) => {
+      const providerText = fixture.providerResponses.map((response) => response.outputText).join(' ');
+      return {
+        finalOutput: providerText,
+        sanitizedKinds: ['pseudo_tool_fence', 'invoke'],
+      };
+    };
+
+    const [result] = await runEvalSuite(
+      [
+        createCase({
+          name: 'dirty-output',
+          checks: {
+            finalOutputClean: true,
+          },
+        }),
+      ],
+      dirtyRunner,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.finalOutputCleanResult).toEqual({
+      clean: false,
+      sanitizedKinds: ['invoke', 'pseudo_tool_fence'],
+    });
+    expect(result.score.components.finalOutputClean).toBe(0);
+  });
+
+  it('returns results in deterministic name order', async () => {
+    const results = await runEvalSuite(
+      [createCase({ name: 'zeta' }), createCase({ name: 'alpha' })],
+      createSyntheticRunner(),
+    );
+
+    expect(results.map((result) => result.name)).toEqual(['alpha', 'zeta']);
+  });
+});

--- a/packages/telemetry/test/harness-bridge.test.ts
+++ b/packages/telemetry/test/harness-bridge.test.ts
@@ -2,13 +2,25 @@ import { describe, expect, it, vi } from 'vitest';
 import type {
   HarnessExecutionState,
   HarnessHooks,
+  HarnessRuntimePolicyBlockedTraceEvent,
   HarnessResult,
   HarnessModelCallRecord,
+  HarnessTraceSink,
+  HarnessTurnFinishedEvent,
+  HarnessTurnStartedEvent,
 } from '@agent-assistant/harness';
 
-import { createTelemetryHook } from '../src/harness-bridge.js';
+import {
+  createTelemetryHook,
+  createTelemetryTraceBridge,
+  telemetryEventsFromTraceEvent,
+} from '../src/harness-bridge.js';
 import { FROZEN_PRICING_TABLE } from '../src/pricing.js';
-import type { TelemetryEvent, TelemetrySink } from '../src/sinks/types.js';
+import type {
+  TelemetryEvent,
+  TelemetrySink,
+  TelemetryTurnFinishedEvent,
+} from '../src/sinks/types.js';
 
 function createResult(): HarnessResult {
   return {
@@ -90,7 +102,7 @@ describe('createTelemetryHook', () => {
     await hook(createResult(), createState());
 
     expect(emit).toHaveBeenCalledOnce();
-    const [event] = emit.mock.calls[0] as [TelemetryEvent];
+    const [event] = emit.mock.calls[0] as [TelemetryTurnFinishedEvent];
     expect(event).toMatchObject({
       eventId: 'event-1',
       eventKind: 'turn.finished',
@@ -159,7 +171,7 @@ describe('createTelemetryHook', () => {
 
     await hook(createResult(), createState());
 
-    const [event] = emit.mock.calls[0] as [TelemetryEvent];
+    const [event] = emit.mock.calls[0] as [TelemetryTurnFinishedEvent];
     expect(event.eventId).toBe('custom-event-id');
   });
 
@@ -182,7 +194,7 @@ describe('createTelemetryHook', () => {
 
       await hook(result, createState());
 
-      const [event] = emit.mock.calls[0] as [TelemetryEvent];
+      const [event] = emit.mock.calls[0] as [TelemetryTurnFinishedEvent];
       expect(event.output.kind).toBe(expectedKind);
       expect(event.metadata?.outcome).toBe(outcome);
     },
@@ -201,7 +213,7 @@ describe('createTelemetryHook', () => {
 
     await hook(result, createState());
 
-    const [event] = emit.mock.calls[0] as [TelemetryEvent];
+    const [event] = emit.mock.calls[0] as [TelemetryTurnFinishedEvent];
     expect(event.output).toEqual({
       kind: 'refused',
       text: 'cannot help',
@@ -226,7 +238,7 @@ describe('createTelemetryHook', () => {
 
     await hook(createResult(), state);
 
-    const [event] = emit.mock.calls[0] as [TelemetryEvent];
+    const [event] = emit.mock.calls[0] as [TelemetryTurnFinishedEvent];
     expect(event.cost).toEqual({
       usd: 0,
       missingPricing: true,
@@ -239,6 +251,181 @@ describe('createTelemetryHook', () => {
           missingPricing: true,
         },
       ],
+    });
+  });
+});
+
+describe('telemetry trace bridge', () => {
+  function createSubagentStartedTrace(): HarnessTurnStartedEvent {
+    return {
+      type: 'turn_started',
+      timestamp: '2026-05-07T10:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1.sa-1',
+      iteration: 0,
+      toolCallCount: 0,
+      metadata: {
+        parentTraceId: 'trace-parent',
+        childTraceId: 'trace-parent.sa-1',
+        subagentName: 'research-worker',
+      },
+    };
+  }
+
+  function createSubagentFinishedTrace(
+    overrides: Partial<HarnessTurnFinishedEvent> = {},
+  ): HarnessTurnFinishedEvent {
+    return {
+      type: 'turn_finished',
+      timestamp: '2026-05-07T10:00:05.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1.sa-1',
+      iteration: 2,
+      toolCallCount: 3,
+      elapsedMs: 5000,
+      outcome: 'completed',
+      stopReason: 'answer_finalized',
+      metadata: {
+        parentTraceId: 'trace-parent',
+        childTraceId: 'trace-parent.sa-1',
+        subagentName: 'research-worker',
+      },
+      ...overrides,
+    };
+  }
+
+  it('maps subagent turn trace metadata into lifecycle telemetry events', () => {
+    expect(
+      telemetryEventsFromTraceEvent(createSubagentStartedTrace(), {
+        generateEventId: () => 'event-start',
+      }),
+    ).toEqual([
+      {
+        eventId: 'event-start',
+        eventKind: 'subagent.started',
+        timestamp: '2026-05-07T10:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        parentTraceId: 'trace-parent',
+        durationMs: undefined,
+        subagentName: 'research-worker',
+        childTraceId: 'trace-parent.sa-1',
+        toolCallCount: 0,
+      },
+    ]);
+
+    expect(
+      telemetryEventsFromTraceEvent(createSubagentFinishedTrace(), {
+        generateEventId: () => 'event-finish',
+      }),
+    ).toEqual([
+      {
+        eventId: 'event-finish',
+        eventKind: 'subagent.finished',
+        timestamp: '2026-05-07T10:00:05.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        parentTraceId: 'trace-parent',
+        durationMs: 5000,
+        subagentName: 'research-worker',
+        childTraceId: 'trace-parent.sa-1',
+        iterations: 2,
+        stopReason: 'answer_finalized',
+        toolCallCount: 3,
+      },
+    ]);
+  });
+
+  it('maps non-finalized subagent turns to subagent.failed', () => {
+    expect(
+      telemetryEventsFromTraceEvent(
+        createSubagentFinishedTrace({
+          outcome: 'failed',
+          stopReason: 'runtime_error',
+        }),
+        {
+          generateEventId: () => 'event-failed',
+        },
+      ),
+    ).toEqual([
+      {
+        eventId: 'event-failed',
+        eventKind: 'subagent.failed',
+        timestamp: '2026-05-07T10:00:05.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        parentTraceId: 'trace-parent',
+        durationMs: 5000,
+        subagentName: 'research-worker',
+        childTraceId: 'trace-parent.sa-1',
+        iterations: 2,
+        stopReason: 'runtime_error',
+        toolCallCount: 3,
+      },
+    ]);
+  });
+
+  it('maps runtime policy trace metadata into privacy-safe telemetry events', () => {
+    const event: HarnessRuntimePolicyBlockedTraceEvent = {
+      type: 'runtime_policy.blocked',
+      timestamp: '2026-05-07T11:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      elapsedMs: 20,
+      reason: 'reserve_floor_reached',
+      toolName: 'search',
+      metadata: {
+        parentTraceId: 'trace-parent',
+        floor: 2,
+        categories: ['broad'],
+        output: 'private tool output that must not survive',
+      },
+    };
+
+    expect(
+      telemetryEventsFromTraceEvent(event, {
+        generateEventId: () => 'event-policy',
+      }),
+    ).toEqual([
+      {
+        eventId: 'event-policy',
+        eventKind: 'runtime_policy.blocked',
+        timestamp: '2026-05-07T11:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        parentTraceId: 'trace-parent',
+        durationMs: 20,
+        toolName: 'search',
+        reason: 'reserve_floor_reached',
+        metadata: {
+          floor: 2,
+          categories: ['broad'],
+        },
+      },
+    ]);
+  });
+
+  it('emits mapped trace events through the bridge sink', async () => {
+    const emit = vi.fn();
+    const sink: TelemetrySink = { emit };
+    const bridge: HarnessTraceSink = createTelemetryTraceBridge({
+      sink,
+      generateEventId: () => 'event-bridge',
+    });
+
+    await bridge.emit(createSubagentStartedTrace());
+
+    expect(emit).toHaveBeenCalledWith({
+      eventId: 'event-bridge',
+      eventKind: 'subagent.started',
+      timestamp: '2026-05-07T10:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1.sa-1',
+      parentTraceId: 'trace-parent',
+      durationMs: undefined,
+      subagentName: 'research-worker',
+      childTraceId: 'trace-parent.sa-1',
+      toolCallCount: 0,
     });
   });
 });

--- a/packages/telemetry/test/human-suite.test.ts
+++ b/packages/telemetry/test/human-suite.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertHumanEvalExpected,
+  createHumanEvalRunRecord,
+  humanEvalNeedsReview,
+  loadHumanEvalCasesFromSuitesDir,
+  matchesHumanEvalFilters,
+  renderHumanEvalReview,
+  renderHumanEvalSummary,
+  type HumanEvalTrial,
+  validateHumanEvalCase,
+  writeHumanEvalRunArtifacts,
+} from '../src/evals/index.js';
+
+function makeTempRoot(): string {
+  return mkdtempSync(path.join(tmpdir(), 'aa-human-evals-'));
+}
+
+describe('human eval suite helpers', () => {
+  it('loads JSONL cases from suite directories while ignoring comments and blanks', () => {
+    const root = makeTempRoot();
+    const suiteDir = path.join(root, 'planning');
+    mkdirSync(suiteDir, { recursive: true });
+    writeFileSync(
+      path.join(suiteDir, 'cases.jsonl'),
+      [
+        '# comment',
+        '',
+        JSON.stringify({
+          id: 'planning.case',
+          executor: 'manual',
+          input: { message: 'Plan the work' },
+          expected: { must: ['has validation gates'] },
+          tags: ['planning'],
+        }),
+      ].join('\n'),
+    );
+
+    const cases = loadHumanEvalCasesFromSuitesDir(root, { rootDir: root });
+
+    expect(cases).toHaveLength(1);
+    expect(cases[0]).toMatchObject({
+      id: 'planning.case',
+      suite: 'planning',
+      source: path.join('planning', 'cases.jsonl'),
+      sourceLine: 3,
+    });
+  });
+
+  it('filters by suite, case id, and tags', () => {
+    const evalCase = {
+      id: 'routing.github',
+      suite: 'routing',
+      input: { message: 'list PRs' },
+      tags: ['github', 'routing'],
+    };
+
+    expect(matchesHumanEvalFilters(evalCase, { suite: 'routing' })).toBe(true);
+    expect(matchesHumanEvalFilters(evalCase, { caseId: 'routing.github' })).toBe(true);
+    expect(matchesHumanEvalFilters(evalCase, { tags: new Set(['github']) })).toBe(true);
+    expect(matchesHumanEvalFilters(evalCase, { tags: new Set(['linear']) })).toBe(false);
+  });
+
+  it('validates required case fields', () => {
+    expect(() => validateHumanEvalCase({ id: '', suite: 'x', input: {} })).toThrow(/case.id/);
+    expect(() => validateHumanEvalCase({ id: 'x', suite: '', input: {} })).toThrow(/case.suite/);
+    expect(() => validateHumanEvalCase({ id: 'x', suite: 'y', input: null as never })).toThrow(/case.input/);
+  });
+
+  it('applies deterministic expected checks to normalized output', () => {
+    const checks = assertHumanEvalExpected(
+      {
+        id: 'routing.github',
+        suite: 'routing',
+        input: { message: 'list PRs' },
+        expected: {
+          tier: 'harness',
+          reasonIncludes: 'workspace-data',
+          contentIncludes: ['plan'],
+          forbidPhrases: ['implemented'],
+          toolCallsInclude: ['workspace_list'],
+          toolCallsExclude: ['github_create_issue'],
+          maxToolCalls: 2,
+          must: ['human criterion'],
+        },
+      },
+      {
+        tier: 'harness',
+        reason: 'heuristic:workspace-data',
+        content: 'Here is the plan.',
+        toolCalls: [{ name: 'workspace_list' }],
+      },
+    );
+
+    expect(checks.every((check) => check.passed)).toBe(true);
+    expect(checks.map((check) => check.name)).toContain('human:must');
+  });
+
+  it('flags human review when requested by expected or grading metadata', () => {
+    expect(humanEvalNeedsReview({
+      id: 'x',
+      suite: 'planning',
+      input: {},
+      expected: { humanReviewRequired: true },
+    })).toBe(true);
+    expect(humanEvalNeedsReview({
+      id: 'y',
+      suite: 'planning',
+      input: {},
+      grading: { humanReview: true },
+    })).toBe(true);
+  });
+
+  it('renders and writes run artifacts', () => {
+    const root = makeTempRoot();
+    const run = createHumanEvalRunRecord({
+      branch: 'main',
+      gitSha: 'abc123',
+      mode: 'offline',
+      runDir: path.join(root, 'run-1'),
+      selectedCaseCount: 1,
+      timestamp: '2026-05-08T00:00:00.000Z',
+    });
+    const trial: HumanEvalTrial = {
+      id: 'planning.case',
+      suite: 'planning',
+      kind: 'capability',
+      executor: 'manual',
+      trial: 1,
+      tags: [],
+      status: 'needs-human',
+      duration_ms: 12,
+      checks: [{ name: 'status', passed: true, message: 'case executed' }],
+      actual: { content: 'A plan requiring review.' },
+    };
+    run.tests.push(trial);
+
+    const summary = writeHumanEvalRunArtifacts(run, { final: true });
+
+    expect(summary.needs_human).toBe(1);
+    expect(renderHumanEvalSummary(summary)).toContain('NEEDS-HUMAN planning.case');
+    expect(renderHumanEvalReview(summary)).toContain('Human verdict: TODO');
+    expect(readFileSync(path.join(root, 'run-1', 'result.json'), 'utf8')).toContain('"needs_human": 1');
+  });
+});

--- a/packages/telemetry/test/pr-comment-format.test.ts
+++ b/packages/telemetry/test/pr-comment-format.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatPrCommentSummary, type EvalResult } from '../src/evals/index.js';
+
+function createResult(overrides: Partial<EvalResult> & Pick<EvalResult, 'name' | 'passed'>): EvalResult {
+  return {
+    name: overrides.name,
+    passed: overrides.passed,
+    score: overrides.score ?? {
+      components: {
+        requiredEvidence: overrides.passed ? 1 : 0,
+        forbiddenFanout: overrides.passed ? 1 : 0,
+        budget: overrides.passed ? 1 : 0,
+        finalOutputClean: overrides.passed ? 1 : 0,
+      },
+      total: overrides.passed ? 1 : 0.25,
+    },
+    evidence: overrides.evidence ?? {
+      matched: overrides.passed ? ['package.json'] : [],
+      missing: overrides.passed ? [] : ['docs/spec.md'],
+    },
+    forbiddenFanoutViolations: overrides.forbiddenFanoutViolations ?? (
+      overrides.passed ? [] : ['workspace_list called 4 times (max 2)']
+    ),
+    budget: overrides.budget ?? {
+      toolCalls: overrides.passed ? 2 : 6,
+      latencyMs: overrides.passed ? 24 : 145,
+      cost: overrides.passed ? 0.2 : 1.7,
+    },
+    finalOutputCleanResult: overrides.finalOutputCleanResult ?? {
+      clean: overrides.passed,
+      sanitizedKinds: overrides.passed ? [] : ['pseudo_tool_fence'],
+    },
+  };
+}
+
+describe('formatPrCommentSummary', () => {
+  it('keeps the markdown under the size cap and uses compact failure details', () => {
+    const results: EvalResult[] = Array.from({ length: 40 }, (_, index) =>
+      createResult({
+        name: `case-${String(index).padStart(2, '0')}`,
+        passed: index % 3 !== 0,
+      }),
+    );
+
+    const summary = formatPrCommentSummary(results);
+
+    expect(Buffer.byteLength(summary, 'utf8')).toBeLessThanOrEqual(4 * 1024);
+    expect(summary).toContain('## Eval Summary');
+    expect(summary).toContain('<details>');
+    expect(summary).toContain('Additional eval detail omitted');
+  });
+
+  it('orders failures before passes and sorts names deterministically', () => {
+    const summary = formatPrCommentSummary([
+      createResult({ name: 'bravo', passed: true }),
+      createResult({ name: 'alpha', passed: false }),
+      createResult({ name: 'charlie', passed: false }),
+    ]);
+
+    const alphaIndex = summary.indexOf('FAIL `alpha`');
+    const charlieIndex = summary.indexOf('FAIL `charlie`');
+    const bravoIndex = summary.indexOf('PASS `bravo`');
+
+    expect(alphaIndex).toBeGreaterThanOrEqual(0);
+    expect(charlieIndex).toBeGreaterThan(alphaIndex);
+    expect(bravoIndex).toBeGreaterThan(charlieIndex);
+    expect(summary).toContain('missing evidence: docs/spec.md');
+  });
+});

--- a/packages/telemetry/test/private_content_never_leaks.test.ts
+++ b/packages/telemetry/test/private_content_never_leaks.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { HarnessRuntimePolicyBlockedTraceEvent } from '@agent-assistant/harness';
+
+import {
+  createRuntimePolicyBlockedEvent,
+  createSynthesisSalvagedEvent,
+} from '../src/events.js';
+import { telemetryEventsFromTraceEvent } from '../src/harness-bridge.js';
+
+describe('privacy-safe telemetry constructors', () => {
+  it.each([
+    [{ message: 'provider said hello' }],
+    [{ input: 'raw tool input' }],
+    [{ output: 'raw tool output' }],
+    [{ text: 'verbatim provider text' }],
+  ])('rejects forbidden raw-content metadata shapes: %j', (metadata) => {
+    expect(() =>
+      createRuntimePolicyBlockedEvent({
+        timestamp: '2026-05-07T14:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'reserve_floor_reached',
+        metadata,
+      }),
+    ).toThrow(/not allowed/u);
+  });
+
+  it('rejects nested object metadata instead of serializing it', () => {
+    expect(() =>
+      createSynthesisSalvagedEvent({
+        timestamp: '2026-05-07T14:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'completed_after_runtime_policy_intervention',
+        metadata: {
+          nested: { unsafe: true } as never,
+        },
+      }),
+    ).toThrow(/bounded scalar values/u);
+  });
+
+  it('strips unsafe metadata keys when bridging from harness trace events', () => {
+    const traceEvent: HarnessRuntimePolicyBlockedTraceEvent = {
+      type: 'runtime_policy.blocked',
+      timestamp: '2026-05-07T14:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      reason: 'reserve_floor_reached',
+      metadata: {
+        message: 'private provider content',
+        output: 'private tool output',
+        floor: 2,
+        categories: ['broad'],
+      },
+    };
+
+    expect(telemetryEventsFromTraceEvent(traceEvent)).toEqual([
+      {
+        eventId: expect.any(String),
+        eventKind: 'runtime_policy.blocked',
+        timestamp: '2026-05-07T14:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'reserve_floor_reached',
+        metadata: {
+          floor: 2,
+          categories: ['broad'],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/telemetry/test/runtime-policy-events.test.ts
+++ b/packages/telemetry/test/runtime-policy-events.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createRuntimePolicyBlockedEvent,
+  createRuntimePolicyCacheHitEvent,
+  createRuntimePolicyOutputSanitizedEvent,
+  createSubagentBatchStartedEvent,
+  createSubagentFailedEvent,
+  createSubagentFinishedEvent,
+  createSubagentStartedEvent,
+  createSynthesisSalvagedEvent,
+} from '../src/events.js';
+import { InMemoryTelemetrySink } from '../src/sinks/memory.js';
+
+describe('runtime policy telemetry events', () => {
+  it('returns frozen, schema-stable runtime policy payloads', () => {
+    const blocked = createRuntimePolicyBlockedEvent(
+      {
+        timestamp: '2026-05-07T13:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        parentTraceId: 'trace-parent',
+        toolName: 'search',
+        reason: 'reserve_floor_reached',
+        metadata: {
+          floor: 2,
+          categories: ['broad'],
+        },
+      },
+      { generateEventId: () => 'event-blocked' },
+    );
+    const cacheHit = createRuntimePolicyCacheHitEvent(
+      {
+        timestamp: '2026-05-07T13:00:01.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        toolName: 'search',
+        reason: 'duplicate_tool_call_cached',
+        metadata: {
+          cached: true,
+        },
+      },
+      { generateEventId: () => 'event-cache' },
+    );
+    const sanitized = createRuntimePolicyOutputSanitizedEvent(
+      {
+        timestamp: '2026-05-07T13:00:02.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'pseudo_tool_syntax_removed',
+        metadata: {
+          strippedTokenClasses: ['pseudo_tool_fence', 'invoke'],
+        },
+      },
+      { generateEventId: () => 'event-sanitized' },
+    );
+    const salvaged = createSynthesisSalvagedEvent(
+      {
+        timestamp: '2026-05-07T13:00:03.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'completed_after_runtime_policy_intervention',
+        metadata: {
+          blockedCalls: 1,
+          cacheHits: 2,
+          sanitizerHits: 1,
+        },
+      },
+      { generateEventId: () => 'event-salvaged' },
+    );
+
+    expect(blocked).toEqual({
+      eventId: 'event-blocked',
+      eventKind: 'runtime_policy.blocked',
+      timestamp: '2026-05-07T13:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      parentTraceId: 'trace-parent',
+      toolName: 'search',
+      reason: 'reserve_floor_reached',
+      metadata: {
+        floor: 2,
+        categories: ['broad'],
+      },
+    });
+    expect(cacheHit).toEqual({
+      eventId: 'event-cache',
+      eventKind: 'runtime_policy.cache_hit',
+      timestamp: '2026-05-07T13:00:01.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      toolName: 'search',
+      reason: 'duplicate_tool_call_cached',
+      metadata: {
+        cached: true,
+      },
+    });
+    expect(sanitized).toEqual({
+      eventId: 'event-sanitized',
+      eventKind: 'runtime_policy.output_sanitized',
+      timestamp: '2026-05-07T13:00:02.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      reason: 'pseudo_tool_syntax_removed',
+      metadata: {
+        strippedTokenClasses: ['pseudo_tool_fence', 'invoke'],
+      },
+    });
+    expect(salvaged).toEqual({
+      eventId: 'event-salvaged',
+      eventKind: 'synthesis.salvaged',
+      timestamp: '2026-05-07T13:00:03.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      reason: 'completed_after_runtime_policy_intervention',
+      metadata: {
+        blockedCalls: 1,
+        cacheHits: 2,
+        sanitizerHits: 1,
+      },
+    });
+
+    expect(Object.isFrozen(blocked)).toBe(true);
+    expect(Object.isFrozen(blocked.metadata)).toBe(true);
+  });
+
+  it('round-trips every new event kind through the in-memory sink', () => {
+    const sink = new InMemoryTelemetrySink();
+    const events = [
+      createSubagentBatchStartedEvent({
+        timestamp: '2026-05-07T13:10:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        subagentNames: ['reader'],
+        childTraceIds: ['trace-parent.sa-1'],
+      }),
+      createSubagentStartedEvent({
+        timestamp: '2026-05-07T13:10:01.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        subagentName: 'reader',
+        childTraceId: 'trace-parent.sa-1',
+      }),
+      createSubagentFinishedEvent({
+        timestamp: '2026-05-07T13:10:02.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        subagentName: 'reader',
+        childTraceId: 'trace-parent.sa-1',
+      }),
+      createSubagentFailedEvent({
+        timestamp: '2026-05-07T13:10:03.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-2',
+        subagentName: 'writer',
+        childTraceId: 'trace-parent.sa-2',
+        stopReason: 'runtime_error',
+      }),
+      createRuntimePolicyBlockedEvent({
+        timestamp: '2026-05-07T13:10:04.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'reserve_floor_reached',
+      }),
+      createRuntimePolicyCacheHitEvent({
+        timestamp: '2026-05-07T13:10:05.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'duplicate_tool_call_cached',
+      }),
+      createRuntimePolicyOutputSanitizedEvent({
+        timestamp: '2026-05-07T13:10:06.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'pseudo_tool_syntax_removed',
+      }),
+      createSynthesisSalvagedEvent({
+        timestamp: '2026-05-07T13:10:07.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        reason: 'completed_after_runtime_policy_intervention',
+      }),
+    ];
+
+    for (const event of events) {
+      sink.emit(event);
+    }
+
+    expect(sink.events()).toEqual(events);
+  });
+});

--- a/packages/telemetry/test/subagent-events.test.ts
+++ b/packages/telemetry/test/subagent-events.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createSubagentBatchStartedEvent,
+  createSubagentFailedEvent,
+  createSubagentFinishedEvent,
+  createSubagentStartedEvent,
+} from '../src/events.js';
+
+describe('subagent telemetry events', () => {
+  it('returns frozen, schema-stable payloads for subagent lifecycle events', () => {
+    const started = createSubagentStartedEvent(
+      {
+        timestamp: '2026-05-07T12:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        parentTraceId: 'trace-parent',
+        childTraceId: 'trace-parent.sa-1',
+        subagentName: 'repo-reader',
+        toolCallCount: 0,
+      },
+      { generateEventId: () => 'event-started' },
+    );
+    const finished = createSubagentFinishedEvent(
+      {
+        timestamp: '2026-05-07T12:00:05.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-1',
+        parentTraceId: 'trace-parent',
+        childTraceId: 'trace-parent.sa-1',
+        subagentName: 'repo-reader',
+        iterations: 2,
+        stopReason: 'answer_finalized',
+        toolCallCount: 3,
+        durationMs: 5000,
+      },
+      { generateEventId: () => 'event-finished' },
+    );
+    const failed = createSubagentFailedEvent(
+      {
+        timestamp: '2026-05-07T12:00:06.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1.sa-2',
+        parentTraceId: 'trace-parent',
+        childTraceId: 'trace-parent.sa-2',
+        subagentName: 'repo-writer',
+        iterations: 1,
+        stopReason: 'runtime_error',
+        toolCallCount: 1,
+      },
+      { generateEventId: () => 'event-failed' },
+    );
+    const batch = createSubagentBatchStartedEvent(
+      {
+        timestamp: '2026-05-07T12:00:00.000Z',
+        assistantId: 'assistant-1',
+        turnId: 'turn-1',
+        parentTraceId: 'trace-parent',
+        subagentNames: ['repo-reader', 'repo-writer'],
+        childTraceIds: ['trace-parent.sa-1', 'trace-parent.sa-2'],
+      },
+      { generateEventId: () => 'event-batch' },
+    );
+
+    expect(started).toEqual({
+      eventId: 'event-started',
+      eventKind: 'subagent.started',
+      timestamp: '2026-05-07T12:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1.sa-1',
+      parentTraceId: 'trace-parent',
+      childTraceId: 'trace-parent.sa-1',
+      subagentName: 'repo-reader',
+      toolCallCount: 0,
+    });
+    expect(finished).toEqual({
+      eventId: 'event-finished',
+      eventKind: 'subagent.finished',
+      timestamp: '2026-05-07T12:00:05.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1.sa-1',
+      parentTraceId: 'trace-parent',
+      childTraceId: 'trace-parent.sa-1',
+      subagentName: 'repo-reader',
+      iterations: 2,
+      stopReason: 'answer_finalized',
+      toolCallCount: 3,
+      durationMs: 5000,
+    });
+    expect(failed).toEqual({
+      eventId: 'event-failed',
+      eventKind: 'subagent.failed',
+      timestamp: '2026-05-07T12:00:06.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1.sa-2',
+      parentTraceId: 'trace-parent',
+      childTraceId: 'trace-parent.sa-2',
+      subagentName: 'repo-writer',
+      iterations: 1,
+      stopReason: 'runtime_error',
+      toolCallCount: 1,
+    });
+    expect(batch).toEqual({
+      eventId: 'event-batch',
+      eventKind: 'subagent.batch.started',
+      timestamp: '2026-05-07T12:00:00.000Z',
+      assistantId: 'assistant-1',
+      turnId: 'turn-1',
+      parentTraceId: 'trace-parent',
+      subagentNames: ['repo-reader', 'repo-writer'],
+      childTraceIds: ['trace-parent.sa-1', 'trace-parent.sa-2'],
+      batchSize: 2,
+    });
+
+    expect(Object.isFrozen(started)).toBe(true);
+    expect(Object.isFrozen(batch)).toBe(true);
+    expect(Object.isFrozen(batch.subagentNames)).toBe(true);
+    expect(Object.isFrozen(batch.childTraceIds)).toBe(true);
+  });
+
+  it('rejects oversize payloads at construction time', () => {
+    expect(() =>
+      createSubagentStartedEvent(
+        {
+          timestamp: '2026-05-07T12:00:00.000Z',
+          assistantId: 'assistant-1',
+          turnId: 'turn-1.sa-1',
+          parentTraceId: 'trace-parent',
+          childTraceId: 'trace-parent.sa-1',
+          subagentName: 'repo-reader',
+        },
+        {
+          generateEventId: () => 'event-started',
+          maxPayloadBytes: 64,
+        },
+      ),
+    ).toThrow(/exceeds max 64 bytes/u);
+  });
+});

--- a/packages/turn-context/package.json
+++ b/packages/turn-context/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
     "@agent-assistant/memory": "^0.2.0",
-    "@agent-assistant/traits": "^0.2.0"
+    "@agent-assistant/traits": "^0.2.0",
+    "@agent-assistant/vfs": "^0.4.0 || ^0.6.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/turn-context/src/index.ts
+++ b/packages/turn-context/src/index.ts
@@ -2,6 +2,8 @@ export { createTurnContextAssembler } from './assembler.js';
 export type { CreateTurnContextAssemblerOptions } from './assembler.js';
 export { createMemoryTurnRetriever } from './memory-retriever.js';
 export type { CreateMemoryTurnRetrieverOptions } from './memory-retriever.js';
+export { projectInsightAsContextBlock } from './insight-projection.js';
+export type { InsightProjectionInput } from './insight-projection.js';
 export { projectToHarness, toExecutionRequest } from './projection.js';
 export type {
   ExecutionRequestMessageInput,

--- a/packages/turn-context/src/insight-projection.test.ts
+++ b/packages/turn-context/src/insight-projection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectInsightAsContextBlock, type InsightEnvelope } from './insight-projection.js';
+
+describe('projectInsightAsContextBlock', () => {
+  it('preserves provenance fields in block metadata', () => {
+    const envelope: InsightEnvelope<{ summary: string }> = {
+      schemaVersion: 'insight/v1',
+      generatedAt: '2026-05-07T12:00:00.000Z',
+      sourceProvider: 'relayfile',
+      sourcePaths: ['/insights/pr-123.json', '/insights/supporting.txt'],
+      freshness: {
+        ttlSeconds: 600,
+        staleAt: '2026-05-07T12:10:00.000Z',
+      },
+      body: {
+        summary: 'Insight summary.',
+      },
+    };
+
+    const block = projectInsightAsContextBlock({ envelope });
+
+    expect(block).toMatchObject({
+      label: 'Insight (relayfile)',
+      source: 'relayfile',
+      category: 'other',
+      metadata: {
+        schemaVersion: 'insight/v1',
+        generatedAt: '2026-05-07T12:00:00.000Z',
+        sourceProvider: 'relayfile',
+        sourcePaths: ['/insights/pr-123.json', '/insights/supporting.txt'],
+        freshness: {
+          ttlSeconds: 600,
+          staleAt: '2026-05-07T12:10:00.000Z',
+        },
+      },
+    });
+    expect(block.content).toContain('"summary": "Insight summary."');
+  });
+
+  it('respects preview.maxChars when projecting content', () => {
+    const block = projectInsightAsContextBlock({
+      envelope: {
+        schemaVersion: 'insight/v1',
+        generatedAt: '2026-05-07T12:00:00.000Z',
+        sourceProvider: 'relayfile',
+        sourcePaths: ['/insights/preview.txt'],
+        body: 'abcdefghijklmnopqrstuvwxyz',
+      },
+      preview: { maxChars: 10 },
+    });
+
+    expect(block.content).toBe('abcdefghij');
+  });
+});

--- a/packages/turn-context/src/insight-projection.ts
+++ b/packages/turn-context/src/insight-projection.ts
@@ -1,0 +1,73 @@
+import type { TurnPreparedContextBlock } from './types.js';
+
+export interface InsightFreshness {
+  ttlSeconds?: number;
+  staleAt?: string;
+}
+
+export interface InsightEnvelope<TBody = unknown> {
+  schemaVersion: string;
+  generatedAt: string;
+  sourceProvider: string;
+  sourcePaths: string[];
+  freshness?: InsightFreshness;
+  body: TBody;
+}
+
+export interface InsightProjectionInput<TBody = unknown> {
+  envelope: InsightEnvelope<TBody>;
+  preview?: { maxChars: number };
+}
+
+function stringifyBody(body: unknown): string {
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  if (
+    typeof body === 'number' ||
+    typeof body === 'boolean' ||
+    body === null ||
+    Array.isArray(body) ||
+    (typeof body === 'object' && body !== null)
+  ) {
+    return JSON.stringify(body, null, 2);
+  }
+
+  return String(body);
+}
+
+function applyPreview(content: string, maxChars: number | undefined): string {
+  if (maxChars === undefined) {
+    return content;
+  }
+
+  const limit = Math.max(0, Math.floor(maxChars));
+  return content.length > limit ? content.slice(0, limit) : content;
+}
+
+function toBlockId(envelope: InsightEnvelope): string {
+  const rawId = `${envelope.sourceProvider}-${envelope.generatedAt}`;
+  return `insight-${rawId.toLowerCase().replace(/[^a-z0-9]+/gu, '-').replace(/(^-|-$)/gu, '')}`;
+}
+
+export function projectInsightAsContextBlock<TBody = unknown>(
+  input: InsightProjectionInput<TBody>,
+): TurnPreparedContextBlock {
+  const { envelope } = input;
+
+  return {
+    id: toBlockId(envelope),
+    label: `Insight (${envelope.sourceProvider})`,
+    content: applyPreview(stringifyBody(envelope.body), input.preview?.maxChars),
+    source: envelope.sourceProvider,
+    category: 'other',
+    metadata: {
+      schemaVersion: envelope.schemaVersion,
+      generatedAt: envelope.generatedAt,
+      sourceProvider: envelope.sourceProvider,
+      sourcePaths: [...envelope.sourcePaths],
+      ...(envelope.freshness !== undefined ? { freshness: { ...envelope.freshness } } : {}),
+    },
+  };
+}

--- a/packages/turn-context/src/projection.ts
+++ b/packages/turn-context/src/projection.ts
@@ -176,9 +176,13 @@ function mapContextBlock(
     label: block.label,
     text: block.content,
     ...(mappedCategory !== undefined ? { category: mappedCategory } : {}),
-    ...(block.source !== undefined || block.importance !== undefined || block.category === 'session'
+    ...(block.source !== undefined ||
+    block.importance !== undefined ||
+    block.category === 'session' ||
+    block.metadata !== undefined
       ? {
           metadata: {
+            ...(block.metadata ?? {}),
             ...(block.source !== undefined ? { source: block.source } : {}),
             ...(block.importance !== undefined ? { importance: block.importance } : {}),
             ...(block.category === 'session' ? { turnContextCategory: 'session' } : {}),

--- a/packages/turn-context/src/types.ts
+++ b/packages/turn-context/src/types.ts
@@ -226,6 +226,7 @@ export interface TurnPreparedContextBlock {
   importance?: 'low' | 'medium' | 'high';
   source?: string;
   category?: 'memory' | 'session' | 'enrichment' | 'workspace' | 'guardrail' | 'other';
+  metadata?: Record<string, unknown>;
 }
 
 export interface TurnContextProvenance {

--- a/packages/turn-context/src/vfs-insight-types.d.ts
+++ b/packages/turn-context/src/vfs-insight-types.d.ts
@@ -1,0 +1,15 @@
+declare module '@agent-assistant/vfs' {
+  export interface InsightFreshness {
+    ttlSeconds?: number;
+    staleAt?: string;
+  }
+
+  export interface InsightEnvelope<TBody = unknown> {
+    schemaVersion: string;
+    generatedAt: string;
+    sourceProvider: string;
+    sourcePaths: string[];
+    freshness?: InsightFreshness;
+    body: TBody;
+  }
+}

--- a/packages/vfs/src/index.ts
+++ b/packages/vfs/src/index.ts
@@ -1,4 +1,5 @@
 export { runVfsCli } from './cli.js';
+export { readInsightEnvelope } from './insight/index.js';
 export {
   basename,
   dirname,
@@ -23,6 +24,12 @@ export type {
   VfsSearchOptions,
   VfsSearchResult,
 } from './types.js';
+export type {
+  InsightEnvelope,
+  InsightFreshness,
+  InsightReadResult,
+  VirtualFileSystem,
+} from './insight/index.js';
 export type { TruncatedReadResult } from './output.js';
 // Clone primitives — see './clone' subpath for the focused submodule.
 export type {

--- a/packages/vfs/src/insight/envelope.ts
+++ b/packages/vfs/src/insight/envelope.ts
@@ -1,0 +1,25 @@
+import type { VfsProvider } from '../types.js';
+
+export interface InsightFreshness {
+  ttlSeconds?: number;
+  staleAt?: string;
+}
+
+export interface InsightEnvelope<TBody = unknown> {
+  schemaVersion: string;
+  generatedAt: string;
+  sourceProvider: string;
+  sourcePaths: string[];
+  freshness?: InsightFreshness;
+  body: TBody;
+}
+
+export type VirtualFileSystem = VfsProvider;
+
+export type InsightReadResult<TBody = unknown> =
+  | { ok: true; envelope: InsightEnvelope<TBody> }
+  | {
+      ok: false;
+      reason: 'missing' | 'malformed' | 'unsupported_schema';
+      partial?: Partial<InsightEnvelope<TBody>>;
+    };

--- a/packages/vfs/src/insight/index.ts
+++ b/packages/vfs/src/insight/index.ts
@@ -1,0 +1,7 @@
+export type {
+  InsightEnvelope,
+  InsightFreshness,
+  InsightReadResult,
+  VirtualFileSystem,
+} from './envelope.js';
+export { readInsightEnvelope } from './reader.js';

--- a/packages/vfs/src/insight/reader.test.ts
+++ b/packages/vfs/src/insight/reader.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { readInsightEnvelope } from '../index.js';
+import type { InsightEnvelope, VfsProvider } from '../index.js';
+
+class InMemoryVfs implements VfsProvider {
+  constructor(private readonly files: Record<string, string>) {}
+
+  async list() {
+    return [];
+  }
+
+  async read(path: string) {
+    const content = this.files[path];
+    return content === undefined ? null : { path, content };
+  }
+
+  async search() {
+    return [];
+  }
+}
+
+describe('readInsightEnvelope', () => {
+  it('reads a valid insight envelope and preserves provenance fields', async () => {
+    const envelope: InsightEnvelope<{ summary: string }> = {
+      schemaVersion: 'insight/v1',
+      generatedAt: '2026-05-07T12:00:00.000Z',
+      sourceProvider: 'relayfile',
+      sourcePaths: ['/insights/pr-123.json'],
+      freshness: {
+        ttlSeconds: 600,
+        staleAt: '2026-05-07T12:10:00.000Z',
+      },
+      body: {
+        summary: 'A concise summary.',
+      },
+    };
+
+    const result = await readInsightEnvelope<{ summary: string }>(
+      new InMemoryVfs({
+        '/insights/pr-123.json': JSON.stringify(envelope),
+      }),
+      '/insights/pr-123.json',
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      envelope,
+    });
+  });
+
+  it('returns missing when the file does not exist', async () => {
+    const result = await readInsightEnvelope(new InMemoryVfs({}), '/insights/missing.json');
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'missing',
+    });
+  });
+
+  it('returns malformed with partial fields for partial artifacts', async () => {
+    const result = await readInsightEnvelope(
+      new InMemoryVfs({
+        '/insights/partial.json': JSON.stringify({
+          schemaVersion: 'insight/v1',
+          generatedAt: '2026-05-07T12:00:00.000Z',
+          sourceProvider: 'relayfile',
+          sourcePaths: ['/insights/partial.json'],
+        }),
+      }),
+      '/insights/partial.json',
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'malformed',
+      partial: {
+        schemaVersion: 'insight/v1',
+        generatedAt: '2026-05-07T12:00:00.000Z',
+        sourceProvider: 'relayfile',
+        sourcePaths: ['/insights/partial.json'],
+      },
+    });
+  });
+
+  it('returns malformed with partial fields salvaged from malformed json', async () => {
+    const result = await readInsightEnvelope(
+      new InMemoryVfs({
+        '/insights/broken.json': `{
+  "schemaVersion": "insight/v1",
+  "generatedAt": "2026-05-07T12:00:00.000Z",
+  "sourceProvider": "relayfile",
+  "sourcePaths": ["/insights/broken.json"],
+  "freshness": { "ttlSeconds": 600 },
+  "body": {
+`,
+      }),
+      '/insights/broken.json',
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'malformed',
+      partial: {
+        schemaVersion: 'insight/v1',
+        generatedAt: '2026-05-07T12:00:00.000Z',
+        sourceProvider: 'relayfile',
+        sourcePaths: ['/insights/broken.json'],
+        freshness: { ttlSeconds: 600 },
+      },
+    });
+  });
+
+  it('returns unsupported_schema for unknown schema versions', async () => {
+    const result = await readInsightEnvelope(
+      new InMemoryVfs({
+        '/insights/future.json': JSON.stringify({
+          schemaVersion: 'insight/v2',
+          generatedAt: '2026-05-07T12:00:00.000Z',
+          sourceProvider: 'relayfile',
+          sourcePaths: ['/insights/future.json'],
+          body: {
+            summary: 'Future schema.',
+          },
+        }),
+      }),
+      '/insights/future.json',
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unsupported_schema',
+      partial: {
+        schemaVersion: 'insight/v2',
+        generatedAt: '2026-05-07T12:00:00.000Z',
+        sourceProvider: 'relayfile',
+        sourcePaths: ['/insights/future.json'],
+        body: {
+          summary: 'Future schema.',
+        },
+      },
+    });
+  });
+});

--- a/packages/vfs/src/insight/reader.ts
+++ b/packages/vfs/src/insight/reader.ts
@@ -1,0 +1,274 @@
+import type { InsightEnvelope, InsightFreshness, InsightReadResult, VirtualFileSystem } from './envelope.js';
+
+const SUPPORTED_SCHEMA_VERSION = 'insight/v1';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function parseFreshness(value: unknown): InsightFreshness | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const freshness: InsightFreshness = {};
+  if (typeof value.ttlSeconds === 'number' && Number.isFinite(value.ttlSeconds)) {
+    freshness.ttlSeconds = value.ttlSeconds;
+  }
+  if (typeof value.staleAt === 'string') {
+    freshness.staleAt = value.staleAt;
+  }
+
+  return Object.keys(freshness).length > 0 ? freshness : undefined;
+}
+
+function toPartialEnvelope<TBody = unknown>(value: Record<string, unknown>): Partial<InsightEnvelope<TBody>> {
+  const partial: Partial<InsightEnvelope<TBody>> = {};
+
+  if (typeof value.schemaVersion === 'string') {
+    partial.schemaVersion = value.schemaVersion;
+  }
+  if (typeof value.generatedAt === 'string') {
+    partial.generatedAt = value.generatedAt;
+  }
+  if (typeof value.sourceProvider === 'string') {
+    partial.sourceProvider = value.sourceProvider;
+  }
+  if (isStringArray(value.sourcePaths)) {
+    partial.sourcePaths = [...value.sourcePaths];
+  }
+
+  const freshness = parseFreshness(value.freshness);
+  if (freshness !== undefined) {
+    partial.freshness = freshness;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(value, 'body')) {
+    partial.body = value.body as TBody;
+  }
+
+  return partial;
+}
+
+function skipWhitespace(raw: string, index: number): number {
+  let cursor = index;
+  while (cursor < raw.length && /\s/u.test(raw[cursor] ?? '')) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function readStringValue(raw: string, start: number): string | undefined {
+  let cursor = start + 1;
+  let escaped = false;
+
+  while (cursor < raw.length) {
+    const char = raw[cursor];
+    if (char === undefined) {
+      return undefined;
+    }
+
+    if (escaped) {
+      escaped = false;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      return raw.slice(start, cursor + 1);
+    }
+
+    cursor += 1;
+  }
+
+  return undefined;
+}
+
+function readBalancedValue(raw: string, start: number, openChar: '{' | '[', closeChar: '}' | ']'): string | undefined {
+  let cursor = start;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  while (cursor < raw.length) {
+    const char = raw[cursor];
+    if (char === undefined) {
+      return undefined;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+
+      cursor += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      cursor += 1;
+      continue;
+    }
+
+    if (char === openChar) {
+      depth += 1;
+    } else if (char === closeChar) {
+      depth -= 1;
+      if (depth === 0) {
+        return raw.slice(start, cursor + 1);
+      }
+    }
+
+    cursor += 1;
+  }
+
+  return undefined;
+}
+
+function readPrimitiveValue(raw: string, start: number): string | undefined {
+  let cursor = start;
+  while (cursor < raw.length) {
+    const char = raw[cursor];
+    if (char === undefined || char === ',' || char === '}' || char === ']') {
+      break;
+    }
+    cursor += 1;
+  }
+
+  const fragment = raw.slice(start, cursor).trim();
+  return fragment.length > 0 ? fragment : undefined;
+}
+
+function extractKeyValue(raw: string, key: string): unknown {
+  const keyPattern = new RegExp(`"${key}"\\s*:`, 'u');
+  const match = keyPattern.exec(raw);
+  if (match?.index === undefined) {
+    return undefined;
+  }
+
+  const valueStart = skipWhitespace(raw, match.index + match[0].length);
+  const firstChar = raw[valueStart];
+
+  let fragment: string | undefined;
+  if (firstChar === '"') {
+    fragment = readStringValue(raw, valueStart);
+  } else if (firstChar === '{') {
+    fragment = readBalancedValue(raw, valueStart, '{', '}');
+  } else if (firstChar === '[') {
+    fragment = readBalancedValue(raw, valueStart, '[', ']');
+  } else {
+    fragment = readPrimitiveValue(raw, valueStart);
+  }
+
+  if (!fragment) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(fragment);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractPartialFromMalformedJson<TBody = unknown>(raw: string): Partial<InsightEnvelope<TBody>> | undefined {
+  const source: Record<string, unknown> = {};
+  for (const key of ['schemaVersion', 'generatedAt', 'sourceProvider', 'sourcePaths', 'freshness', 'body']) {
+    const value = extractKeyValue(raw, key);
+    if (value !== undefined) {
+      source[key] = value;
+    }
+  }
+
+  const partial = toPartialEnvelope<TBody>(source);
+  return Object.keys(partial).length > 0 ? partial : undefined;
+}
+
+function isValidEnvelope<TBody = unknown>(
+  partial: Partial<InsightEnvelope<TBody>>,
+): partial is InsightEnvelope<TBody> {
+  if (typeof partial.schemaVersion !== 'string') {
+    return false;
+  }
+  if (typeof partial.generatedAt !== 'string') {
+    return false;
+  }
+  if (typeof partial.sourceProvider !== 'string') {
+    return false;
+  }
+  if (!Array.isArray(partial.sourcePaths) || partial.sourcePaths.some((item) => typeof item !== 'string')) {
+    return false;
+  }
+  if (!Object.prototype.hasOwnProperty.call(partial, 'body')) {
+    return false;
+  }
+  if (
+    partial.freshness !== undefined &&
+    (typeof partial.freshness !== 'object' || partial.freshness === null || Array.isArray(partial.freshness))
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function readInsightEnvelope<TBody = unknown>(
+  vfs: VirtualFileSystem,
+  path: string,
+): Promise<InsightReadResult<TBody>> {
+  const entry = await vfs.read(path);
+  if (entry === null) {
+    return { ok: false, reason: 'missing' };
+  }
+
+  try {
+    const parsed = JSON.parse(entry.content) as unknown;
+    if (!isRecord(parsed)) {
+      return { ok: false, reason: 'malformed' };
+    }
+
+    const partial = toPartialEnvelope<TBody>(parsed);
+    if (!isValidEnvelope(partial)) {
+      return {
+        ok: false,
+        reason: 'malformed',
+        ...(Object.keys(partial).length > 0 ? { partial } : {}),
+      };
+    }
+
+    if (partial.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
+      return {
+        ok: false,
+        reason: 'unsupported_schema',
+        partial,
+      };
+    }
+
+    return {
+      ok: true,
+      envelope: partial,
+    };
+  } catch {
+    const partial = extractPartialFromMalformedJson<TBody>(entry.content);
+    return {
+      ok: false,
+      reason: 'malformed',
+      ...(partial !== undefined ? { partial } : {}),
+    };
+  }
+}

--- a/workflows/generated/ricky-spec-agent-assistant-harness-v0-5-v0-6-v0-7-impr.ts
+++ b/workflows/generated/ricky-spec-agent-assistant-harness-v0-5-v0-6-v0-7-impr.ts
@@ -1,0 +1,447 @@
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const WORKFLOW_NAME = 'ricky-spec-agent-assistant-harness-v0-5-v0-6-v0-7-impr';
+const WORKFLOW_CHANNEL = 'wf-ricky-spec-agent-assistant-harness-v0-5-v0-6-v0-7-impr';
+const WORKFLOW_GATE_DIR = 'tmp/workflow-gates';
+const CONTEXT_SNAPSHOT_FILE = `${WORKFLOW_GATE_DIR}/ricky-skill-router-context.md`;
+const PLAN_FILE = 'docs/architecture/ricky-harness-v0.5-v0.7-plan.md';
+const RUNTIME_GATE_FILE = `${WORKFLOW_GATE_DIR}/ricky-runtime-gate.txt`;
+const V05_LAUNCH_GATE_FILE = `${WORKFLOW_GATE_DIR}/implement-v0-5-launch-gate.txt`;
+const V067_LAUNCH_GATE_FILE = `${WORKFLOW_GATE_DIR}/implement-v0-6-v0-7-launch-gate.txt`;
+
+function buildRelayEnv() {
+  return {
+    ...process.env,
+    API: process.env.API ?? 'configured',
+    PREFLIGHT_OK: process.env.PREFLIGHT_OK ?? '1',
+    SKILL: process.env.SKILL ?? 'loaded',
+    MODE_DEPTH: process.env.MODE_DEPTH ?? 'available',
+    STALE_AGENT_RELAY_DIR_PRESENT: process.env.STALE_AGENT_RELAY_DIR_PRESENT ?? '0',
+    SDK: process.env.SDK ?? 'agent-relay',
+    WARNING: process.env.WARNING ?? 'none',
+    OWNER_DECISION: process.env.OWNER_DECISION ?? 'COMPLETE',
+    COMPLETE: process.env.COMPLETE ?? '1',
+    REASON: process.env.REASON ?? 'workflow-runner',
+    RICKY_PLAN_READY: process.env.RICKY_PLAN_READY ?? '1',
+    ROUTER_WIRING_COMPATIBLE: process.env.ROUTER_WIRING_COMPATIBLE ?? '1',
+    STEP_COMPLETE: process.env.STEP_COMPLETE ?? 'seeded',
+  };
+}
+
+async function main() {
+  const result = await workflow(WORKFLOW_NAME)
+    .description(
+      'IMPLEMENTATION_WORKFLOW_CONTRACT: one-shot local workflow that maps the harness v0.5/v0.6/v0.7 spec into bounded implementation slices with deterministic gates, repair loops, and final signoff for Ricky.',
+    )
+    .pattern('pipeline')
+    .channel(WORKFLOW_CHANNEL)
+    .maxConcurrency(1)
+    .timeout(7_200_000)
+
+    .agent('implementer', {
+      cli: 'codex',
+      preset: 'worker',
+      role: 'Implements source and test changes for harness spec slices with bounded diffs.',
+      retries: 1,
+      timeoutMs: 2_400_000,
+    })
+    .agent('reviewer', {
+      cli: 'codex',
+      preset: 'reviewer',
+      role: 'Performs strict review for regressions, boundary violations, and missing coverage.',
+      retries: 1,
+      timeoutMs: 600_000,
+    })
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'set -e',
+        'test -f docs/specs/v0.5-harness-improvements.md',
+        'test -f packages/harness/src/adapter/types.ts',
+        'test -f packages/harness/src/types.ts',
+        'test -f packages/harness/package.json',
+        'test -f packages/harness/src/index.ts',
+        'test -f packages/routing/src/types.ts',
+        `mkdir -p workflows/generated docs/architecture ${WORKFLOW_GATE_DIR}`,
+        'echo preflight_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('read-skill-manifest-and-router-state', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: [
+        'set -e',
+        `: > ${CONTEXT_SNAPSHOT_FILE}`,
+        `printf '%s\n' '--- writing-agent-relay-workflows skill ---' >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `sed -n '1,220p' .agents/skills/writing-agent-relay-workflows/SKILL.md >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `printf '%s\n' '--- choosing-swarm-patterns skill ---' >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `sed -n '1,220p' .agents/skills/choosing-swarm-patterns/SKILL.md >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `printf '%s\n' '--- current router state (types) ---' >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `sed -n '1,260p' packages/routing/src/types.ts >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `printf '%s\n' '--- current router state (routing) ---' >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `sed -n '1,320p' packages/routing/src/routing.ts >> ${CONTEXT_SNAPSHOT_FILE}`,
+        `test -s ${CONTEXT_SNAPSHOT_FILE}`,
+        'echo context_snapshot_ready',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('runtime-and-resume-gate', {
+      type: 'deterministic',
+      dependsOn: ['read-skill-manifest-and-router-state'],
+      command: [
+        'set -e',
+        'command -v node >/dev/null',
+        'command -v npm >/dev/null',
+        'command -v rg >/dev/null',
+        `mkdir -p ${WORKFLOW_GATE_DIR}`,
+        'if [ -d .agent-relay ]; then echo stale_agent_relay_dir_present; fi',
+        `printf 'runtime_gate_ok run_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > ${RUNTIME_GATE_FILE}`,
+        `test -s ${RUNTIME_GATE_FILE}`,
+        'echo runtime_gate_ready',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('emit-minimal-plan-and-mapping', {
+      type: 'deterministic',
+      dependsOn: ['runtime-and-resume-gate'],
+      command: [
+        'set -e',
+        `cat > ${PLAN_FILE} <<'EOF'`,
+        '# 1. Steps (minimal, executable)',
+        '1. Run deterministic preflight checks and capture a local snapshot of the workflow-writing skill and current routing state.',
+        '2. Generate this plan artifact deterministically so launch-time behavior is stable and model-agnostic.',
+        '3. Execute the v0.5 implementation slice, then run first-pass build/test evidence capture and repair loop until hard validation passes.',
+        '4. Execute the v0.6/v0.7 implementation slices, then run first-pass evidence capture and repair loop until hard validation passes.',
+        '5. Run final deterministic validation + diff gate, then reviewer signoff and final contract gate.',
+        '',
+        '# 2. Wiring (how plan maps to existing routing modes and negotiation surfaces)',
+        '- Routing compatibility is preserved with existing policy-driven `cheap | fast | deep` mode selection in `packages/routing`.',
+        '- Workflow prompts remain model-agnostic and do not bind to any specific model name.',
+        '- Streaming negotiation wiring remains explicit: `prefer` allows downgrade, `require` must fail fast when unavailable, `forbid` forces non-streaming execution.',
+        '- Bounded-turn behavior is preserved: repair loops are explicit, deterministic gates enforce scope, and final signoff remains evidence-backed.',
+        '',
+        '# 3. Task-to-workflow mapping (one concrete example)',
+        'User task: "Repair an Agent Relay workflow artifact for Ricky after a failed run."',
+        '- Diagnosis and launch hardening: `read-skill-manifest-and-router-state` -> `runtime-and-resume-gate` -> `emit-minimal-plan-and-mapping`.',
+        '- Resume point for failed attempt: `implement-v0-5-slice` (with `--start-from implement-v0-5-slice --previous-run-id 8703892316407f6a41ed936c`).',
+        '- Recovery loop: `validate-v0-5-first-pass` -> `repair-v0-5-from-evidence` -> `hard-validate-v0-5`, then repeat pattern for v0.6/v0.7.',
+        '- Completion proof: `final-hard-validation-and-diff-gate` -> `review-and-final-signoff` -> `final-contract-gate`.',
+        '',
+        '# 4. Integration test notes',
+        '- Validate the plan gate markers and implementation note markers using deterministic `rg -q` checks only (no noisy marker line dumps).',
+        '- Keep `npm run build -w @agent-assistant/harness` and `npm test -w @agent-assistant/harness` as hard acceptance checks after each repair loop.',
+        '- Confirm the final diff gate still requires non-transient repo changes and expected harness file touchpoints.',
+        '- Resume test: rerun with `--start-from implement-v0-5-slice --previous-run-id 8703892316407f6a41ed936c` and verify the workflow continues from that step without re-running earlier gates.',
+        '',
+        'RICKY_PLAN_READY',
+        'ROUTER_WIRING_COMPATIBLE',
+        'EOF',
+        `rg -q 'RICKY_PLAN_READY' ${PLAN_FILE}`,
+        `rg -q 'ROUTER_WIRING_COMPATIBLE' ${PLAN_FILE}`,
+        'echo plan_artifact_ready',
+      ].join('\n'),
+      verification: { type: 'file_exists', value: PLAN_FILE },
+      timeoutMs: 120_000,
+    })
+
+    .step('gate-before-implement-v0-5', {
+      type: 'deterministic',
+      dependsOn: ['emit-minimal-plan-and-mapping'],
+      command: [
+        'set -e',
+        `test -f ${RUNTIME_GATE_FILE}`,
+        `test -f ${PLAN_FILE}`,
+        `rg -q 'RICKY_PLAN_READY' ${PLAN_FILE}`,
+        `rg -q 'ROUTER_WIRING_COMPATIBLE' ${PLAN_FILE}`,
+        `printf 'launch_gate_ok step=implement-v0-5-slice run_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > ${V05_LAUNCH_GATE_FILE}`,
+        `test -s ${V05_LAUNCH_GATE_FILE}`,
+        'echo gate_before_implement_v0_5_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-v0-5-slice', {
+      agent: 'implementer',
+      dependsOn: ['gate-before-implement-v0-5'],
+      timeoutMs: 2_400_000,
+      task: `Implement v0.5 slice from docs/specs/v0.5-harness-improvements.md with additive, non-breaking type updates and tests.
+
+Scope for this step:
+- Streaming contract additions in packages/harness/src/adapter/types.ts.
+- AbortSignal propagation surfaces in packages/harness/src/types.ts and adapter request/result types.
+- MCP subpath scaffolding in packages/harness/src/mcp/* and package exports in packages/harness/package.json.
+- Keep root barrel behavior compatible (do not break existing imports).
+
+Hard constraints:
+- Do NOT cache bare fetch references; use call-time globalThis.fetch lambda pattern.
+- Keep changes additive/non-breaking for existing consumers unless opt-in.
+- Preserve trace + stream coexistence semantics.
+- Add or update tests relevant to implemented slice.
+- Keep console output concise and avoid emitting OWNER_DECISION / STEP_COMPLETE control markers in chat output.
+
+Deliverables:
+- Source edits
+- Tests
+- Short implementation notes in docs/architecture/ricky-harness-v0.5-implementation-notes.md
+- End notes file with marker V0_5_SLICE_IMPLEMENTED`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('gate-after-implement-v0-5', {
+      type: 'deterministic',
+      dependsOn: ['implement-v0-5-slice'],
+      command: [
+        'set -e',
+        `test -f ${V05_LAUNCH_GATE_FILE}`,
+        'test -f docs/architecture/ricky-harness-v0.5-implementation-notes.md',
+        'rg -q "V0_5_SLICE_IMPLEMENTED" docs/architecture/ricky-harness-v0.5-implementation-notes.md',
+        'echo gate_after_implement_v0_5_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('validate-v0-5-first-pass', {
+      type: 'deterministic',
+      dependsOn: ['gate-after-implement-v0-5'],
+      command: [
+        'set +e',
+        'npm run build -w @agent-assistant/harness > /tmp/ricky_v05_build.log 2>&1',
+        'BUILD_EXIT=$?',
+        'npm test -w @agent-assistant/harness > /tmp/ricky_v05_test.log 2>&1',
+        'TEST_EXIT=$?',
+        'echo "BUILD_EXIT=$BUILD_EXIT"',
+        'echo "TEST_EXIT=$TEST_EXIT"',
+        'echo "--- build tail ---"',
+        'tail -n 120 /tmp/ricky_v05_build.log || true',
+        'echo "--- test tail ---"',
+        'tail -n 120 /tmp/ricky_v05_test.log || true',
+        'exit 0',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: false,
+      timeoutMs: 300_000,
+    })
+
+    .step('repair-v0-5-from-evidence', {
+      agent: 'implementer',
+      dependsOn: ['validate-v0-5-first-pass'],
+      timeoutMs: 420_000,
+      task: `Use first-pass failure evidence to repair v0.5 implementation until green.
+
+Evidence:
+{{steps.validate-v0-5-first-pass.output}}
+
+Rules:
+- If build/tests already pass, make no unnecessary edits.
+- If failing, fix root causes in source/tests and rerun targeted checks.
+- Keep all changes within bounded-turn harness scope.
+- Do not introduce model-specific prompt logic.
+- Keep console output concise and avoid emitting OWNER_DECISION / STEP_COMPLETE control markers in chat output.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('hard-validate-v0-5', {
+      type: 'deterministic',
+      dependsOn: ['repair-v0-5-from-evidence'],
+      command: [
+        'set -e',
+        'npm run build -w @agent-assistant/harness',
+        'npm test -w @agent-assistant/harness',
+        'test -f docs/architecture/ricky-harness-v0.5-implementation-notes.md',
+        'rg -q "V0_5_SLICE_IMPLEMENTED" docs/architecture/ricky-harness-v0.5-implementation-notes.md',
+        'echo v0_5_hard_validation_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+      timeoutMs: 600_000,
+    })
+
+    .step('gate-before-implement-v0-6-v0-7', {
+      type: 'deterministic',
+      dependsOn: ['hard-validate-v0-5'],
+      command: [
+        'set -e',
+        `test -f ${RUNTIME_GATE_FILE}`,
+        `printf 'launch_gate_ok step=implement-v0-6-v0-7-slices run_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > ${V067_LAUNCH_GATE_FILE}`,
+        `test -s ${V067_LAUNCH_GATE_FILE}`,
+        'echo gate_before_implement_v0_6_v0_7_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('implement-v0-6-v0-7-slices', {
+      agent: 'implementer',
+      dependsOn: ['gate-before-implement-v0-6-v0-7'],
+      timeoutMs: 2_400_000,
+      task: `Implement remaining scoped improvements for v0.6 and v0.7 from docs/specs/v0.5-harness-improvements.md.
+
+Required areas:
+- Direct provider adapter files and associated conformance tests.
+- Per-tool executionMode with parallel batch semantics and trace event.
+- terminate: true tool-result behavior.
+- Subpath export hygiene and compatibility behavior.
+- transformTranscript hook.
+- evidence_density_violation payload surfacing.
+- trace settlement flush semantics.
+
+Requirements:
+- Keep all additions backward compatible unless explicitly opt-in.
+- Preserve worker-fetch compatibility requirements.
+- Add/update tests to enforce behavior.
+- Keep prompts and generated artifacts model-agnostic.
+- Keep output concise and avoid emitting OWNER_DECISION / STEP_COMPLETE control markers in chat output.
+
+Write docs/architecture/ricky-harness-v0.6-v0.7-implementation-notes.md and end with marker V0_6_V0_7_SLICES_IMPLEMENTED.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('gate-after-implement-v0-6-v0-7', {
+      type: 'deterministic',
+      dependsOn: ['implement-v0-6-v0-7-slices'],
+      command: [
+        'set -e',
+        `test -f ${V067_LAUNCH_GATE_FILE}`,
+        'test -f docs/architecture/ricky-harness-v0.6-v0.7-implementation-notes.md',
+        'rg -q "V0_6_V0_7_SLICES_IMPLEMENTED" docs/architecture/ricky-harness-v0.6-v0.7-implementation-notes.md',
+        'echo gate_after_implement_v0_6_v0_7_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('validate-v0-6-v0-7-first-pass', {
+      type: 'deterministic',
+      dependsOn: ['gate-after-implement-v0-6-v0-7'],
+      command: [
+        'set +e',
+        'npm run build -w @agent-assistant/harness > /tmp/ricky_v067_build.log 2>&1',
+        'BUILD_EXIT=$?',
+        'npm test -w @agent-assistant/harness > /tmp/ricky_v067_test.log 2>&1',
+        'TEST_EXIT=$?',
+        'echo "BUILD_EXIT=$BUILD_EXIT"',
+        'echo "TEST_EXIT=$TEST_EXIT"',
+        'echo "--- build tail ---"',
+        'tail -n 160 /tmp/ricky_v067_build.log || true',
+        'echo "--- test tail ---"',
+        'tail -n 160 /tmp/ricky_v067_test.log || true',
+        'exit 0',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: false,
+      timeoutMs: 300_000,
+    })
+
+    .step('repair-v0-6-v0-7-from-evidence', {
+      agent: 'implementer',
+      dependsOn: ['validate-v0-6-v0-7-first-pass'],
+      timeoutMs: 420_000,
+      task: `Use this validation evidence to fix remaining failures for v0.6/v0.7.
+
+Evidence:
+{{steps.validate-v0-6-v0-7-first-pass.output}}
+
+Loop until clean:
+1. Read failures.
+2. Apply minimal corrective edits.
+3. Re-run targeted build/tests.
+4. Confirm no regression against v0.5 behavior.
+
+Keep output concise and avoid emitting OWNER_DECISION / STEP_COMPLETE control markers in chat output.`,
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('final-hard-validation-and-diff-gate', {
+      type: 'deterministic',
+      dependsOn: ['repair-v0-6-v0-7-from-evidence'],
+      command: [
+        'set -e',
+        'npm run build -w @agent-assistant/harness',
+        'npm test -w @agent-assistant/harness',
+        `test -f ${PLAN_FILE}`,
+        'test -f docs/architecture/ricky-harness-v0.5-implementation-notes.md',
+        'test -f docs/architecture/ricky-harness-v0.6-v0.7-implementation-notes.md',
+        `rg -q 'RICKY_PLAN_READY' ${PLAN_FILE}`,
+        `rg -q 'ROUTER_WIRING_COMPATIBLE' ${PLAN_FILE}`,
+        'rg -q "V0_5_SLICE_IMPLEMENTED" docs/architecture/ricky-harness-v0.5-implementation-notes.md',
+        'rg -q "V0_6_V0_7_SLICES_IMPLEMENTED" docs/architecture/ricky-harness-v0.6-v0.7-implementation-notes.md',
+        'DIFF_FILES=$( (git diff --name-only; git ls-files --others --exclude-standard) | sort -u )',
+        'echo "$DIFF_FILES"',
+        'test -n "$DIFF_FILES"',
+        'NON_TRANSIENT=$(echo "$DIFF_FILES" | rg -v "^(logs/|\\.trajectories/|tmp/|dist/)$" || true)',
+        'test -n "$NON_TRANSIENT"',
+        'echo "$DIFF_FILES" | rg -q "^packages/harness/src/"',
+        'echo "$DIFF_FILES" | rg -q "^packages/harness/package.json$"',
+        `test -f ${RUNTIME_GATE_FILE}`,
+        `test -f ${V05_LAUNCH_GATE_FILE}`,
+        `test -f ${V067_LAUNCH_GATE_FILE}`,
+        'echo final_hard_validation_ok',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+      timeoutMs: 900_000,
+    })
+
+    .step('review-and-final-signoff', {
+      agent: 'reviewer',
+      dependsOn: ['final-hard-validation-and-diff-gate'],
+      timeoutMs: 300_000,
+      task: `Perform final review and produce a concise signoff report.
+
+Inputs:
+- docs/specs/v0.5-harness-improvements.md
+- docs/architecture/ricky-harness-v0.5-v0.7-plan.md
+- docs/architecture/ricky-harness-v0.5-implementation-notes.md
+- docs/architecture/ricky-harness-v0.6-v0.7-implementation-notes.md
+- validation evidence:
+{{steps.final-hard-validation-and-diff-gate.output}}
+
+Write docs/architecture/ricky-harness-v0.5-v0.7-signoff.md with:
+1. Findings (if any)
+2. Verification summary
+3. Residual risks
+4. Final status: PASS or FAIL
+
+End file with marker RICKY_FINAL_SIGNOFF_COMPLETE.
+Keep console output concise and avoid emitting OWNER_DECISION / STEP_COMPLETE control markers in chat output.`,
+      verification: { type: 'file_exists', value: 'docs/architecture/ricky-harness-v0.5-v0.7-signoff.md' },
+    })
+
+    .step('final-contract-gate', {
+      type: 'deterministic',
+      dependsOn: ['review-and-final-signoff'],
+      command: [
+        'set -e',
+        'rg -q "RICKY_FINAL_SIGNOFF_COMPLETE" docs/architecture/ricky-harness-v0.5-v0.7-signoff.md',
+        'rg -q "PASS|FAIL" docs/architecture/ricky-harness-v0.5-v0.7-signoff.md',
+        'echo workflow_contract_complete',
+      ].join(' && '),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .onError('retry', { maxRetries: 1, retryDelayMs: 5_000 })
+    .run({
+      cwd: process.cwd(),
+      relay: {
+        env: buildRelayEnv(),
+      },
+    });
+
+  console.log('Workflow status:', result.status);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/workflows/generated/sage-v2-substrate-extraction-pr.ts
+++ b/workflows/generated/sage-v2-substrate-extraction-pr.ts
@@ -2,80 +2,88 @@ import { workflow } from '@agent-relay/sdk/workflows';
 import { ClaudeModels, CodexModels } from '@agent-relay/config';
 import { applyAgentAssistantRepoSetup } from '../lib/agent-assistant-repo-setup.ts';
 
-const WORKFLOW_NAME = 'sage-v2-substrate-extraction-pr';
-const WORKFLOW_CHANNEL = 'wf-sage-v2-substrate-extraction-pr';
-const IMPLEMENTATION_BRANCH = 'codex/sage-v2-agent-assistant-substrate';
+const WORKFLOW_NAME = 'sage-v2-nested-subagent-runner-pr';
+const WORKFLOW_CHANNEL = 'wf-sage-v2-nested-subagent-runner';
+const IMPLEMENTATION_BRANCH = 'codex/sage-v2-nested-subagent-runner';
 
-const GATE_DIR = 'tmp/sage-v2-substrate-workflow';
+const GATE_DIR = 'tmp/sage-v2-nested-runner-workflow';
 const CONTEXT_FILE = `${GATE_DIR}/source-context.md`;
-const VALIDATION_LOG = `${GATE_DIR}/hard-validation.log`;
+const VALIDATION_LOG = `${GATE_DIR}/validation.log`;
 const PR_BODY_FILE = `${GATE_DIR}/pr-body.md`;
 
-const LEAD_PLAN = 'docs/architecture/sage-v2-substrate-implementation-plan.md';
-const LEAD_REFLECTION = 'docs/architecture/sage-v2-substrate-lead-reflection.md';
-const EXECUTOR_REFLECTION = 'docs/architecture/sage-v2-substrate-executor-reflection.md';
-const FRESH_REVIEW = 'docs/architecture/sage-v2-substrate-fresh-eyes-review.md';
-const FRESH_REFLECTION = 'docs/architecture/sage-v2-substrate-fresh-eyes-reflection.md';
-const CLAUDE_REVIEW = 'docs/architecture/sage-v2-substrate-claude-peer-review.md';
-const CLAUDE_REVIEW_REFLECTION = 'docs/architecture/sage-v2-substrate-claude-peer-review-reflection.md';
-const VALIDATION_REPORT = 'docs/architecture/sage-v2-substrate-80-to-100-validation.md';
-const VALIDATION_REFLECTION = 'docs/architecture/sage-v2-substrate-validation-reflection.md';
+const PLAN_DOC = 'docs/architecture/sage-v2-nested-subagent-runner-plan.md';
+const LEAD_REFLECTION = 'docs/architecture/sage-v2-nested-subagent-runner-lead-reflection.md';
+const EXECUTOR_REFLECTION = 'docs/architecture/sage-v2-nested-subagent-runner-executor-reflection.md';
+const FRESH_REVIEW = 'docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-review.md';
+const FRESH_REFLECTION = 'docs/architecture/sage-v2-nested-subagent-runner-fresh-eyes-reflection.md';
+const CLAUDE_REVIEW = 'docs/architecture/sage-v2-nested-subagent-runner-claude-peer-review.md';
+const CLAUDE_REFLECTION = 'docs/architecture/sage-v2-nested-subagent-runner-claude-reflection.md';
+const VALIDATION_REPORT = 'docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md';
+const VALIDATION_REFLECTION = 'docs/architecture/sage-v2-nested-subagent-runner-validation-reflection.md';
 
 async function runWorkflow() {
   const baseWf = workflow(WORKFLOW_NAME)
     .description(
-      'Implement the reusable Agent Assistant substrate extracted from Sage v2: nested subagent runner, runtime budget policy, telemetry vocabulary, eval substrate, insight contracts, full validation, review, commit, push, and PR.',
+      'First Sage v2 substrate PR only: add the reusable nested subagent runner helper in @agent-assistant/harness with targeted tests, review, validation, commit, push, and PR.',
     )
     .pattern('dag')
     .channel(WORKFLOW_CHANNEL)
-    .maxConcurrency(4)
-    .timeout(10_800_000)
+    .maxConcurrency(2)
+    .timeout(5_400_000)
+
+    .step('runtime-launch', {
+      type: 'deterministic',
+      command: 'echo SAGE_V2_NESTED_RUNNER_RUNTIME_READY',
+      captureOutput: true,
+      failOnError: true,
+    })
 
     .agent('lead-claude', {
       cli: 'claude',
       model: ClaudeModels.OPUS,
       preset: 'lead',
-      role: 'Lead architect. Converts the Sage v2 specs into an Agent Assistant implementation contract, keeps Sage product logic out, and owns final architectural coherence.',
+      role: 'Lead architect for the first Sage v2 substrate slice. Keeps scope to nested subagent runner only.',
       retries: 1,
-      timeoutMs: 1_200_000,
+      timeoutMs: 900_000,
     })
     .agent('executor-codex', {
       cli: 'codex',
       model: CodexModels.GPT_5_4,
       preset: 'worker',
-      role: 'Implementation executor. Edits source and tests in narrow slices, follows Cloudflare Workers fetch rules, and keeps every change backed by deterministic tests.',
+      role: 'Implements only the @agent-assistant/harness nested subagent runner slice and its focused tests.',
       retries: 2,
-      timeoutMs: 2_400_000,
+      timeoutMs: 1_200_000,
     })
     .agent('fresh-eyes-codex', {
       cli: 'codex',
       model: CodexModels.GPT_5_4,
       preset: 'reviewer',
-      role: 'Fresh-eyes self reviewer. Reviews the complete Codex-produced diff as if seeing it for the first time, fixes narrow issues, and writes a verdict.',
+      role: 'Fresh-eyes reviewer for the nested runner diff only.',
       retries: 1,
-      timeoutMs: 1_200_000,
+      timeoutMs: 600_000,
     })
     .agent('peer-review-claude', {
       cli: 'claude',
       model: ClaudeModels.SONNET,
       preset: 'reviewer',
-      role: 'Claude peer reviewer. Reviews implementation quality, extraction boundaries, test sufficiency, and hidden regressions.',
+      role: 'Claude peer reviewer for API shape, extraction boundary, and test adequacy.',
       retries: 1,
-      timeoutMs: 1_200_000,
+      timeoutMs: 600_000,
     })
     .agent('validation-claude', {
       cli: 'claude',
-      model: ClaudeModels.OPUS,
+      model: ClaudeModels.SONNET,
       preset: 'reviewer',
-      role: '80-to-100 validator. Proves the feature works beyond compilation, applies the relay-80-100 workflow checklist, and records evidence before PR publication.',
+      role: '80-to-100 validator. Confirms deterministic evidence, scoped diff, and production readiness for this one slice.',
       retries: 1,
-      timeoutMs: 1_800_000,
+      timeoutMs: 600_000,
     });
 
   const wf = applyAgentAssistantRepoSetup(baseWf, {
     branch: IMPLEMENTATION_BRANCH,
-    committerName: 'Sage v2 Substrate Workflow',
+    committerName: 'Sage v2 Nested Runner Workflow',
     committerEmail: 'agent@agent-assistant.local',
+    dependsOn: ['runtime-launch'],
   });
 
   const result = await wf
@@ -89,73 +97,75 @@ async function runWorkflow() {
         'gh auth status >/dev/null',
         'test -f docs/architecture/sage-v2-substrate-extraction-map.md',
         'test -f ../sage/specs/sage-v2-agentic-orchestration.md',
-        'test -f ../sage/specs/sage-v2-runtime-budget-control.md',
         'test -f .agents/skills/writing-agent-relay-workflows/SKILL.md',
         'test -f .agents/skills/relay-80-100-workflow/SKILL.md',
+        'test -f packages/harness/src/subagent-registry.ts',
+        'test -f packages/harness/src/types.ts',
         `mkdir -p ${GATE_DIR}`,
-        'echo SAGE_V2_PREFLIGHT_OK',
+        'echo SAGE_V2_NESTED_RUNNER_PREFLIGHT_OK',
       ].join(' && '),
       captureOutput: true,
       failOnError: true,
     })
 
-    .step('collect-source-context', {
+    .step('collect-context', {
       type: 'deterministic',
       dependsOn: ['preflight-source-docs'],
       command: [
         'set -e',
         `: > ${CONTEXT_FILE}`,
-        `printf '%s\n' '# Sage v2 substrate workflow context' >> ${CONTEXT_FILE}`,
+        `printf '%s\n' '# Sage v2 nested subagent runner context' >> ${CONTEXT_FILE}`,
         `printf '%s\n' '## Extraction map' >> ${CONTEXT_FILE}`,
-        `sed -n '1,340p' docs/architecture/sage-v2-substrate-extraction-map.md >> ${CONTEXT_FILE}`,
-        `printf '%s\n' '## Sage orchestration spec' >> ${CONTEXT_FILE}`,
-        `sed -n '1,420p' ../sage/specs/sage-v2-agentic-orchestration.md >> ${CONTEXT_FILE}`,
-        `printf '%s\n' '## Sage runtime budget spec' >> ${CONTEXT_FILE}`,
-        `sed -n '1,360p' ../sage/specs/sage-v2-runtime-budget-control.md >> ${CONTEXT_FILE}`,
-        `printf '%s\n' '## writing-agent-relay-workflows skill' >> ${CONTEXT_FILE}`,
-        `sed -n '1,360p' .agents/skills/writing-agent-relay-workflows/SKILL.md >> ${CONTEXT_FILE}`,
-        `printf '%s\n' '## relay-80-100-workflow skill' >> ${CONTEXT_FILE}`,
-        `sed -n '1,320p' .agents/skills/relay-80-100-workflow/SKILL.md >> ${CONTEXT_FILE}`,
-        `printf '%s\n' '## Current package surfaces' >> ${CONTEXT_FILE}`,
-        `rg --files packages/harness packages/telemetry packages/vfs packages/turn-context | sort >> ${CONTEXT_FILE}`,
+        `sed -n '1,150p' docs/architecture/sage-v2-substrate-extraction-map.md >> ${CONTEXT_FILE}`,
+        `printf '%s\n' '## Orchestration spec task-tool target' >> ${CONTEXT_FILE}`,
+        `sed -n '1,180p' ../sage/specs/sage-v2-agentic-orchestration.md >> ${CONTEXT_FILE}`,
+        `printf '%s\n' '## Current harness subagent registry' >> ${CONTEXT_FILE}`,
+        `sed -n '1,260p' packages/harness/src/subagent-registry.ts >> ${CONTEXT_FILE}`,
+        `printf '%s\n' '## Harness types' >> ${CONTEXT_FILE}`,
+        `sed -n '1,260p' packages/harness/src/types.ts >> ${CONTEXT_FILE}`,
+        `printf '%s\n' '## Harness exports/package' >> ${CONTEXT_FILE}`,
+        `sed -n '1,220p' packages/harness/src/index.ts >> ${CONTEXT_FILE}`,
+        `sed -n '1,220p' packages/harness/package.json >> ${CONTEXT_FILE}`,
+        `printf '%s\n' '## Workflow skills' >> ${CONTEXT_FILE}`,
+        `sed -n '1,240p' .agents/skills/writing-agent-relay-workflows/SKILL.md >> ${CONTEXT_FILE}`,
+        `sed -n '1,220p' .agents/skills/relay-80-100-workflow/SKILL.md >> ${CONTEXT_FILE}`,
         `test -s ${CONTEXT_FILE}`,
-        'echo SAGE_V2_CONTEXT_READY',
+        'echo SAGE_V2_NESTED_RUNNER_CONTEXT_READY',
       ].join('\n'),
       captureOutput: true,
       failOnError: true,
     })
 
-    .step('lead-architecture-contract', {
+    .step('lead-plan', {
       agent: 'lead-claude',
-      dependsOn: ['collect-source-context'],
-      task: `Read ${CONTEXT_FILE} and write ${LEAD_PLAN}.
+      dependsOn: ['collect-context'],
+      task: `Write ${PLAN_DOC} from ${CONTEXT_FILE}.
 
-The plan must be an implementation contract, not a product roadmap. It must:
-1. Keep Sage-owned product prompts, Slack/Notion semantics, and specialist roster definitions out of Agent Assistant.
-2. Define exact Agent Assistant deliverables for nested subagent runner, runtime budget policy, telemetry event vocabulary, eval substrate, and insight envelope/readers.
-3. Name the packages/files likely to change and the tests required for each slice.
-4. Include Cloudflare Workers fetch compatibility: no bare fetch storage; call globalThis.fetch at invocation time.
-5. Include the 80-to-100 validation contract: targeted tests, final hard gates, regression suite, review gates, and PR publication.
-6. Include how Claude leads, Codex executes, every agent self-reflects, Codex fresh-eyes reviews, Claude peer-reviews, and Claude signs off on 80-to-100.
+This is PR 1 only: nested subagent runner helper in @agent-assistant/harness.
 
-End with SAGE_V2_SUBSTRATE_PLAN_READY.`,
-      verification: { type: 'file_exists', value: LEAD_PLAN },
+The plan must:
+1. Define the smallest reusable API shape for a helper that supplies createSubagentToolRegistry's runSubagent implementation.
+2. Keep Sage product prompts, roster definitions, Slack/Notion semantics, work-mode classifiers, runtime budget policy, telemetry vocabulary, evals, and insight contracts out of this PR.
+3. Name exact files likely to change.
+4. Require tests for success, unknown subagent, subagent failure, max-iteration failure, cancellation, and parallel task batches where the existing registry supports them.
+5. Include Cloudflare Workers fetch compatibility guidance: no bare fetch storage.
+6. Include the 80-to-100 validation gates for this single slice.
+
+End with SAGE_V2_NESTED_RUNNER_PLAN_READY.`,
+      verification: { type: 'file_exists', value: PLAN_DOC },
     })
 
-    .step('verify-lead-contract', {
+    .step('verify-lead-plan', {
       type: 'deterministic',
-      dependsOn: ['lead-architecture-contract'],
+      dependsOn: ['lead-plan'],
       command: [
         'set -e',
-        `rg -q 'SAGE_V2_SUBSTRATE_PLAN_READY' ${LEAD_PLAN}`,
-        `rg -q 'nested subagent|Nested subagent|createNestedSubagentRunner' ${LEAD_PLAN}`,
-        `rg -q 'runtime budget|runtime policy|Runtime budget' ${LEAD_PLAN}`,
-        `rg -q 'telemetry' ${LEAD_PLAN}`,
-        `rg -q 'eval' ${LEAD_PLAN}`,
-        `rg -q 'InsightEnvelope|insight envelope|insight' ${LEAD_PLAN}`,
-        `rg -q 'globalThis.fetch|Cloudflare' ${LEAD_PLAN}`,
-        `rg -q '80-to-100|80 to 100' ${LEAD_PLAN}`,
-        'echo SAGE_V2_LEAD_CONTRACT_VERIFIED',
+        `rg -q 'SAGE_V2_NESTED_RUNNER_PLAN_READY' ${PLAN_DOC}`,
+        `rg -q 'nested subagent|Nested subagent|createNestedSubagentRunner' ${PLAN_DOC}`,
+        `rg -q 'runtime budget policy|Runtime budget policy|Runtime budget' ${PLAN_DOC}`,
+        `rg -q 'PR 2|deferred|out of scope|Out of scope|must NOT|MUST NOT' ${PLAN_DOC}`,
+        `rg -q '80.*100' ${PLAN_DOC}`,
+        'echo SAGE_V2_NESTED_RUNNER_PLAN_VERIFIED',
       ].join(' && '),
       captureOutput: true,
       failOnError: true,
@@ -163,316 +173,144 @@ End with SAGE_V2_SUBSTRATE_PLAN_READY.`,
 
     .step('lead-self-reflection', {
       agent: 'lead-claude',
-      dependsOn: ['verify-lead-contract'],
+      dependsOn: ['verify-lead-plan'],
       task: `Write ${LEAD_REFLECTION}.
 
-Reflect on your own architecture contract against the source specs and skills. Include:
-- any risk that the plan accidentally moves Sage product intelligence into Agent Assistant
-- any risk that the workflow misses an 80-to-100 gate
-- any scope-control adjustment Codex should honor before implementation
+Reflect on whether ${PLAN_DOC} is actually scoped to PR 1 only. Name any scope risks Codex must avoid.
 
 End with LEAD_SELF_REFLECTION_COMPLETE.`,
       verification: { type: 'file_exists', value: LEAD_REFLECTION },
     })
 
-    .step('implement-nested-subagent-runner', {
+    .step('implement-nested-runner', {
       agent: 'executor-codex',
       dependsOn: ['lead-self-reflection'],
-      task: `Implement the nested subagent runner slice from ${LEAD_PLAN}.
+      task: `Implement only the nested subagent runner slice using ${PLAN_DOC}.
 
-Scope:
-- Add a first-party helper for createSubagentToolRegistry runSubagent wiring in @agent-assistant/harness.
-- Preserve parent trace ids, isolate nested turns, enforce subagent tool allowlists, support cancellation, and return TaskToolResult-compatible flat output.
-- Keep product subagent selection, Sage prompts, Slack/Notion/GitHub/Linear semantics, and model policy out of Agent Assistant.
-- Add focused tests for success, unknown subagent, subagent failure, max-iteration failure, cancellation, and parallel task batches where supported.
-- Do not store bare fetch references; use globalThis.fetch only at call time if fetch is needed.
+Allowed scope:
+- packages/harness/src/nested-subagent-runner.ts
+- packages/harness/src/nested-subagent-runner.test.ts
+- packages/harness/src/subagent-registry.ts and existing subagent registry tests, only if needed for the helper contract
+- packages/harness/src/index.ts, packages/harness/src/registries/index.ts, packages/harness/src/subpath-exports.test.ts, and packages/harness/package.json, only for exports/subpaths
+- docs/architecture/sage-v2-nested-subagent-runner-*.md
 
-Keep edits narrow. Run the targeted harness tests you add before exiting.`,
+Do not add runtime policy, telemetry, eval, insight, Slack, Notion, GitHub, Linear, or Sage-specific product behavior.
+If unrelated changes exist in the worktree from previous runs, ignore them and do not edit or revert them.
+Run the targeted nested-runner tests before exiting.`,
       verification: { type: 'exit_code', value: '0' },
     })
 
-    .step('verify-nested-subagent-runner', {
+    .step('verify-implementation-shape', {
       type: 'deterministic',
-      dependsOn: ['implement-nested-subagent-runner'],
+      dependsOn: ['implement-nested-runner'],
       command: [
         'set -e',
-        'git diff --quiet packages/harness && (echo "packages/harness was not modified"; exit 1) || true',
         'rg -q "createNestedSubagentRunner|NestedSubagentRunner|CreateNestedSubagentRunner" packages/harness/src',
-        'rg -q "createNestedSubagentRunner|NestedSubagentRunner|subagent runner" packages/harness/src --glob "*test.ts"',
-        'echo SAGE_V2_NESTED_RUNNER_VERIFIED',
-      ].join(' && '),
+        'test -f packages/harness/src/nested-subagent-runner.test.ts',
+        'rg -q "unknown|failure|max|cancel|parallel|allowlist" packages/harness/src/nested-subagent-runner.test.ts',
+        'if rg -n "SAGE_HARNESS_SUBAGENTS_ENABLED|slack-researcher|competitor-researcher|notion_create_page" packages/harness/src/nested-subagent-runner.ts packages/harness/src/subagent-registry.ts; then echo "Sage product semantics leaked"; exit 1; fi',
+        'if rg -n "(fetchImpl\\s*=\\s*[^?;]*\\?\\?\\s*fetch\\b|=\\s*fetch\\s*;)" packages/harness/src/nested-subagent-runner.ts packages/harness/src/subagent-registry.ts; then echo "bare fetch storage found"; exit 1; fi',
+        'echo SAGE_V2_NESTED_RUNNER_SHAPE_VERIFIED',
+      ].join('\n'),
       captureOutput: true,
       failOnError: true,
     })
 
-    .step('run-harness-tests-after-nested-runner', {
+    .step('run-targeted-tests-first-pass', {
       type: 'deterministic',
-      dependsOn: ['verify-nested-subagent-runner'],
-      command: 'npm test -w @agent-assistant/harness 2>&1 | tail -120; echo "EXIT: $?"',
-      captureOutput: true,
-      failOnError: false,
-      timeoutMs: 600_000,
-    })
-
-    .step('fix-harness-after-nested-runner', {
-      agent: 'executor-codex',
-      dependsOn: ['run-harness-tests-after-nested-runner'],
-      task: `Harness test output after nested runner:
-
-{{steps.run-harness-tests-after-nested-runner.output}}
-
-If EXIT: 0, do nothing. Otherwise fix only the nested runner slice and its tests, then rerun npm test -w @agent-assistant/harness until green.`,
-      verification: { type: 'exit_code', value: '0' },
-    })
-
-    .step('hard-harness-tests-after-nested-runner', {
-      type: 'deterministic',
-      dependsOn: ['fix-harness-after-nested-runner'],
-      command: 'npm test -w @agent-assistant/harness 2>&1 | tail -80',
-      captureOutput: true,
-      failOnError: true,
-      timeoutMs: 600_000,
-    })
-
-    .step('implement-runtime-budget-policy', {
-      agent: 'executor-codex',
-      dependsOn: ['hard-harness-tests-after-nested-runner'],
-      task: `Implement the runtime budget policy slice from ${LEAD_PLAN}.
-
-Scope:
-- Add configurable turn-scoped runtime policy primitives in @agent-assistant/harness, conservatively defaulted or opt-in.
-- Cover todo rewrite cap, duplicate tool-result cache, reserved synthesis budget, drill-or-stop validation, deep-repo funnel hook if planned, and final pseudo-tool output sanitizer.
-- Emit structured trace or telemetry-ready events for blocked calls, cache hits, no-op todo rewrites, sanitizer activity, and synthesis salvage.
-- Tests must prove the acceptance criteria from ../sage/specs/sage-v2-runtime-budget-control.md.
-- Keep product definitions of "broad", provider priorities, and final answer style out of shared packages.
-
-Run targeted runtime-policy tests before exiting.`,
-      verification: { type: 'exit_code', value: '0' },
-    })
-
-    .step('verify-runtime-budget-policy', {
-      type: 'deterministic',
-      dependsOn: ['implement-runtime-budget-policy'],
-      command: [
-        'set -e',
-        'rg -q "runtime.*policy|RuntimePolicy|createRuntimePolicy|todo rewrite|pseudo-tool|sanit" packages/harness/src',
-        'rg -q "duplicate|cache_hit|reserve|drill|write_todos|function_calls|pseudo" packages/harness/src --glob "*test.ts"',
-        'echo SAGE_V2_RUNTIME_POLICY_VERIFIED',
-      ].join(' && '),
-      captureOutput: true,
-      failOnError: true,
-    })
-
-    .step('run-harness-tests-after-runtime-policy', {
-      type: 'deterministic',
-      dependsOn: ['verify-runtime-budget-policy'],
-      command: 'npm test -w @agent-assistant/harness 2>&1 | tail -120; echo "EXIT: $?"',
-      captureOutput: true,
-      failOnError: false,
-      timeoutMs: 600_000,
-    })
-
-    .step('fix-harness-after-runtime-policy', {
-      agent: 'executor-codex',
-      dependsOn: ['run-harness-tests-after-runtime-policy'],
-      task: `Harness test output after runtime policy:
-
-{{steps.run-harness-tests-after-runtime-policy.output}}
-
-If EXIT: 0, do nothing. Otherwise fix runtime policy implementation or tests. Re-run npm test -w @agent-assistant/harness until green.`,
-      verification: { type: 'exit_code', value: '0' },
-    })
-
-    .step('hard-harness-tests-after-runtime-policy', {
-      type: 'deterministic',
-      dependsOn: ['fix-harness-after-runtime-policy'],
-      command: 'npm test -w @agent-assistant/harness 2>&1 | tail -80',
-      captureOutput: true,
-      failOnError: true,
-      timeoutMs: 600_000,
-    })
-
-    .step('implement-telemetry-evals-insights', {
-      agent: 'executor-codex',
-      dependsOn: ['hard-harness-tests-after-runtime-policy'],
-      task: `Implement the telemetry, eval substrate, and insight contract slices from ${LEAD_PLAN}.
-
-Scope:
-- In @agent-assistant/telemetry, add typed constructors or helpers for subagent lifecycle, runtime_policy.*, and synthesis.salvaged style events without raw private provider content by default.
-- Bridge policy/subagent metadata from harness where the plan requires it.
-- Add a small fixture-oriented eval runner contract either in a new @agent-assistant/evals package or a narrowly scoped telemetry/evals module, following the plan's package choice.
-- Add InsightEnvelope and reader helpers in @agent-assistant/vfs and/or @agent-assistant/turn-context with provenance, freshness, partial JSON tolerance, and graceful malformed-input failures.
-- Add tests for event shape stability, eval result JSON summary shape, and insight parsing/provenance.
-
-Do not add Sage-specific prompts, tool rosters, Slack/Notion workflows, or customer semantics.`,
-      verification: { type: 'exit_code', value: '0' },
-    })
-
-    .step('verify-telemetry-evals-insights', {
-      type: 'deterministic',
-      dependsOn: ['implement-telemetry-evals-insights'],
-      command: [
-        'set -e',
-        'rg -q "subagent\\.batch\\.started|subagent\\.started|runtime_policy|synthesis\\.salvaged|output_sanitized" packages/telemetry packages/harness',
-        '(test -d packages/evals || rg -q "eval.*runner|fixture.*runner|PR-comment|score" packages/telemetry packages/harness packages/turn-context packages/vfs)',
-        'rg -q "InsightEnvelope|sourceProvider|sourcePaths|generatedAt|freshness" packages/vfs packages/turn-context',
-        'rg -q "InsightEnvelope|runtime_policy|subagent\\.started|eval.*runner|fixture" packages --glob "*test.ts"',
-        'echo SAGE_V2_TELEMETRY_EVALS_INSIGHTS_VERIFIED',
-      ].join(' && '),
-      captureOutput: true,
-      failOnError: true,
-    })
-
-    .step('run-targeted-package-tests', {
-      type: 'deterministic',
-      dependsOn: ['verify-telemetry-evals-insights'],
+      dependsOn: ['verify-implementation-shape'],
       command: [
         'set +e',
-        'npm test -w @agent-assistant/harness > /tmp/sage_v2_harness_tests.log 2>&1',
-        'HARNESS_EXIT=$?',
-        'npm test -w @agent-assistant/telemetry > /tmp/sage_v2_telemetry_tests.log 2>&1',
-        'TELEMETRY_EXIT=$?',
-        'npm test -w @agent-assistant/vfs > /tmp/sage_v2_vfs_tests.log 2>&1',
-        'VFS_EXIT=$?',
-        'npm test -w @agent-assistant/turn-context > /tmp/sage_v2_turn_context_tests.log 2>&1',
-        'TURN_CONTEXT_EXIT=$?',
-        'echo "HARNESS_EXIT=$HARNESS_EXIT"',
-        'echo "TELEMETRY_EXIT=$TELEMETRY_EXIT"',
-        'echo "VFS_EXIT=$VFS_EXIT"',
-        'echo "TURN_CONTEXT_EXIT=$TURN_CONTEXT_EXIT"',
-        'echo "--- harness tail ---"; tail -80 /tmp/sage_v2_harness_tests.log || true',
-        'echo "--- telemetry tail ---"; tail -80 /tmp/sage_v2_telemetry_tests.log || true',
-        'echo "--- vfs tail ---"; tail -80 /tmp/sage_v2_vfs_tests.log || true',
-        'echo "--- turn-context tail ---"; tail -80 /tmp/sage_v2_turn_context_tests.log || true',
+        'npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts > /tmp/sage_v2_nested_targeted.log 2>&1',
+        'TEST_EXIT=$?',
+        'npm run build -w @agent-assistant/harness > /tmp/sage_v2_nested_build.log 2>&1',
+        'BUILD_EXIT=$?',
+        'echo "TEST_EXIT=$TEST_EXIT"',
+        'echo "BUILD_EXIT=$BUILD_EXIT"',
+        'echo "--- targeted tests tail ---"; tail -100 /tmp/sage_v2_nested_targeted.log || true',
+        'echo "--- harness build tail ---"; tail -80 /tmp/sage_v2_nested_build.log || true',
         'exit 0',
       ].join('\n'),
       captureOutput: true,
       failOnError: false,
-      timeoutMs: 900_000,
+      timeoutMs: 600_000,
     })
 
-    .step('fix-targeted-package-tests', {
+    .step('fix-targeted-tests', {
       agent: 'executor-codex',
-      dependsOn: ['run-targeted-package-tests'],
-      task: `Targeted package test output:
+      dependsOn: ['run-targeted-tests-first-pass'],
+      task: `Targeted test/build evidence:
 
-{{steps.run-targeted-package-tests.output}}
+{{steps.run-targeted-tests-first-pass.output}}
 
-If every *_EXIT is 0, do nothing. Otherwise fix only regressions caused by this workflow's changes, then rerun the failing package tests until green.`,
+If TEST_EXIT=0 and BUILD_EXIT=0, do nothing.
+Otherwise fix only the nested-runner slice. Re-run:
+  npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts
+  npm run build -w @agent-assistant/harness
+
+Do not edit runtime policy, telemetry, eval, insight, or Sage product files.`,
       verification: { type: 'exit_code', value: '0' },
     })
 
-    .step('hard-targeted-package-tests', {
+    .step('hard-targeted-validation', {
       type: 'deterministic',
-      dependsOn: ['fix-targeted-package-tests'],
+      dependsOn: ['fix-targeted-tests'],
       command: [
         'set -e',
-        'npm test -w @agent-assistant/harness 2>&1 | tail -80',
-        'npm test -w @agent-assistant/telemetry 2>&1 | tail -80',
-        'npm test -w @agent-assistant/vfs 2>&1 | tail -80',
-        'npm test -w @agent-assistant/turn-context 2>&1 | tail -80',
-        'echo SAGE_V2_TARGETED_TESTS_GREEN',
+        `mkdir -p ${GATE_DIR}`,
+        `: > ${VALIDATION_LOG}`,
+        `npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts >> ${VALIDATION_LOG} 2>&1`,
+        `npm run build -w @agent-assistant/harness >> ${VALIDATION_LOG} 2>&1`,
+        `tail -120 ${VALIDATION_LOG}`,
+        'echo SAGE_V2_NESTED_RUNNER_TARGETED_GREEN',
       ].join('\n'),
       captureOutput: true,
       failOnError: true,
-      timeoutMs: 900_000,
+      timeoutMs: 600_000,
     })
 
     .step('executor-self-reflection', {
       agent: 'executor-codex',
-      dependsOn: ['hard-targeted-package-tests'],
+      dependsOn: ['hard-targeted-validation'],
       task: `Write ${EXECUTOR_REFLECTION}.
 
-Reflect on your own implementation. Include:
-- exact files changed by slice
-- tests added or updated
-- how each Sage v2 extraction acceptance item is covered
-- Cloudflare Workers fetch compatibility evidence
-- any residual risks or deferred Sage-owned behavior
+Include:
+- files changed for the nested-runner slice
+- tests added/updated
+- validation commands run
+- how Sage product logic was kept out
+- any residual risk
 
 End with EXECUTOR_SELF_REFLECTION_COMPLETE.`,
       verification: { type: 'file_exists', value: EXECUTOR_REFLECTION },
     })
 
-    .step('build-and-regression-first-pass', {
-      type: 'deterministic',
-      dependsOn: ['executor-self-reflection'],
-      command: [
-        'set +e',
-        `mkdir -p ${GATE_DIR}`,
-        `: > ${VALIDATION_LOG}`,
-        'npm run build --workspaces --if-present >> ' + VALIDATION_LOG + ' 2>&1',
-        'BUILD_EXIT=$?',
-        'npm test --workspaces --if-present >> ' + VALIDATION_LOG + ' 2>&1',
-        'TEST_EXIT=$?',
-        'echo "BUILD_EXIT=$BUILD_EXIT"',
-        'echo "TEST_EXIT=$TEST_EXIT"',
-        `tail -160 ${VALIDATION_LOG}`,
-        'exit 0',
-      ].join('\n'),
-      captureOutput: true,
-      failOnError: false,
-      timeoutMs: 1_800_000,
-    })
-
-    .step('fix-build-and-regressions', {
-      agent: 'executor-codex',
-      dependsOn: ['build-and-regression-first-pass'],
-      task: `Workspace build/regression output:
-
-{{steps.build-and-regression-first-pass.output}}
-
-If BUILD_EXIT=0 and TEST_EXIT=0, do nothing. Otherwise fix only issues caused by this workflow. Re-run:
-  npm run build --workspaces --if-present
-  npm test --workspaces --if-present
-
-Keep fixing until both are green.`,
-      verification: { type: 'exit_code', value: '0' },
-    })
-
-    .step('hard-workspace-validation', {
-      type: 'deterministic',
-      dependsOn: ['fix-build-and-regressions'],
-      command: [
-        'set -e',
-        `mkdir -p ${GATE_DIR}`,
-        `: > ${VALIDATION_LOG}`,
-        `npm run build --workspaces --if-present >> ${VALIDATION_LOG} 2>&1`,
-        `npm test --workspaces --if-present >> ${VALIDATION_LOG} 2>&1`,
-        `tail -120 ${VALIDATION_LOG}`,
-        'echo SAGE_V2_WORKSPACE_VALIDATION_GREEN',
-      ].join('\n'),
-      captureOutput: true,
-      failOnError: true,
-      timeoutMs: 1_800_000,
-    })
-
-    .step('codex-fresh-eyes-review', {
+    .step('fresh-eyes-review', {
       agent: 'fresh-eyes-codex',
-      dependsOn: ['hard-workspace-validation'],
-      task: `Perform a fresh-eyes review of the complete diff:
-  git diff origin/main...HEAD
+      dependsOn: ['executor-self-reflection'],
+      task: `Review only the nested-runner intended diff.
 
-Review for bugs, missing tests, product-boundary violations, Cloudflare Workers fetch mistakes, public API breakage, and workflow scope creep. You may make narrow fixes if you find issues, but do not broaden the implementation.
+Use:
+  git diff -- packages/harness/src/nested-subagent-runner.ts packages/harness/src/nested-subagent-runner.test.ts packages/harness/src/subagent-registry.ts packages/harness/src/subagent-registry.test.ts packages/harness/src/index.ts packages/harness/src/registries/index.ts packages/harness/src/subpath-exports.test.ts packages/harness/package.json docs/architecture/sage-v2-nested-subagent-runner-*.md
 
-Write ${FRESH_REVIEW}. Use one of PASS, PASS_WITH_FOLLOWUPS, or FAIL as the verdict. End with FRESH_EYES_REVIEW_COMPLETE.`,
+Look for bugs, missing edge tests, API breakage, product-boundary leaks, and scope creep. Make narrow fixes only if needed.
+Write ${FRESH_REVIEW}. Use PASS, PASS_WITH_FOLLOWUPS, or FAIL. End with FRESH_EYES_REVIEW_COMPLETE.`,
       verification: { type: 'file_exists', value: FRESH_REVIEW },
     })
 
     .step('verify-fresh-eyes-review', {
       type: 'deterministic',
-      dependsOn: ['codex-fresh-eyes-review'],
+      dependsOn: ['fresh-eyes-review'],
       command: [
         'set -e',
         `rg -q 'FRESH_EYES_REVIEW_COMPLETE' ${FRESH_REVIEW}`,
         `! rg -q '^FAIL\\b' ${FRESH_REVIEW}`,
-        'npm run build --workspaces --if-present 2>&1 | tail -80',
-        'npm test --workspaces --if-present 2>&1 | tail -80',
-        'echo SAGE_V2_FRESH_EYES_REVIEW_VERIFIED',
+        'npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts 2>&1 | tail -100',
+        'echo SAGE_V2_FRESH_EYES_VERIFIED',
       ].join('\n'),
       captureOutput: true,
       failOnError: true,
-      timeoutMs: 1_800_000,
+      timeoutMs: 600_000,
     })
 
     .step('fresh-eyes-self-reflection', {
@@ -480,7 +318,7 @@ Write ${FRESH_REVIEW}. Use one of PASS, PASS_WITH_FOLLOWUPS, or FAIL as the verd
       dependsOn: ['verify-fresh-eyes-review'],
       task: `Write ${FRESH_REFLECTION}.
 
-Reflect on your review process: what you checked, what you fixed if anything, what uncertainty remains, and why the verdict is justified.
+Reflect on what you checked, any fixes made, and why the verdict is justified for PR 1 only.
 
 End with FRESH_EYES_SELF_REFLECTION_COMPLETE.`,
       verification: { type: 'file_exists', value: FRESH_REFLECTION },
@@ -489,18 +327,11 @@ End with FRESH_EYES_SELF_REFLECTION_COMPLETE.`,
     .step('claude-peer-review', {
       agent: 'peer-review-claude',
       dependsOn: ['fresh-eyes-self-reflection'],
-      task: `Perform the required Claude peer review.
+      task: `Perform Claude peer review for this one nested-runner PR.
 
-Inputs:
-- ${LEAD_PLAN}
-- ${LEAD_REFLECTION}
-- ${EXECUTOR_REFLECTION}
-- ${FRESH_REVIEW}
-- git diff origin/main...HEAD
-- ${VALIDATION_LOG}
-
-Review for extraction correctness, API minimality, type safety, test adequacy, telemetry privacy, eval usefulness, insight provenance, runtime budget behavior, and absence of Sage product logic. Make narrow fixes if needed, then rerun relevant tests.
-
+Read ${PLAN_DOC}, ${LEAD_REFLECTION}, ${EXECUTOR_REFLECTION}, ${FRESH_REVIEW}, and the nested-runner diff.
+Review API minimality, extraction boundary, cancellation behavior, allowlist enforcement, tests, and public exports.
+Make narrow fixes only if needed.
 Write ${CLAUDE_REVIEW}. Use PASS, PASS_WITH_FOLLOWUPS, or FAIL. End with CLAUDE_PEER_REVIEW_COMPLETE.`,
       verification: { type: 'file_exists', value: CLAUDE_REVIEW },
     })
@@ -512,113 +343,95 @@ Write ${CLAUDE_REVIEW}. Use PASS, PASS_WITH_FOLLOWUPS, or FAIL. End with CLAUDE_
         'set -e',
         `rg -q 'CLAUDE_PEER_REVIEW_COMPLETE' ${CLAUDE_REVIEW}`,
         `! rg -q '^FAIL\\b' ${CLAUDE_REVIEW}`,
-        'npm run build --workspaces --if-present 2>&1 | tail -80',
-        'npm test --workspaces --if-present 2>&1 | tail -80',
-        'echo SAGE_V2_CLAUDE_PEER_REVIEW_VERIFIED',
+        'npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts 2>&1 | tail -100',
+        'echo SAGE_V2_CLAUDE_REVIEW_VERIFIED',
       ].join('\n'),
       captureOutput: true,
       failOnError: true,
-      timeoutMs: 1_800_000,
+      timeoutMs: 600_000,
     })
 
     .step('claude-peer-review-self-reflection', {
       agent: 'peer-review-claude',
       dependsOn: ['verify-claude-peer-review'],
-      task: `Write ${CLAUDE_REVIEW_REFLECTION}.
+      task: `Write ${CLAUDE_REFLECTION}.
 
-Reflect on the peer review. Include what you checked, why the verdict is not merely based on green tests, and which follow-ups remain outside this Agent Assistant substrate PR.
+Reflect on why the review verdict is valid beyond green tests, and list follow-up substrate slices that remain separate PRs.
 
 End with CLAUDE_PEER_REVIEW_SELF_REFLECTION_COMPLETE.`,
-      verification: { type: 'file_exists', value: CLAUDE_REVIEW_REFLECTION },
+      verification: { type: 'file_exists', value: CLAUDE_REFLECTION },
     })
 
     .step('claude-80-to-100-validation', {
       agent: 'validation-claude',
       dependsOn: ['claude-peer-review-self-reflection'],
-      task: `Apply the relay-80-100-workflow skill as the final validation authority.
+      task: `Apply the relay-80-100-workflow checklist to this nested-runner PR only.
 
-You must:
-1. Read ${LEAD_PLAN}, ${EXECUTOR_REFLECTION}, ${FRESH_REVIEW}, ${CLAUDE_REVIEW}, and ${VALIDATION_LOG}.
-2. Inspect git diff origin/main...HEAD.
-3. Re-run or spot-run the highest-risk targeted tests for nested runner, runtime policy, telemetry, eval, and insights.
-4. Verify the final hard gates are real: tests exist, tests run deterministically, failures have a fix-rerun path, build passes, regressions pass, and commit is downstream of all gates.
-5. Verify Cloudflare Workers fetch safety with rg.
-6. Verify no Sage product prompts, tool roster definitions, Slack/Notion product workflows, or Sage env flags leaked into shared packages.
+Verify from evidence:
+1. Tests exist and were run deterministically.
+2. Test failures had a fix-rerun path.
+3. Harness build passes.
+4. Review gates completed.
+5. Final commit will stage only nested-runner allowlist files.
+6. Follow-up slices remain out of scope.
 
-Write ${VALIDATION_REPORT} with an explicit checklist and evidence. Use PASS, PASS_WITH_FOLLOWUPS, or FAIL. End with CLAUDE_80_TO_100_VALIDATION_COMPLETE.`,
+Write ${VALIDATION_REPORT}. Use PASS, PASS_WITH_FOLLOWUPS, or FAIL. End with CLAUDE_80_TO_100_VALIDATION_COMPLETE.`,
       verification: { type: 'file_exists', value: VALIDATION_REPORT },
     })
 
-    .step('verify-claude-80-to-100-validation', {
+    .step('final-hard-validation', {
       type: 'deterministic',
       dependsOn: ['claude-80-to-100-validation'],
       command: [
         'set -e',
         `rg -q 'CLAUDE_80_TO_100_VALIDATION_COMPLETE' ${VALIDATION_REPORT}`,
         `! rg -q '^FAIL\\b' ${VALIDATION_REPORT}`,
-        'npm run build --workspaces --if-present 2>&1 | tail -100',
-        'npm test --workspaces --if-present 2>&1 | tail -100',
-        'if rg -n "(fetchImpl\\s*=\\s*[^?;]*\\?\\?\\s*fetch\\b|=\\s*fetch\\s*;)" packages; then echo "bare fetch storage found"; exit 1; fi',
-        'if rg -n "SAGE_HARNESS_SUBAGENTS_ENABLED|slack-researcher|competitor-researcher|notion_create_page" packages; then echo "Sage product semantics leaked into shared packages"; exit 1; fi',
-        'echo SAGE_V2_80_TO_100_VERIFIED',
+        `mkdir -p ${GATE_DIR}`,
+        `: > ${VALIDATION_LOG}`,
+        `npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts >> ${VALIDATION_LOG} 2>&1`,
+        `npm run build -w @agent-assistant/harness >> ${VALIDATION_LOG} 2>&1`,
+        'if rg -n "(fetchImpl\\s*=\\s*[^?;]*\\?\\?\\s*fetch\\b|=\\s*fetch\\s*;)" packages/harness/src/nested-subagent-runner.ts packages/harness/src/subagent-registry.ts; then echo "bare fetch storage found"; exit 1; fi',
+        'if rg -n "SAGE_HARNESS_SUBAGENTS_ENABLED|slack-researcher|competitor-researcher|notion_create_page" packages/harness/src/nested-subagent-runner.ts packages/harness/src/subagent-registry.ts; then echo "Sage product semantics leaked"; exit 1; fi',
+        `tail -120 ${VALIDATION_LOG}`,
+        'echo SAGE_V2_NESTED_RUNNER_FINAL_VALIDATION_GREEN',
       ].join('\n'),
       captureOutput: true,
       failOnError: true,
-      timeoutMs: 1_800_000,
+      timeoutMs: 600_000,
     })
 
     .step('validation-self-reflection', {
       agent: 'validation-claude',
-      dependsOn: ['verify-claude-80-to-100-validation'],
+      dependsOn: ['final-hard-validation'],
       task: `Write ${VALIDATION_REFLECTION}.
 
-Reflect on whether your 80-to-100 signoff truly proves production readiness. Name any blind spots and why they are acceptable for this PR or explicitly documented as follow-ups.
+Reflect on final confidence for the nested-runner PR and name any residual risk or follow-up slice.
 
 End with VALIDATION_SELF_REFLECTION_COMPLETE.`,
       verification: { type: 'file_exists', value: VALIDATION_REFLECTION },
     })
 
-    .step('final-acceptance-gate', {
+    .step('stage-allowlist-and-commit', {
       type: 'deterministic',
       dependsOn: ['validation-self-reflection'],
       command: [
         'set -e',
-        `rg -q 'LEAD_SELF_REFLECTION_COMPLETE' ${LEAD_REFLECTION}`,
-        `rg -q 'EXECUTOR_SELF_REFLECTION_COMPLETE' ${EXECUTOR_REFLECTION}`,
-        `rg -q 'FRESH_EYES_SELF_REFLECTION_COMPLETE' ${FRESH_REFLECTION}`,
-        `rg -q 'CLAUDE_PEER_REVIEW_SELF_REFLECTION_COMPLETE' ${CLAUDE_REVIEW_REFLECTION}`,
-        `rg -q 'VALIDATION_SELF_REFLECTION_COMPLETE' ${VALIDATION_REFLECTION}`,
-        'git diff --quiet && (echo "No implementation diff to publish"; exit 1) || true',
-        'git status --short',
-        'echo "--- diff stat ---"',
-        'git diff --stat',
-        'echo SAGE_V2_FINAL_ACCEPTANCE_GATE_OK',
-      ].join('\n'),
-      captureOutput: true,
-      failOnError: true,
-    })
-
-    .step('commit', {
-      type: 'deterministic',
-      dependsOn: ['final-acceptance-gate'],
-      command: [
-        'set -e',
         `mkdir -p ${GATE_DIR}`,
         `cat > ${GATE_DIR}/commit-message.txt <<'COMMIT'`,
-        'feat: add Sage v2 reusable substrate primitives',
+        'feat(harness): add nested subagent runner helper',
         '',
-        'Implement the reusable Agent Assistant substrate needed by Sage v2 without importing Sage product behavior:',
-        '- nested subagent runner helper for harness task delegation',
-        '- runtime budget policy primitives and final-output sanitation',
-        '- reusable telemetry vocabulary for subagents, policies, and synthesis salvage',
-        '- eval runner substrate for assistant-turn fixtures',
-        '- insight envelope and reader helpers with provenance',
+        'Add the first reusable Sage v2 substrate slice: a harness helper for wiring createSubagentToolRegistry to isolated nested harness turns.',
         '',
-        'Validation, fresh-eyes review, Claude peer review, and Claude 80-to-100 signoff are recorded under docs/architecture.',
+        'Keep Sage product prompts, specialist rosters, runtime policy, telemetry, eval, and insight slices out of this PR.',
+        '',
+        'Validation is recorded in docs/architecture/sage-v2-nested-subagent-runner-80-to-100-validation.md.',
         'COMMIT',
-        'git add package.json package-lock.json packages docs/architecture',
+        'git add packages/harness/package.json packages/harness/src/nested-subagent-runner.ts packages/harness/src/nested-subagent-runner.test.ts packages/harness/src/subagent-registry.ts packages/harness/src/subagent-registry.test.ts packages/harness/src/index.ts packages/harness/src/registries/index.ts packages/harness/src/subpath-exports.test.ts',
+        'git add docs/architecture/sage-v2-nested-subagent-runner-*.md',
+        'git diff --cached --name-only > /tmp/sage_v2_nested_staged.txt',
+        'test -s /tmp/sage_v2_nested_staged.txt',
+        'if rg -v "^(packages/harness/package\\.json|packages/harness/src/(nested-subagent-runner|nested-subagent-runner\\.test|subagent-registry|subagent-registry\\.test|index|registries/index|subpath-exports\\.test)\\.ts|docs/architecture/sage-v2-nested-subagent-runner-.*\\.md)$" /tmp/sage_v2_nested_staged.txt; then echo "unexpected staged file"; exit 1; fi',
         'git status --short',
-        'if git diff --cached --quiet; then echo "Nothing staged for commit"; exit 1; fi',
         `git commit -F ${GATE_DIR}/commit-message.txt`,
       ].join('\n'),
       captureOutput: true,
@@ -627,7 +440,7 @@ End with VALIDATION_SELF_REFLECTION_COMPLETE.`,
 
     .step('push', {
       type: 'deterministic',
-      dependsOn: ['commit'],
+      dependsOn: ['stage-allowlist-and-commit'],
       command: 'branch=$(git rev-parse --abbrev-ref HEAD) && git push -u origin "$branch"',
       captureOutput: true,
       failOnError: true,
@@ -639,32 +452,26 @@ End with VALIDATION_SELF_REFLECTION_COMPLETE.`,
       command: `mkdir -p ${GATE_DIR} && cat > ${PR_BODY_FILE} <<'PRBODY'
 ## Summary
 
-This PR extracts the reusable Agent Assistant substrate required by Sage v2 while keeping Sage product intelligence in Sage.
+First Sage v2 substrate extraction slice:
 
-- Add nested subagent runner support for harness task delegation.
-- Add runtime budget policy primitives for todo rewrite caps, duplicate call caching, synthesis reserve, drill-or-stop enforcement, and pseudo-tool output sanitation.
-- Add reusable telemetry event vocabulary for subagent lifecycle, runtime policy interventions, and synthesis salvage.
-- Add a fixture-oriented eval substrate for assistant turns.
-- Add insight envelope and reader helpers with provenance and graceful malformed-input handling.
-
-## Boundary
-
-This PR intentionally does not move Sage prompts, Sage specialist roster definitions, Slack-to-Notion workflows, connector semantics, or Sage environment flags into Agent Assistant.
+- Add a reusable @agent-assistant/harness nested subagent runner helper for createSubagentToolRegistry.
+- Preserve Sage product prompts, specialist rosters, runtime policy, telemetry, eval, and insight work for separate PRs.
+- Include targeted nested-runner tests, fresh-eyes review, Claude peer review, and Claude 80-to-100 validation.
 
 ## Validation
 
-- Claude lead architecture contract: ${LEAD_PLAN}
-- Codex executor reflection: ${EXECUTOR_REFLECTION}
-- Codex fresh-eyes review: ${FRESH_REVIEW}
-- Claude peer review: ${CLAUDE_REVIEW}
-- Claude 80-to-100 validation: ${VALIDATION_REPORT}
-- npm run build --workspaces --if-present
-- npm test --workspaces --if-present
-- rg check for bare fetch storage and Sage product semantic leakage
+- npm test -w @agent-assistant/harness -- src/nested-subagent-runner.test.ts src/subagent-registry.test.ts src/subpath-exports.test.ts
+- npm run build -w @agent-assistant/harness
+- Cloudflare Workers bare-fetch storage grep
+- Sage product semantic leakage grep
 
-## Follow-up
+## Follow-ups
 
-Sage should adopt the new Agent Assistant release in a separate Sage PR and delete or simplify its local nested subagent runner and duplicated generic policy machinery.
+- Runtime budget policy primitives
+- Telemetry event vocabulary
+- Eval runner substrate
+- Insight envelope and reader helpers
+- Sage adoption after Agent Assistant release
 PRBODY
 wc -l ${PR_BODY_FILE}`,
       captureOutput: true,
@@ -680,10 +487,10 @@ wc -l ${PR_BODY_FILE}`,
         'existing=$(gh pr list --head "$branch" --json url --jq ".[0].url" 2>/dev/null || true)',
         'if [ -n "$existing" ] && [ "$existing" != "null" ]; then',
         '  echo "[open-pr] PR already exists for $branch; updating body."',
-        `  gh pr edit "$existing" --title "feat: add Sage v2 reusable substrate primitives" --body-file ${PR_BODY_FILE} >/dev/null`,
+        `  gh pr edit "$existing" --title "feat(harness): add nested subagent runner helper" --body-file ${PR_BODY_FILE} >/dev/null`,
         '  echo "PR: $existing"',
         'else',
-        `  PR_URL=$(gh pr create --title "feat: add Sage v2 reusable substrate primitives" --body-file ${PR_BODY_FILE})`,
+        `  PR_URL=$(gh pr create --title "feat(harness): add nested subagent runner helper" --body-file ${PR_BODY_FILE})`,
         '  echo "PR: $PR_URL"',
         'fi',
       ].join('\n'),

--- a/workflows/lib/agent-assistant-repo-setup.ts
+++ b/workflows/lib/agent-assistant-repo-setup.ts
@@ -46,6 +46,8 @@ export interface AgentAssistantRepoSetupOptions {
   committerEmail?: string;
   /** Extra shell commands appended to the setup-branch step (e.g. `prpm install`). */
   extraSetupCommands?: string[];
+  /** Optional upstream gate for setup-branch. Useful for runtime wrapper resume anchors. */
+  dependsOn?: string[];
   /** Skip `npm run build --workspaces --if-present`. Rarely the right call; only set when the workflow produces no TS changes that consume cross-package dist output. */
   skipWorkspaceBuild?: boolean;
 }
@@ -84,6 +86,7 @@ export function applyAgentAssistantRepoSetup<T>(
   chain
     .step('setup-branch', {
       type: 'deterministic',
+      ...(opts.dependsOn ? { dependsOn: opts.dependsOn } : {}),
       command: setupBranchCommand,
       captureOutput: true,
       failOnError: true,


### PR DESCRIPTION
## Summary

Bundles the four substrate follow-ups that PR #86 (nested subagent runner) carved out for separate work:

- **Runtime budget policy** — `packages/harness/src/runtime-policy/` with unit + integration tests
- **Telemetry event vocabulary** — `packages/telemetry/src/events.ts`, harness-bridge wiring, sink type updates, runtime-policy/subagent event tests
- **Eval runner substrate** — `packages/telemetry/src/evals/` (eval runner, human suite, PR comment formatter, eval checks) with tests
- **Insight envelope + reader** — `packages/vfs/src/insight/`, `packages/turn-context/src/insight-projection*`, projection wiring, vfs-insight type declarations

Also folds in:
- Substrate extraction docs (implementation plan, fresh-eyes review, executor + lead reflections)
- `docs/consumer/evals-adoption-guide.md`
- May 2026 trajectory archives + index update
- Generated workflow updates (`sage-v2-substrate-extraction-pr.ts`, `ricky-spec-agent-assistant-harness-v0-5-v0-6-v0-7-impr.ts`)
- `workflows/lib/agent-assistant-repo-setup.ts` tweak

Excluded from the commit: local `tmp/` and `.ricky/` scratch dirs.

## Test plan

- [ ] CI: `npm test -w @agent-assistant/harness` (runtime-policy unit + integration)
- [ ] CI: `npm test -w @agent-assistant/telemetry` (events, eval runner, human suite, PR comment, runtime-policy events, subagent events, private-content leakage)
- [ ] CI: `npm test -w @agent-assistant/turn-context` (insight projection)
- [ ] CI: `npm test -w @agent-assistant/vfs` (insight reader)
- [ ] CI: `npm run build -w @agent-assistant/{harness,telemetry,turn-context,vfs}`
- [ ] Manual: confirm new `@agent-assistant/telemetry/evals` subpath export resolves
- [ ] Manual: confirm `turn-context` `@agent-assistant/vfs` dep resolves at install

🤖 Generated with [Claude Code](https://claude.com/claude-code)