### PR TITLE
feat(telemetry): add human-driven eval foundation

### DIFF
--- a/packages/telemetry/src/evals/human-suite.ts
+++ b/packages/telemetry/src/evals/human-suite.ts
@@ -65,6 +65,8 @@ export interface HumanEvalTrial {
   status: HumanEvalStatus;
   duration_ms: number;
   checks: HumanEvalCheck[];
+  input?: Record<string, unknown>;
+  expected?: HumanEvalExpected;
   actual?: Partial<HumanEvalActual>;
   error?: string;
 }
@@ -385,13 +387,48 @@ export function renderHumanEvalReview(result: HumanEvalRunSummary): string {
     lines.push(`- Status: ${test.status}`);
     lines.push(`- Suite: ${test.suite}`);
     lines.push(`- Executor: ${test.executor}`);
+    if (test.input?.message !== undefined) {
+      lines.push(`- Message: ${String(test.input.message)}`);
+    }
+    if (test.input?.actualPath !== undefined) {
+      lines.push(`- Actual path: ${String(test.input.actualPath)}`);
+    }
     lines.push('');
+    if ((test.expected?.must?.length ?? 0) > 0) {
+      lines.push('### Must');
+      lines.push('');
+      for (const item of test.expected?.must ?? []) {
+        lines.push(`- ${item}`);
+      }
+      lines.push('');
+    }
+    if ((test.expected?.mustNot?.length ?? 0) > 0) {
+      lines.push('### Must Not');
+      lines.push('');
+      for (const item of test.expected?.mustNot ?? []) {
+        lines.push(`- ${item}`);
+      }
+      lines.push('');
+    }
+    const deterministicChecks = test.checks.filter((check) => !check.name.startsWith('human:'));
+    if (deterministicChecks.length > 0) {
+      lines.push('### Deterministic Checks');
+      lines.push('');
+      for (const check of deterministicChecks) {
+        lines.push(`- ${check.passed ? 'PASS' : 'FAIL'} ${check.name}: ${check.message}`);
+      }
+      lines.push('');
+    }
     lines.push('Human verdict: TODO pass / fail / case-bug / grader-bug');
     lines.push('');
     lines.push('Notes:');
     lines.push('');
+    if ((test.actual?.content ?? '').length > 0) {
+      lines.push('### Output');
+      lines.push('');
+    }
     lines.push('```');
-    lines.push((test.actual?.content ?? '').slice(0, 4000));
+    lines.push(((test.actual?.content ?? '') || 'No assistant output captured for this executor.').slice(0, 4000));
     lines.push('```');
     lines.push('');
   }

--- a/packages/telemetry/src/evals/human-suite.ts
+++ b/packages/telemetry/src/evals/human-suite.ts
@@ -289,7 +289,7 @@ export function assertHumanEvalExpected(
       `expected >= ${expected.minToolCalls} tool calls, got ${toolNames.length}`,
     );
   }
