### PR TITLE
feat(telemetry): add provider eval executors

### DIFF
--- a/packages/telemetry/README.md
+++ b/packages/telemetry/README.md
@@ -16,6 +16,8 @@ Products can usually keep only a small wrapper script plus their own
 - Human-review tracking via `Must`, `Must Not`, and `Human Review: true`.
 - Run artifact writing: `result.json`, `summary.md`, and `human-review.md`.
 - A generic CLI run loop with pluggable product executors.
+- Provider executor helpers for local OpenCode one-shot runs and deeper
+  Agent Relay handoffs.
 - CI summary rendering that fails on failed/skipped cases while listing
   `needs-human` cases for review.
 
@@ -61,3 +63,90 @@ if (process.env.GITHUB_STEP_SUMMARY) {
 process.exit(exitCode);
 ```
 
+## Provider-Backed Runs
+
+Provider-backed runs are opt-in so offline deterministic checks stay cheap. Use
+`--provider` to allow an executor to call a model or broker, and `--executor` to
+run existing manual cases through a provider without rewriting every case.
+
+```sh
+node scripts/evals/run-product-evals.mjs --provider --executor opencode --suite workflow-authoring
+```
+
+The OpenCode helper wraps the Agent Assistant harness CLI runner, so products
+can use free or local OpenCode models without OpenRouter credentials:
+
+```ts
+import {
+  createOpenCodeHumanEvalExecutor,
+  runHumanEvalCli,
+} from '@agent-assistant/telemetry/evals';
+
+const exitCode = await runHumanEvalCli({
+  argv: process.argv.slice(2),
+  rootDir,
+  productName: 'Ricky Evals',
+  executors: {
+    opencode: createOpenCodeHumanEvalExecutor({
+      productName: 'Ricky',
+      model: 'opencode/minimax-m2.5-free',
+      instructions: [
+        'Follow Ricky workflow standards.',
+        'Prefer deterministic verification, review artifacts, and honest blocker reporting.',
+      ],
+    }),
+  },
+});
+```
+
+Use the direct OpenCode path for quick local quality sweeps where the candidate
+answer is a single assistant response. The result is still usually
+`needs-human`; the model output is captured into `human-review.md` for a person
+to grade against the case's `Must` and `Must Not` bullets.
+
+## Agent Relay For Complex Evals
+
+Use Agent Relay when the eval needs real execution topology rather than a single
+model answer: worker spawning, tool-mediated work, channel/broker behavior,
+multi-agent coordination, or a product path that depends on Relay metadata.
+`createAgentRelayHumanEvalExecutor()` dynamically imports the Node-only Relay
+adapter only when this executor runs.
+
+```ts
+import {
+  createAgentRelayHumanEvalExecutor,
+  runHumanEvalCli,
+} from '@agent-assistant/telemetry/evals';
+
+const exitCode = await runHumanEvalCli({
+  argv: process.argv.slice(2),
+  rootDir,
+  productName: 'Ricky Evals',
+  executors: {
+    relay: createAgentRelayHumanEvalExecutor({
+      productName: 'Ricky',
+      channelId: 'agent-assistant-evals',
+      workerName: 'ricky-eval-worker',
+      timeoutMs: 300_000,
+      spawnWorker: {
+        enabled: true,
+        cli: 'opencode',
+        model: 'opencode/minimax-m2.5-free',
+        includeWorkflowConventions: true,
+      },
+      instructions: 'Exercise the real worker path and return an Agent Assistant ExecutionResult.',
+    }),
+  },
+});
+```
+
+Run those cases with:
+
+```sh
+node scripts/evals/run-product-evals.mjs --provider --executor relay --case workflow-authoring.multi-agent-repair
+```
+
+For long-running evals, prefer one case or one suite at a time and give the
+executor a larger timeout. Relay eval outputs include normalized content,
+structured tool calls when present, Relay metadata, and trace data in the normal
+human-eval run artifacts.

--- a/packages/telemetry/src/evals/human-runner-cli.ts
+++ b/packages/telemetry/src/evals/human-runner-cli.ts
@@ -44,6 +44,7 @@ interface ParsedArgs {
   list?: boolean;
   suite?: string;
   caseId?: string;
+  executor?: string;
   tags: Set<string>;
   trials?: number;
 }
@@ -99,7 +100,7 @@ export async function runHumanEvalCli(options: RunHumanEvalCliOptions): Promise<
     const trials = readPositiveInt(args.trials ?? testCase.trials, 1);
     for (let trialIndex = 0; trialIndex < trials; trialIndex += 1) {
       const startedAt = Date.now();
-      const executorName = testCase.executor ?? defaultExecutor;
+      const executorName = args.executor ?? testCase.executor ?? defaultExecutor;
       const trial = {
         id: testCase.id,
         suite: testCase.suite,
@@ -272,6 +273,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     else if (arg === '--list') parsed.list = true;
     else if (arg === '--suite') parsed.suite = argv[++index];
     else if (arg === '--case') parsed.caseId = argv[++index];
+    else if (arg === '--executor') parsed.executor = argv[++index];
     else if (arg === '--tag') parsed.tags.add(argv[++index] ?? '');
     else if (arg === '--trials') parsed.trials = Number(argv[++index]);
     else if (arg === '--help' || arg === '-h') {
@@ -290,6 +292,7 @@ Options:
   --list             List selected cases without running them.
   --suite NAME       Run one suite.
   --case ID          Run one case id.
+  --executor NAME    Override selected cases to run with this executor.
   --tag TAG          Require a tag. Can be repeated.
   --trials N         Override trial count for every case.
   --provider         Allow provider-backed product cases.

--- a/packages/telemetry/src/evals/index.ts
+++ b/packages/telemetry/src/evals/index.ts
@@ -4,4 +4,5 @@ export * from './human-ci-summary.js';
 export * from './human-markdown.js';
 export * from './human-runner-cli.js';
 export * from './human-suite.js';
+export * from './provider-executors.js';
 export * from './pr-comment-format.js';

--- a/packages/telemetry/src/evals/provider-executors.ts
+++ b/packages/telemetry/src/evals/provider-executors.ts
@@ -1,0 +1,295 @@
+import {
+  createOpenCodeCliRunner,
+  type CliRunner,
+} from '@agent-assistant/harness/worker-bridge';
+
+import {
+  createSkippedEvalError,
+  type HumanEvalExecutor,
+} from './human-runner-cli.js';
+import type { HumanEvalActual, HumanEvalCase } from './human-suite.js';
+
+export interface HumanEvalPromptOptions {
+  productName?: string;
+  systemPrompt?: string | ((testCase: HumanEvalCase) => string | undefined);
+  instructions?: string | string[];
+}
+
+export interface OpenCodeHumanEvalExecutorOptions extends HumanEvalPromptOptions {
+  command?: string;
+  model?: string;
+  timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  requireProviderMode?: boolean;
+  runner?: CliRunner;
+}
+
+export interface AgentRelayHumanEvalExecutorOptions extends HumanEvalPromptOptions {
+  channelId?: string;
+  workerName?: string;
+  orchestratorName?: string;
+  workspaceId?: string;
+  timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  binaryPath?: string;
+  spawnWorker?: {
+    enabled?: boolean;
+    name?: string;
+    cli: string;
+    task?: string;
+    model?: string;
+    cwd?: string;
+    team?: string;
+    includeWorkflowConventions?: boolean;
+  };
+  adapter?: HumanEvalExecutionAdapter;
+  adapterFactory?: () => HumanEvalExecutionAdapter | Promise<HumanEvalExecutionAdapter>;
+  requireProviderMode?: boolean;
+}
+
+interface HumanEvalExecutionAdapter {
+  execute(request: HumanEvalExecutionRequest): Promise<HumanEvalExecutionResult>;
+}
+
+interface HumanEvalExecutionRequest {
+  assistantId: string;
+  turnId: string;
+  threadId: string;
+  userId?: string;
+  message: {
+    id: string;
+    text: string;
+    receivedAt: string;
+  };
+  instructions: {
+    systemPrompt: string;
+  };
+  context?: {
+    blocks: Array<{
+      id: string;
+      label: string;
+      text: string;
+      category?: string;
+    }>;
+    structured?: Record<string, unknown>;
+  };
+  requirements?: {
+    toolUse?: 'forbidden' | 'allowed' | 'required';
+    structuredToolCalls?: 'forbidden' | 'preferred' | 'required';
+    traceDepth?: 'minimal' | 'standard' | 'detailed';
+  };
+  metadata?: Record<string, unknown>;
+}
+
+interface HumanEvalExecutionResult {
+  backendId?: string;
+  status?: string;
+  output?: {
+    text?: string;
+    structured?: Record<string, unknown>;
+  };
+  error?: {
+    code?: string;
+    message?: string;
+  };
+  trace?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+const DEFAULT_OPENCODE_TIMEOUT_MS = 120_000;
+const DEFAULT_AGENT_RELAY_TIMEOUT_MS = 300_000;
+
+export function createOpenCodeHumanEvalExecutor(
+  options: OpenCodeHumanEvalExecutorOptions = {},
+): HumanEvalExecutor {
+  const requireProviderMode = options.requireProviderMode ?? true;
+  const runner = options.runner ?? createOpenCodeCliRunner({ command: options.command });
+
+  return async (testCase, context) => {
+    if (requireProviderMode && !context.providerMode) {
+      throw createSkippedEvalError('opencode executor skipped; rerun with --provider or HUMAN_EVAL_PROVIDER=1');
+    }
+
+    const startedAt = Date.now();
+    const result = await runner.run({
+      prompt: buildHumanEvalOneShotPrompt(testCase, options),
+      timeoutMs: options.timeoutMs ?? DEFAULT_OPENCODE_TIMEOUT_MS,
+      cwd: options.cwd ?? context.rootDir,
+      env: options.env ?? process.env,
+      model: options.model,
+    });
+    const durationMs = Date.now() - startedAt;
+
+    if (result.status === 'completed') {
+      return {
+        ok: true,
+        status: 'completed',
+        content: result.text,
+        toolCalls: [],
+        ...(options.model ? { model: options.model } : {}),
+        notes: `Ran OpenCode one-shot eval in ${durationMs}ms.`,
+      } satisfies HumanEvalActual;
+    }
+
+    if (result.error.startsWith('Failed to spawn')) {
+      throw createSkippedEvalError(result.error);
+    }
+
+    return {
+      ok: false,
+      status: 'failed',
+      content: [result.error, result.stderr].filter(Boolean).join('\n'),
+      toolCalls: [],
+      ...(options.model ? { model: options.model } : {}),
+      notes: `OpenCode one-shot eval failed in ${durationMs}ms.`,
+    } satisfies HumanEvalActual;
+  };
+}
+
+export function createAgentRelayHumanEvalExecutor(
+  options: AgentRelayHumanEvalExecutorOptions = {},
+): HumanEvalExecutor {
+  const requireProviderMode = options.requireProviderMode ?? true;
+
+  return async (testCase, context) => {
+    if (requireProviderMode && !context.providerMode) {
+      throw createSkippedEvalError('agent-relay executor skipped; rerun with --provider or HUMAN_EVAL_PROVIDER=1');
+    }
+
+    const adapter = await resolveAgentRelayAdapter(options, context.rootDir);
+    const result = await adapter.execute(buildAgentRelayEvalRequest(testCase, options));
+    return executionResultToHumanEvalActual(result);
+  };
+}
+
+export function buildHumanEvalOneShotPrompt(
+  testCase: HumanEvalCase,
+  options: HumanEvalPromptOptions = {},
+): string {
+  const productName = options.productName ?? 'the product';
+  const sections = [
+    `You are evaluating ${productName} behavior by answering as the product assistant.`,
+    'Answer the user request directly. Do not mention the eval harness or hidden rubric.',
+  ];
+  const instructions = Array.isArray(options.instructions)
+    ? options.instructions.join(' ')
+    : options.instructions;
+  const systemPrompt = readSystemPrompt(testCase, options);
+  const threadHistory = Array.isArray(testCase.input.threadHistory)
+    ? testCase.input.threadHistory
+    : undefined;
+
+  if (instructions) {
+    sections.push(instructions);
+  }
+  if (systemPrompt) {
+    sections.push(`System context:\n${systemPrompt}`);
+  }
+  if (threadHistory && threadHistory.length > 0) {
+    sections.push(`Thread history:\n${JSON.stringify(threadHistory, null, 2)}`);
+  }
+  sections.push(`User request:\n${String(testCase.input.message ?? '').trim()}`);
+  return sections.join('\n\n');
+}
+
+function buildAgentRelayEvalRequest(
+  testCase: HumanEvalCase,
+  options: AgentRelayHumanEvalExecutorOptions,
+): HumanEvalExecutionRequest {
+  const threadId = readInputString(testCase, 'threadId') ?? testCase.id;
+  const prompt = buildHumanEvalOneShotPrompt(testCase, options);
+  return {
+    assistantId: options.productName ?? 'human-eval',
+    turnId: `eval-${testCase.id}`,
+    threadId,
+    userId: readInputString(testCase, 'userId') ?? 'eval-user',
+    message: {
+      id: testCase.id,
+      text: String(testCase.input.message ?? ''),
+      receivedAt: new Date().toISOString(),
+    },
+    instructions: {
+      systemPrompt: prompt,
+    },
+    context: {
+      blocks: [],
+      structured: {
+        evalCaseId: testCase.id,
+        suite: testCase.suite,
+        tags: testCase.tags ?? [],
+      },
+    },
+    requirements: {
+      toolUse: 'allowed',
+      structuredToolCalls: 'preferred',
+      traceDepth: 'standard',
+    },
+    metadata: {
+      source: 'agent-assistant-human-eval',
+      executor: 'agent-relay',
+    },
+  };
+}
+
+async function resolveAgentRelayAdapter(
+  options: AgentRelayHumanEvalExecutorOptions,
+  rootDir: string,
+): Promise<HumanEvalExecutionAdapter> {
+  if (options.adapter) return options.adapter;
+  if (options.adapterFactory) return options.adapterFactory();
+
+  const { createAgentRelayExecutionAdapter } = await import('@agent-assistant/harness/agent-relay');
+  return createAgentRelayExecutionAdapter({
+    channelId: options.channelId ?? 'agent-assistant-evals',
+    workerName: options.workerName,
+    orchestratorName: options.orchestratorName ?? 'agent-assistant-eval',
+    workspaceId: options.workspaceId,
+    timeoutMs: options.timeoutMs ?? DEFAULT_AGENT_RELAY_TIMEOUT_MS,
+    cwd: options.cwd ?? rootDir,
+    env: options.env,
+    binaryPath: options.binaryPath,
+    spawnWorker: options.spawnWorker,
+    shutdownAfterExecute: true,
+  }) as HumanEvalExecutionAdapter;
+}
+
+function executionResultToHumanEvalActual(result: HumanEvalExecutionResult): HumanEvalActual {
+  const content = result.output?.text ?? result.error?.message ?? '';
+  const structured = result.output?.structured ?? {};
+  return {
+    ok: result.status === 'completed',
+    status: result.status,
+    content,
+    toolCalls: readToolCalls(structured),
+    notes: result.error?.message
+      ? `Agent Relay eval returned ${result.error.code ?? 'error'}: ${result.error.message}`
+      : `Agent Relay eval completed via ${result.backendId ?? 'unknown backend'}.`,
+    relay: result.metadata?.relay,
+    trace: result.trace,
+  };
+}
+
+function readToolCalls(structured: Record<string, unknown>): HumanEvalActual['toolCalls'] {
+  const raw = structured.toolCalls ?? structured.tool_calls;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((call): call is Record<string, unknown> => call !== null && typeof call === 'object')
+    .map((call) => ({ ...call, name: String(call.name ?? '') }));
+}
+
+function readSystemPrompt(testCase: HumanEvalCase, options: HumanEvalPromptOptions): string | undefined {
+  if (typeof options.systemPrompt === 'function') {
+    return options.systemPrompt(testCase);
+  }
+  if (typeof options.systemPrompt === 'string' && options.systemPrompt.trim().length > 0) {
+    return options.systemPrompt.trim();
+  }
+  return readInputString(testCase, 'systemPrompt');
+}
+
+function readInputString(testCase: HumanEvalCase, key: string): string | undefined {
+  const value = testCase.input[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/packages/telemetry/src/evals/provider-executors.ts
+++ b/packages/telemetry/src/evals/provider-executors.ts
@@ -137,7 +137,7 @@ export function createOpenCodeHumanEvalExecutor(
       throw createSkippedEvalError(result.error);
     }
 
-    return {
+    const actual = {
       ok: false,
       status: 'failed',
       content: [result.error, result.stderr].filter(Boolean).join('\n'),
@@ -145,6 +145,7 @@ export function createOpenCodeHumanEvalExecutor(
       ...(options.model ? { model: options.model } : {}),
       notes: `OpenCode one-shot eval failed in ${durationMs}ms.`,
     } satisfies HumanEvalActual;
+    throw new Error(formatFailedActual('OpenCode one-shot eval failed', actual));
   };
 }
 
@@ -160,7 +161,11 @@ export function createAgentRelayHumanEvalExecutor(
 
     const adapter = await resolveAgentRelayAdapter(options, context.rootDir);
     const result = await adapter.execute(buildAgentRelayEvalRequest(testCase, options));
-    return executionResultToHumanEvalActual(result);
+    const actual = executionResultToHumanEvalActual(result);
+    if (actual.status !== 'completed') {
+      throw new Error(formatFailedActual('Agent Relay eval failed', actual));
+    }
+    return actual;
   };
 }
 
@@ -258,17 +263,34 @@ async function resolveAgentRelayAdapter(
 function executionResultToHumanEvalActual(result: HumanEvalExecutionResult): HumanEvalActual {
   const content = result.output?.text ?? result.error?.message ?? '';
   const structured = result.output?.structured ?? {};
+  const status = result.status ?? 'unknown';
+  const backend = result.backendId ?? 'unknown backend';
   return {
-    ok: result.status === 'completed',
-    status: result.status,
+    ok: status === 'completed',
+    status,
     content,
     toolCalls: readToolCalls(structured),
-    notes: result.error?.message
-      ? `Agent Relay eval returned ${result.error.code ?? 'error'}: ${result.error.message}`
-      : `Agent Relay eval completed via ${result.backendId ?? 'unknown backend'}.`,
+    notes: formatAgentRelayNotes({ ...result, status }, backend),
     relay: result.metadata?.relay,
     trace: result.trace,
   };
+}
+
+function formatAgentRelayNotes(result: HumanEvalExecutionResult, backend: string): string {
+  const status = result.status ?? 'unknown';
+  if (status === 'completed') {
+    return `Agent Relay eval completed via ${backend}.`;
+  }
+  const code = result.error?.code ? `: ${result.error.code}` : '';
+  const message = result.error?.message ? ` - ${result.error.message}` : '';
+  return `Agent Relay eval ${status}${code}${message} via ${backend}.`;
+}
+
+function formatFailedActual(prefix: string, actual: HumanEvalActual): string {
+  const details = [actual.status, actual.notes, actual.content]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' | ');
+  return details ? `${prefix}: ${details}` : prefix;
 }
 
 function readToolCalls(structured: Record<string, unknown>): HumanEvalActual['toolCalls'] {

--- a/packages/telemetry/test/human-runner-cli.test.ts
+++ b/packages/telemetry/test/human-runner-cli.test.ts
@@ -100,9 +100,12 @@ describe('runHumanEvalCli', () => {
 
     expect(exitCode).toBe(0);
     const runsDir = path.join(rootDir, '.evals', 'runs');
-    const result = readFileSync(path.join(runsDir, readdirSingle(runsDir), 'result.json'), 'utf8');
-    expect(result).toContain('"executor": "provider"');
-    expect(result).toContain('provider answer');
+    const resultRaw = readFileSync(path.join(runsDir, readdirSingle(runsDir), 'result.json'), 'utf8');
+    const result = JSON.parse(resultRaw) as {
+      tests?: Array<{ executor?: string; actual?: { content?: string } }>;
+    };
+    expect(result.tests?.[0]?.executor).toBe('provider');
+    expect(result.tests?.[0]?.actual?.content).toContain('provider answer');
   });
 
   it('rejects manual candidate output paths outside the eval root', () => {

--- a/packages/telemetry/test/human-runner-cli.test.ts
+++ b/packages/telemetry/test/human-runner-cli.test.ts
@@ -72,6 +72,39 @@ describe('runHumanEvalCli', () => {
     expect(result).toContain('"checks": []');
   });
 
+  it('can override selected cases to a provider executor', async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'aa-human-evals-executor-'));
+    const suiteDir = path.join(rootDir, 'evals', 'suites', 'smoke');
+    mkdirSync(suiteDir, { recursive: true });
+    writeFileSync(path.join(suiteDir, 'cases.jsonl'), `${JSON.stringify({
+      id: 'smoke.manual-provider',
+      suite: 'smoke',
+      executor: 'manual',
+      input: { message: 'hello' },
+      expected: {
+        contentIncludes: ['provider answer'],
+        humanReviewRequired: true,
+      },
+    })}\n`);
+
+    const exitCode = await runHumanEvalCli({
+      argv: ['--provider', '--executor', 'provider'],
+      rootDir,
+      runsDir: path.join(rootDir, '.evals', 'runs'),
+      executors: {
+        provider() {
+          return { content: 'provider answer', toolCalls: [] };
+        },
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    const runsDir = path.join(rootDir, '.evals', 'runs');
+    const result = readFileSync(path.join(runsDir, readdirSingle(runsDir), 'result.json'), 'utf8');
+    expect(result).toContain('"executor": "provider"');
+    expect(result).toContain('provider answer');
+  });
+
   it('rejects manual candidate output paths outside the eval root', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'aa-human-evals-path-'));
     const executors = createDefaultHumanEvalExecutors(rootDir);

--- a/packages/telemetry/test/provider-executors.test.ts
+++ b/packages/telemetry/test/provider-executors.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHumanEvalOneShotPrompt,
+  createAgentRelayHumanEvalExecutor,
+  createOpenCodeHumanEvalExecutor,
+} from '../src/evals/provider-executors.js';
+import type { CliRunner } from '@agent-assistant/harness/worker-bridge';
+
+describe('provider eval executors', () => {
+  it('builds a one-shot prompt without exposing the human rubric', () => {
+    const prompt = buildHumanEvalOneShotPrompt({
+      id: 'smoke.case',
+      suite: 'smoke',
+      input: {
+        message: 'Generate the thing.',
+        systemPrompt: 'Use product conventions.',
+        threadHistory: [{ role: 'user', content: 'prior' }],
+      },
+      expected: {
+        must: ['Secret criterion'],
+        mustNot: ['Secret anti-criterion'],
+      },
+    }, {
+      productName: 'Ricky',
+      instructions: ['Prefer concrete evidence.'],
+    });
+
+    expect(prompt).toContain('Ricky');
+    expect(prompt).toContain('Use product conventions.');
+    expect(prompt).toContain('Generate the thing.');
+    expect(prompt).toContain('Prefer concrete evidence.');
+    expect(prompt).not.toContain('Secret criterion');
+    expect(prompt).not.toContain('Secret anti-criterion');
+  });
+
+  it('runs OpenCode-compatible CLI runners and normalizes output', async () => {
+    let capturedModel: string | undefined;
+    const runner: CliRunner = {
+      id: 'opencode',
+      async run(input) {
+        capturedModel = input.model;
+        return { status: 'completed', text: `answered: ${input.prompt}` };
+      },
+    };
+    const executor = createOpenCodeHumanEvalExecutor({
+      productName: 'Ricky',
+      model: 'opencode/minimax-m2.5-free',
+      runner,
+    });
+
+    const actual = await executor({
+      id: 'smoke.opencode',
+      suite: 'smoke',
+      input: { message: 'hello' },
+      expected: {},
+    }, {
+      providerMode: true,
+      rootDir: '/tmp/project',
+    });
+
+    expect(capturedModel).toBe('opencode/minimax-m2.5-free');
+    expect(actual).toMatchObject({
+      ok: true,
+      status: 'completed',
+      model: 'opencode/minimax-m2.5-free',
+      toolCalls: [],
+    });
+    expect(String((actual as { content?: unknown }).content)).toContain('hello');
+  });
+
+  it('uses an Agent Relay execution adapter for complex provider evals', async () => {
+    const executor = createAgentRelayHumanEvalExecutor({
+      productName: 'Ricky',
+      adapter: {
+        async execute(request) {
+          expect(request.requirements?.toolUse).toBe('allowed');
+          expect(request.instructions.systemPrompt).toContain('Use the broker.');
+          return {
+            backendId: 'agent-relay',
+            status: 'completed',
+            output: {
+              text: 'relay answer',
+              structured: {
+                toolCalls: [{ name: 'workspace.read' }],
+              },
+            },
+            metadata: {
+              relay: {
+                channelId: 'evals',
+              },
+            },
+          };
+        },
+      },
+    });
+
+    const actual = await executor({
+      id: 'smoke.relay',
+      suite: 'smoke',
+      input: { message: 'Use the broker.' },
+      expected: {},
+    }, {
+      providerMode: true,
+      rootDir: '/tmp/project',
+    });
+
+    expect(actual).toMatchObject({
+      ok: true,
+      status: 'completed',
+      content: 'relay answer',
+      toolCalls: [{ name: 'workspace.read' }],
+      relay: { channelId: 'evals' },
+    });
+  });
+});

--- a/packages/telemetry/test/provider-executors.test.ts
+++ b/packages/telemetry/test/provider-executors.test.ts
@@ -68,6 +68,30 @@ describe('provider eval executors', () => {
     expect(String((actual as { content?: unknown }).content)).toContain('hello');
   });
 
+  it('fails OpenCode provider evals when the backend fails', async () => {
+    const runner: CliRunner = {
+      id: 'opencode',
+      async run() {
+        return {
+          status: 'failed',
+          error: "CLI 'opencode' timed out after 100ms",
+          stderr: 'still thinking',
+        };
+      },
+    };
+    const executor = createOpenCodeHumanEvalExecutor({ runner });
+
+    await expect(executor({
+      id: 'smoke.opencode-failed',
+      suite: 'smoke',
+      input: { message: 'hello' },
+      expected: { humanReviewRequired: true },
+    }, {
+      providerMode: true,
+      rootDir: '/tmp/project',
+    })).rejects.toThrow("CLI 'opencode' timed out");
+  });
+
   it('uses an Agent Relay execution adapter for complex provider evals', async () => {
     const executor = createAgentRelayHumanEvalExecutor({
       productName: 'Ricky',
@@ -111,5 +135,32 @@ describe('provider eval executors', () => {
       toolCalls: [{ name: 'workspace.read' }],
       relay: { channelId: 'evals' },
     });
+  });
+
+  it('fails Agent Relay provider evals when the adapter does not complete', async () => {
+    const executor = createAgentRelayHumanEvalExecutor({
+      adapter: {
+        async execute() {
+          return {
+            backendId: 'agent-relay',
+            status: 'failed',
+            error: {
+              code: 'timeout',
+              message: 'Timed out waiting for Relay execution result.',
+            },
+          };
+        },
+      },
+    });
+
+    await expect(executor({
+      id: 'smoke.relay-failed',
+      suite: 'smoke',
+      input: { message: 'Use the broker.' },
+      expected: { humanReviewRequired: true },
+    }, {
+      providerMode: true,
+      rootDir: '/tmp/project',
+    })).rejects.toThrow(/Agent Relay eval failed: failed.*timeout/s);
   });
 });


### PR DESCRIPTION
## Summary
- add `--executor` override to the shared human eval CLI so manual cases can be run through a provider without editing each case
- add reusable OpenCode one-shot and Agent Relay human-eval executors under `@agent-assistant/telemetry/evals`
- document when to use direct OpenCode vs Agent Relay for complex broker/tool/topology evals

## Validation
- npm run test -w @agent-assistant/telemetry -- human-runner-cli provider-executors
- npm run build -w @agent-assistant/telemetry