-  if (expected.maxQuestionMarks !== undefined) {
+  if (typeof expected.maxQuestionMarks === 'number' && Number.isFinite(expected.maxQuestionMarks)) {
     const questionMarkCount = (actual.content.match(/\?/g) ?? []).length;
     addCheck(
       checks,

--- a/packages/telemetry/src/evals/human-suite.ts
+++ b/packages/telemetry/src/evals/human-suite.ts
@@ -31,6 +31,7 @@ export interface HumanEvalExpected {
   toolCallsExclude?: string[];
   maxToolCalls?: number;
   minToolCalls?: number;
+  maxQuestionMarks?: number;
   must?: string[];
   mustNot?: string[];
   humanReviewRequired?: boolean;
@@ -286,6 +287,15 @@ export function assertHumanEvalExpected(
       'minToolCalls',
       toolNames.length >= expected.minToolCalls,
       `expected >= ${expected.minToolCalls} tool calls, got ${toolNames.length}`,
+    );
+  }
+  if (expected.maxQuestionMarks !== undefined) {
+    const questionMarkCount = (actual.content.match(/\?/g) ?? []).length;
+    addCheck(
+      checks,
+      'maxQuestionMarks',
+      questionMarkCount <= expected.maxQuestionMarks,
+      `expected <= ${expected.maxQuestionMarks} question marks, got ${questionMarkCount}`,
     );
   }
 

--- a/packages/telemetry/src/evals/human-suite.ts
+++ b/packages/telemetry/src/evals/human-suite.ts
@@ -404,18 +404,20 @@ export function renderHumanEvalReview(result: HumanEvalRunSummary): string {
       lines.push(`- Actual path: ${String(test.input.actualPath)}`);
     }
     lines.push('');
-    if ((test.expected?.must?.length ?? 0) > 0) {
+    const mustItems = Array.isArray(test.expected?.must) ? test.expected.must : [];
+    const mustNotItems = Array.isArray(test.expected?.mustNot) ? test.expected.mustNot : [];
+    if (mustItems.length > 0) {
       lines.push('### Must');
       lines.push('');
-      for (const item of test.expected?.must ?? []) {
+      for (const item of mustItems) {
         lines.push(`- ${item}`);
       }
       lines.push('');
     }
-    if ((test.expected?.mustNot?.length ?? 0) > 0) {
+    if (mustNotItems.length > 0) {
       lines.push('### Must Not');
       lines.push('');
-      for (const item of test.expected?.mustNot ?? []) {
+      for (const item of mustNotItems) {
         lines.push(`- ${item}`);
       }
       lines.push('');

--- a/packages/telemetry/test/human-suite.test.ts
+++ b/packages/telemetry/test/human-suite.test.ts
@@ -136,6 +136,11 @@ describe('human eval suite helpers', () => {
       status: 'needs-human',
       duration_ms: 12,
       checks: [{ name: 'status', passed: true, message: 'case executed' }],
+      input: { message: 'Plan the feature' },
+      expected: {
+        must: ['Ask one useful question'],
+        mustNot: ['Pretend work is complete'],
+      },
       actual: { content: 'A plan requiring review.' },
     };
     run.tests.push(trial);
@@ -144,7 +149,12 @@ describe('human eval suite helpers', () => {
 
     expect(summary.needs_human).toBe(1);
     expect(renderHumanEvalSummary(summary)).toContain('NEEDS-HUMAN planning.case');
-    expect(renderHumanEvalReview(summary)).toContain('Human verdict: TODO');
+    const review = renderHumanEvalReview(summary);
+    expect(review).toContain('Human verdict: TODO');
+    expect(review).toContain('### Must');
+    expect(review).toContain('Ask one useful question');
+    expect(review).toContain('### Must Not');
+    expect(review).toContain('Pretend work is complete');
     expect(readFileSync(path.join(root, 'run-1', 'result.json'), 'utf8')).toContain('"needs_human": 1');
   });
 });

--- a/packages/telemetry/test/human-suite.test.ts
+++ b/packages/telemetry/test/human-suite.test.ts
@@ -181,4 +181,50 @@ describe('human eval suite helpers', () => {
     expect(review).toContain('Pretend work is complete');
     expect(readFileSync(path.join(root, 'run-1', 'result.json'), 'utf8')).toContain('"needs_human": 1');
   });
+
+  it('ignores malformed human rubric fields while rendering review artifacts', () => {
+    const run = createHumanEvalRunRecord({
+      branch: 'main',
+      gitSha: 'abc123',
+      mode: 'offline',
+      runDir: path.join(makeTempRoot(), 'run-1'),
+      selectedCaseCount: 1,
+      timestamp: '2026-05-08T00:00:00.000Z',
+    });
+    run.tests.push({
+      id: 'planning.malformed-rubric',
+      suite: 'planning',
+      kind: 'capability',
+      executor: 'manual',
+      trial: 1,
+      tags: [],
+      status: 'needs-human',
+      duration_ms: 12,
+      checks: [],
+      expected: {
+        must: { length: 1 } as unknown as string[],
+        mustNot: { length: 1 } as unknown as string[],
+      },
+      actual: { content: 'Candidate output.' },
+    });
+
+    const review = renderHumanEvalReview(summarizeForTest(run));
+
+    expect(review).toContain('## planning.malformed-rubric');
+    expect(review).not.toContain('### Must');
+    expect(review).not.toContain('### Must Not');
+  });
 });
+
+function summarizeForTest(run: ReturnType<typeof createHumanEvalRunRecord>) {
+  return {
+    ...run,
+    total_trials: run.tests.length,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+    needs_human: run.tests.length,
+    total_duration_ms: run.tests.reduce((sum, test) => sum + test.duration_ms, 0),
+    final: true,
+  };
+}

--- a/packages/telemetry/test/human-suite.test.ts
+++ b/packages/telemetry/test/human-suite.test.ts
@@ -86,6 +86,7 @@ describe('human eval suite helpers', () => {
           toolCallsInclude: ['workspace_list'],
           toolCallsExclude: ['github_create_issue'],
           maxToolCalls: 2,
+          maxQuestionMarks: 0,
           must: ['human criterion'],
         },
       },
@@ -99,6 +100,29 @@ describe('human eval suite helpers', () => {
 
     expect(checks.every((check) => check.passed)).toBe(true);
     expect(checks.map((check) => check.name)).toContain('human:must');
+  });
+
+  it('flags outputs that ask too many questions', () => {
+    const checks = assertHumanEvalExpected(
+      {
+        id: 'planning.question-count',
+        suite: 'planning',
+        input: { message: 'Plan a feature' },
+        expected: {
+          maxQuestionMarks: 1,
+        },
+      },
+      {
+        content: 'What app is this? What user problem matters most?',
+        toolCalls: [],
+      },
+    );
+
+    expect(checks).toContainEqual({
+      name: 'maxQuestionMarks',
+      passed: false,
+      message: 'expected <= 1 question marks, got 2',
+    });
   });
 
   it('flags human review when requested by expected or grading metadata', () => {

--- a/packages/telemetry/test/human-suite.test.ts
+++ b/packages/telemetry/test/human-suite.test.ts
@@ -125,6 +125,25 @@ describe('human eval suite helpers', () => {
     });
   });
 
+  it('ignores malformed maxQuestionMarks values', () => {
+    const checks = assertHumanEvalExpected(
+      {
+        id: 'planning.invalid-question-count',
+        suite: 'planning',
+        input: { message: 'Plan a feature' },
+        expected: {
+          maxQuestionMarks: '1' as unknown as number,
+        },
+      },
+      {
+        content: 'What app is this? What user problem matters most?',
+        toolCalls: [],
+      },
+    );
+
+    expect(checks.map((check) => check.name)).not.toContain('maxQuestionMarks');
+  });
+
   it('flags human review when requested by expected or grading metadata', () => {
     expect(humanEvalNeedsReview({
       id: 'x',


### PR DESCRIPTION
## Summary
- adds Agent Assistant telemetry eval primitives for human-authored suites and deterministic checks
- enriches human review artifacts with input, Must/Must Not criteria, deterministic check status, and captured output
- documents product adoption so Sage can consume this foundation instead of owning generic eval mechanics locally

## Validation
- npm --prefix ../agent-assistant run build -w @agent-assistant/telemetry
- npm --prefix ../agent-assistant run test -w @agent-assistant/telemetry -- human-suite.test.ts eval-runner.test.ts

## Follow-up
- after publish, bump Sage's @agent-assistant/telemetry dependency and remove the sibling-package fallback from the Sage eval runner