### PR TITLE
feat(proactive-runtime): M1 interop helper + M4 session adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A focused, open-source SDK for building production-grade AI assistants from expl
 - **Sessions** — Cross-surface session continuity, resume rules, and storage abstractions (`@agent-assistant/sessions`)
 - **Surfaces** — Assistant-facing inbound/outbound surface contracts above raw transport (`@agent-assistant/surfaces`)
 - **Policy** — Action classification, approvals, and audit hooks (`@agent-assistant/policy`)
-- **Proactive behavior** — Follow-up engines, watch rules, and scheduler bindings for outbound assistant actions (`@agent-assistant/proactive`). For hosted proactive runtime integration, see [Proactive runtime interop](docs/proactive-runtime-interop.md).
+- **Proactive behavior** — Follow-up engines, watch rules, and scheduler bindings for outbound assistant actions (`@agent-assistant/proactive`). For hosted proactive runtime integration, including the `onEvent` + `fromContext(ctx)` recipe, see [Proactive runtime interop](docs/proactive-runtime-interop.md).
 - **Routing / execution envelope selection** — Model-choice and latency/depth/cost routing policy (`@agent-assistant/routing`)
 - **Connectivity and coordination** — Inter-agent signaling plus coordinator/specialist orchestration (`@agent-assistant/connectivity`, `@agent-assistant/coordination`)
 - **Virtual filesystem navigation** — Provider-neutral contracts and Bash-friendly navigation helpers for assistant-readable VFS surfaces (`@agent-assistant/vfs`)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A focused, open-source SDK for building production-grade AI assistants from expl
 - **Sessions** — Cross-surface session continuity, resume rules, and storage abstractions (`@agent-assistant/sessions`)
 - **Surfaces** — Assistant-facing inbound/outbound surface contracts above raw transport (`@agent-assistant/surfaces`)
 - **Policy** — Action classification, approvals, and audit hooks (`@agent-assistant/policy`)
-- **Proactive behavior** — Follow-up engines, watch rules, and scheduler bindings for outbound assistant actions (`@agent-assistant/proactive`)
+- **Proactive behavior** — Follow-up engines, watch rules, and scheduler bindings for outbound assistant actions (`@agent-assistant/proactive`). For hosted proactive runtime integration, see [Proactive runtime interop](docs/proactive-runtime-interop.md).
 - **Routing / execution envelope selection** — Model-choice and latency/depth/cost routing policy (`@agent-assistant/routing`)
 - **Connectivity and coordination** — Inter-agent signaling plus coordinator/specialist orchestration (`@agent-assistant/connectivity`, `@agent-assistant/coordination`)
 - **Virtual filesystem navigation** — Provider-neutral contracts and Bash-friendly navigation helpers for assistant-readable VFS surfaces (`@agent-assistant/vfs`)
@@ -142,6 +142,8 @@ The repo is no longer primarily blocked on package implementation. The main rema
 
 The underlying messaging and runtime infrastructure (transport adapters, webhook verification, normalized transport primitives, channel/session substrate, auth/connection wiring, scheduler/wake infrastructure) lives in the Relay foundation repos.
 
+Hosted proactive runtimes sit in that foundation layer. Use [Proactive runtime interop](docs/proactive-runtime-interop.md) when you need the split between durable cross-process triggers and the in-process `@agent-assistant/proactive` logic that runs after a wake-up.
+
 ## Product Logic (product repos)
 
 Product-specific concerns stay in each product's own repository:
@@ -158,6 +160,7 @@ Product-specific concerns stay in each product's own repository:
 
 - [Docs index](docs/index.md)
 - [Current state](docs/current-state.md)
+- [Proactive runtime interop](docs/proactive-runtime-interop.md)
 - [How to build an assistant](docs/consumer/how-to-build-an-assistant.md)
 - [How products should adopt this SDK](docs/consumer/how-products-should-adopt-agent-assistant-sdk.md)
 - [Connectivity adoption guide](docs/consumer/connectivity-adoption-guide.md)

--- a/docs/proactive-runtime-interop.md
+++ b/docs/proactive-runtime-interop.md
@@ -1,22 +1,29 @@
 # Proactive Runtime Interop
 
-This note explains how the OSS `@agent-assistant/*` packages fit with a hosted proactive runtime.
+This note explains the split between the OSS `@agent-assistant/*` packages and a hosted proactive runtime, and shows the recommended recipe for using them together.
 
 ## The Split
 
-`@agent-assistant/proactive` stays in-process and single-agent. It owns follow-up engines, watch rule evaluation, and the thin `SchedulerBinding` seam that lets a caller request wake-ups from inside one handler. It does not own durable triggers, cross-process orchestration, product routing, or any hosted control plane.
+`@agent-assistant/proactive` is the in-process layer. It stays inside one handler invocation and one assistant. It owns follow-up engines, watch-rule evaluation, and scheduler bindings that request another wake-up from inside the handler.
 
-The proactive runtime is the cloud layer above that package. It is the durable, cross-process, multi-trigger surface that receives trigger events, persists wake-ups, and invokes your agent handler when something meaningful happens. In short: the runtime gives you the trigger; `@agent-assistant` gives you the stateful assistant logic you run when that trigger fires.
+The proactive runtime is the durable cloud layer. It owns cross-process triggers, multi-trigger fan-in, durable delivery, retry, and the hosted control plane that decides when your handler should wake up.
+
+The shorthand is:
+
+- `@agent-assistant/proactive` = in-process follow-up engines, watch rules, and scheduler bindings
+- proactive runtime = cross-process, multi-trigger, durable trigger surface
+
+Use `@agent-assistant` inside `onEvent`. The runtime gives you the trigger. `@agent-assistant` gives you the stateful conversation and follow-up logic that runs after the wake-up.
 
 ## What Belongs Where
 
 Use `@agent-assistant/proactive` for:
 
 - follow-up engines
-- watch rule evaluation
-- scheduler adapter contracts
-- assistant-session-aware logic that runs inside one handler invocation
-- stateful conversation and follow-up logic once the agent is awake
+- watch-rule evaluation
+- scheduler binding contracts
+- assistant-session-aware logic inside one handler
+- stateful conversation and follow-up logic after wake-up
 
 Use the proactive runtime for:
 
@@ -24,35 +31,41 @@ Use the proactive runtime for:
 - cross-process wake-ups
 - multi-trigger fan-in
 - hosted scheduling and dispatch
-- long-lived runtime state outside a single handler process
+- long-lived runtime state outside a single process
 
-## Recommended Integration Pattern
+## Recipe: Use Agent Assistant Inside `onEvent`
 
-Inside the `onEvent` handler, treat the runtime event as the reason to wake the assistant, not as a replacement for assistant state. Build or recover an assistant session, then run the normal `@agent-assistant` logic against that session.
-
-The small helper in `@agent-assistant/proactive` exists for exactly this bridge:
+Treat the runtime event as the reason to wake the assistant, not as a replacement for assistant state. Inside `onEvent`, recover or create an `@agent-assistant/sessions` session, then run the normal proactive engine or follow-up logic against that session.
 
 ```ts
 import { agent } from '@agent-relay/agent';
 import {
+  ContextSchedulerBinding,
   createProactiveEngine,
   fromContext,
-  InMemorySchedulerBinding,
 } from '@agent-assistant/proactive';
-import { createSessionStore, InMemorySessionStoreAdapter } from '@agent-assistant/sessions';
-
-const sessions = createSessionStore({
-  adapter: new InMemorySessionStoreAdapter(),
-});
-
-const schedulerBinding = new InMemorySchedulerBinding();
-const engine = createProactiveEngine({ schedulerBinding });
+import {
+  createSessionStore,
+  ctxFilesToRuntimeSessionStoreAdapterOptions,
+  RuntimeSessionStoreAdapter,
+} from '@agent-assistant/sessions';
 
 await agent({
   workspace: 'your-workspace',
   schedule: '*/5 * * * *',
   onEvent: async (ctx, event) => {
+    const sessions = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter(
+        ctxFilesToRuntimeSessionStoreAdapterOptions(ctx.files, {
+          signal: ctx.signal,
+        }),
+      ),
+    });
+    const engine = createProactiveEngine({
+      schedulerBinding: new ContextSchedulerBinding(ctx),
+    });
     const aaSession = fromContext(ctx);
+    ctx.signal.throwIfAborted?.();
 
     const session =
       (await sessions.get(aaSession.id)) ??
@@ -67,30 +80,107 @@ await agent({
     const decisions = await engine.evaluateFollowUp({
       sessionId: session.id,
       scheduledAt: new Date().toISOString(),
-      lastActivityAt: session.lastActivityAt,
+      lastActivityAt: session.lastActivityAt ?? session.createdAt ?? new Date().toISOString(),
     });
+    ctx.signal.throwIfAborted?.();
 
     for (const decision of decisions) {
       if (decision.action === 'fire') {
-        // Your runtime owns the actual delivery surface.
-        await deliverFollowUp(decision, session);
+        await ctx.once(`followup:${session.id}:${decision.ruleId}:${event.id}`, async () => {
+          await deliverFollowUp(decision, session, ctx.signal);
+        });
       }
     }
   },
 });
 ```
 
+That keeps responsibilities clean:
+
+- the runtime decides when the handler wakes up
+- `fromContext(ctx)` gives you a stable assistant-session key
+- `@agent-assistant/sessions` preserves continuity across wake-ups
+- `@agent-assistant/proactive` decides what follow-up should happen next
+
+### `deliverFollowUp` Responsibility
+
+`deliverFollowUp(decision, session)` is product-owned. A minimal implementation is:
+
+```ts
+async function deliverFollowUp(
+  decision: FollowUpDecision,
+  session: Session,
+  signal?: AbortSignal,
+) {
+  signal?.throwIfAborted?.();
+  await sendAssistantMessage({
+    sessionId: session.id,
+    text: decision.messageTemplate ?? 'Following up on your request.',
+    metadata: {
+      ruleId: decision.ruleId,
+      routingHint: decision.routingHint,
+    },
+  });
+  signal?.throwIfAborted?.();
+}
+```
+
+The runtime does not provide this helper because the delivery surface differs by product. Some products write back into relaycast, some enqueue a hosted assistant turn, and some persist a task for a later human review queue.
+
+### Durable Session Storage
+
+The recipe uses `RuntimeSessionStoreAdapter` so assistant-session continuity survives cold starts. `ctxFilesToRuntimeSessionStoreAdapterOptions(ctx.files, { signal: ctx.signal })` is the shared bridge helper for that wiring, which avoids re-implementing the same `read/write/list/delete` adapter glue in every hosted runtime. `InMemorySessionStoreAdapter` is still useful for tests and single-process demos, but production proactive-runtime handlers should back `@agent-assistant/sessions` with `ctx.files` or another durable store.
+
 ## Why `fromContext` Exists
 
-Runtime contexts usually carry a workspace identifier and an agent identifier, but not an `@agent-assistant/sessions` input shape. `fromContext(ctx)` turns that runtime context into a stable assistant-session descriptor keyed on `(workspace, agentId)`. It scopes the session `id`, `userId`, and `surfaceId` to that tuple so the same agent name in two workspaces does not collapse into one affinity bucket. That keeps the session identity consistent across separate runtime wake-ups without forcing every consumer to hand-roll the same mapping.
+Runtime contexts usually contain a workspace identifier and an agent identifier, but not the shape that `@agent-assistant/sessions` wants. `fromContext(ctx)` converts that runtime context into a stable assistant-session descriptor keyed on `(workspace, agentId)` so consumers do not have to hand-roll the mapping.
 
-Use it when the runtime decides *when* to wake the agent, and `@agent-assistant` decides *how* that agent continues the conversation, evaluates follow-up rules, or resumes watch logic.
+The helper returns:
 
-The helper is intentionally structural and cloud-agnostic:
+- `id` for the session id
+- `userId` scoped to the agent tuple
+- `workspaceId`
+- `surfaceId` as a convenience alias for the runtime-facing attachment id
+- `initialSurfaceId` for `sessions.create(...)`, which is the field the session
+  store consumes when attaching the first surface
+- `metadata` with the runtime source and stable session key
+
+That keeps the same agent in two different workspaces from collapsing into one session bucket, and it keeps repeat wake-ups for the same `(workspace, agentId)` pair attached to the same assistant session identity.
+
+## Helper Contract
+
+`fromContext` is intentionally structural and cloud-agnostic:
 
 - it accepts either `ctx.workspaceId` or `ctx.workspace.id`
+- it also accepts the canonical runtime shape `ctx.workspace: string` with `ctx.agentId: string`
 - it accepts either `ctx.agentId` or `ctx.agent.id`
+- it trims blank ids and prefers the first valid value
 - it derives a stable assistant identity from `(workspace, agentId)`
 - it does not import any hosted runtime package
 
-That preserves the OSS rule that cloud layers may depend on `@agent-assistant/*`, but OSS packages do not depend on cloud layers.
+That preserves the OSS boundary: cloud layers may depend on `@agent-assistant/*`, but OSS packages here do not depend on the hosted runtime.
+
+## Identity Semantics
+
+When the hosted runtime only exposes `ctx.workspace` as a human-readable
+workspace name, `fromContext(ctx)` uses that value as the stable
+`workspaceId`. That keeps the helper structural and runtime-agnostic, but it
+means renaming a workspace changes the derived session id and therefore starts
+a fresh assistant session. Hosted runtimes that need rename-stable continuity
+should pass a durable `ctx.workspaceId` instead of only `ctx.workspace`.
+
+## Delivery Guarantees
+
+The hosted runtime delivers wake-up events with at-least-once semantics, so
+`evaluateFollowUp()` and the follow-up side effects around it must be safe under
+redelivery. The recommended pattern is:
+
+- use `ctx.once(...)` or an equivalent runtime idempotency primitive around the
+  outward side effect
+- key that idempotency scope with the assistant session id, the follow-up rule
+  id, and the runtime event id
+- treat repeated `evaluateFollowUp()` calls as expected after retry or reconnect
+
+The recipe above follows that pattern with
+`followup:${session.id}:${decision.ruleId}:${event.id}` so the engine may be
+re-run while the externally visible follow-up is still deduplicated.

--- a/docs/proactive-runtime-interop.md
+++ b/docs/proactive-runtime-interop.md
@@ -4,9 +4,9 @@ This note explains how the OSS `@agent-assistant/*` packages fit with a hosted p
 
 ## The Split
 
-`@agent-assistant/proactive` stays in-process and single-agent. It owns follow-up rule evaluation, watch rules, and the thin `SchedulerBinding` seam that lets a caller request wake-ups. It does not own durable triggers, cross-process orchestration, product routing, or any hosted control plane.
+`@agent-assistant/proactive` stays in-process and single-agent. It owns follow-up engines, watch rule evaluation, and the thin `SchedulerBinding` seam that lets a caller request wake-ups from inside one handler. It does not own durable triggers, cross-process orchestration, product routing, or any hosted control plane.
 
-The proactive runtime is the cloud layer above that package. It is the durable, cross-process surface that receives multiple trigger types, persists wake-ups, and invokes your agent handler when something meaningful happens. In short: the runtime gives you the trigger; `@agent-assistant` gives you the stateful assistant logic you run when that trigger fires.
+The proactive runtime is the cloud layer above that package. It is the durable, cross-process, multi-trigger surface that receives trigger events, persists wake-ups, and invokes your agent handler when something meaningful happens. In short: the runtime gives you the trigger; `@agent-assistant` gives you the stateful assistant logic you run when that trigger fires.
 
 ## What Belongs Where
 
@@ -16,6 +16,7 @@ Use `@agent-assistant/proactive` for:
 - watch rule evaluation
 - scheduler adapter contracts
 - assistant-session-aware logic that runs inside one handler invocation
+- stateful conversation and follow-up logic once the agent is awake
 
 Use the proactive runtime for:
 
@@ -27,51 +28,63 @@ Use the proactive runtime for:
 
 ## Recommended Integration Pattern
 
-Inside `ctx.onEvent`, treat the runtime event as the reason to wake the assistant, not as a replacement for assistant state. Build or recover an assistant session, then run the normal `@agent-assistant` logic against that session.
+Inside the `onEvent` handler, treat the runtime event as the reason to wake the assistant, not as a replacement for assistant state. Build or recover an assistant session, then run the normal `@agent-assistant` logic against that session.
 
 The small helper in `@agent-assistant/proactive` exists for exactly this bridge:
 
 ```ts
-import { createProactiveEngine, fromContext } from '@agent-assistant/proactive';
+import { agent } from '@agent-relay/agent';
+import {
+  createProactiveEngine,
+  fromContext,
+  InMemorySchedulerBinding,
+} from '@agent-assistant/proactive';
 import { createSessionStore, InMemorySessionStoreAdapter } from '@agent-assistant/sessions';
 
 const sessions = createSessionStore({
   adapter: new InMemorySessionStoreAdapter(),
 });
 
+const schedulerBinding = new InMemorySchedulerBinding();
 const engine = createProactiveEngine({ schedulerBinding });
 
-ctx.onEvent(async (eventCtx) => {
-  const aaSession = fromContext(eventCtx);
+await agent({
+  workspace: 'your-workspace',
+  schedule: '*/5 * * * *',
+  onEvent: async (ctx, event) => {
+    const aaSession = fromContext(ctx);
 
-  const session =
-    (await sessions.get(aaSession.id)) ??
-    (await sessions.create({
-      id: aaSession.id,
-      userId: aaSession.userId,
-      workspaceId: aaSession.workspaceId,
-      initialSurfaceId: aaSession.initialSurfaceId,
-      metadata: aaSession.metadata,
-    }));
+    const session =
+      (await sessions.get(aaSession.id)) ??
+      (await sessions.create({
+        id: aaSession.id,
+        userId: aaSession.userId,
+        workspaceId: aaSession.workspaceId,
+        initialSurfaceId: aaSession.initialSurfaceId,
+        metadata: aaSession.metadata,
+      }));
 
-  const decisions = await engine.evaluateFollowUp({
-    sessionId: session.id,
-    scheduledAt: new Date().toISOString(),
-    lastActivityAt: session.lastActivityAt,
-  });
+    const decisions = await engine.evaluateFollowUp({
+      sessionId: session.id,
+      scheduledAt: new Date().toISOString(),
+      lastActivityAt: session.lastActivityAt,
+    });
 
-  for (const decision of decisions) {
-    if (decision.action === 'fire') {
-      // Your runtime owns the actual delivery surface.
-      await deliverFollowUp(decision, session);
+    for (const decision of decisions) {
+      if (decision.action === 'fire') {
+        // Your runtime owns the actual delivery surface.
+        await deliverFollowUp(decision, session);
+      }
     }
-  }
+  },
 });
 ```
 
 ## Why `fromContext` Exists
 
 Runtime contexts usually carry a workspace identifier and an agent identifier, but not an `@agent-assistant/sessions` input shape. `fromContext(ctx)` turns that runtime context into a stable assistant-session descriptor keyed on `(workspace, agentId)`. It scopes the session `id`, `userId`, and `surfaceId` to that tuple so the same agent name in two workspaces does not collapse into one affinity bucket. That keeps the session identity consistent across separate runtime wake-ups without forcing every consumer to hand-roll the same mapping.
+
+Use it when the runtime decides *when* to wake the agent, and `@agent-assistant` decides *how* that agent continues the conversation, evaluates follow-up rules, or resumes watch logic.
 
 The helper is intentionally structural and cloud-agnostic:
 

--- a/docs/proactive-runtime-interop.md
+++ b/docs/proactive-runtime-interop.md
@@ -1,0 +1,83 @@
+# Proactive Runtime Interop
+
+This note explains how the OSS `@agent-assistant/*` packages fit with a hosted proactive runtime.
+
+## The Split
+
+`@agent-assistant/proactive` stays in-process and single-agent. It owns follow-up rule evaluation, watch rules, and the thin `SchedulerBinding` seam that lets a caller request wake-ups. It does not own durable triggers, cross-process orchestration, product routing, or any hosted control plane.
+
+The proactive runtime is the cloud layer above that package. It is the durable, cross-process surface that receives multiple trigger types, persists wake-ups, and invokes your agent handler when something meaningful happens. In short: the runtime gives you the trigger; `@agent-assistant` gives you the stateful assistant logic you run when that trigger fires.
+
+## What Belongs Where
+
+Use `@agent-assistant/proactive` for:
+
+- follow-up engines
+- watch rule evaluation
+- scheduler adapter contracts
+- assistant-session-aware logic that runs inside one handler invocation
+
+Use the proactive runtime for:
+
+- durable trigger delivery
+- cross-process wake-ups
+- multi-trigger fan-in
+- hosted scheduling and dispatch
+- long-lived runtime state outside a single handler process
+
+## Recommended Integration Pattern
+
+Inside `ctx.onEvent`, treat the runtime event as the reason to wake the assistant, not as a replacement for assistant state. Build or recover an assistant session, then run the normal `@agent-assistant` logic against that session.
+
+The small helper in `@agent-assistant/proactive` exists for exactly this bridge:
+
+```ts
+import { createProactiveEngine, fromContext } from '@agent-assistant/proactive';
+import { createSessionStore, InMemorySessionStoreAdapter } from '@agent-assistant/sessions';
+
+const sessions = createSessionStore({
+  adapter: new InMemorySessionStoreAdapter(),
+});
+
+const engine = createProactiveEngine({ schedulerBinding });
+
+ctx.onEvent(async (eventCtx) => {
+  const aaSession = fromContext(eventCtx);
+
+  const session =
+    (await sessions.get(aaSession.id)) ??
+    (await sessions.create({
+      id: aaSession.id,
+      userId: aaSession.userId,
+      workspaceId: aaSession.workspaceId,
+      initialSurfaceId: aaSession.initialSurfaceId,
+      metadata: aaSession.metadata,
+    }));
+
+  const decisions = await engine.evaluateFollowUp({
+    sessionId: session.id,
+    scheduledAt: new Date().toISOString(),
+    lastActivityAt: session.lastActivityAt,
+  });
+
+  for (const decision of decisions) {
+    if (decision.action === 'fire') {
+      // Your runtime owns the actual delivery surface.
+      await deliverFollowUp(decision, session);
+    }
+  }
+});
+```
+
+## Why `fromContext` Exists
+
+Runtime contexts usually carry a workspace identifier and an agent identifier, but not an `@agent-assistant/sessions` input shape. `fromContext(ctx)` turns that runtime context into a stable assistant-session descriptor keyed on `(workspace, agentId)`. It scopes the session `id`, `userId`, and `surfaceId` to that tuple so the same agent name in two workspaces does not collapse into one affinity bucket. That keeps the session identity consistent across separate runtime wake-ups without forcing every consumer to hand-roll the same mapping.
+
+The helper is intentionally structural and cloud-agnostic:
+
+- it accepts either `ctx.workspaceId` or `ctx.workspace.id`
+- it accepts either `ctx.agentId` or `ctx.agent.id`
+- it derives a stable assistant identity from `(workspace, agentId)`
+- it does not import any hosted runtime package
+
+That preserves the OSS rule that cloud layers may depend on `@agent-assistant/*`, but OSS packages do not depend on cloud layers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,7 +413,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3664,7 +3664,7 @@
     },
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",
@@ -3747,7 +3747,7 @@
     },
     "packages/connectivity": {
       "name": "@agent-assistant/connectivity",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.1.6"
@@ -3759,7 +3759,7 @@
     },
     "packages/continuation": {
       "name": "@agent-assistant/continuation",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -4026,7 +4026,7 @@
     },
     "packages/coordination": {
       "name": "@agent-assistant/coordination",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
@@ -4049,7 +4049,7 @@
     },
     "packages/core": {
       "name": "@agent-assistant/core",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "devDependencies": {
         "@agent-assistant/traits": "file:../traits",
         "typescript": "^5.9.3",
@@ -4082,7 +4082,7 @@
     },
     "packages/harness": {
       "name": "@agent-assistant/harness",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "dependencies": {
         "@agent-assistant/connectivity": "^0.2.6",
         "@agent-assistant/coordination": "^0.2.6",
@@ -4250,7 +4250,7 @@
     },
     "packages/inbox": {
       "name": "@agent-assistant/inbox",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/turn-context": ">=0.1.0"
@@ -5038,7 +5038,7 @@
     },
     "packages/memory": {
       "name": "@agent-assistant/memory",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "@agent-relay/memory": "^6.0.9",
@@ -5051,7 +5051,7 @@
     },
     "packages/policy": {
       "name": "@agent-assistant/policy",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^5.0.0"
@@ -5063,7 +5063,7 @@
     },
     "packages/proactive": {
       "name": "@agent-assistant/proactive",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/coordination": "^0.4.25",
@@ -5086,7 +5086,7 @@
     },
     "packages/sdk": {
       "name": "@agent-assistant/sdk",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/core": ">=0.1.0",
@@ -5103,7 +5103,7 @@
     },
     "packages/sessions": {
       "name": "@agent-assistant/sessions",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5111,7 +5111,7 @@
     },
     "packages/specialists": {
       "name": "@agent-assistant/specialists",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "dependencies": {
         "@agent-assistant/coordination": "^0.2.6",
         "@agent-assistant/vfs": "^0.2.6",
@@ -5150,7 +5150,7 @@
     },
     "packages/surfaces": {
       "name": "@agent-assistant/surfaces",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "devDependencies": {
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -5158,7 +5158,7 @@
     },
     "packages/telemetry": {
       "name": "@agent-assistant/telemetry",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "dependencies": {
         "@agent-assistant/harness": "^0.10.1"
       },
@@ -5431,7 +5431,7 @@
     },
     "packages/traits": {
       "name": "@agent-assistant/traits",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -5440,7 +5440,7 @@
     },
     "packages/turn-context": {
       "name": "@agent-assistant/turn-context",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "dependencies": {
         "@agent-assistant/harness": "^0.4.0 || ^0.6.0",
@@ -5600,7 +5600,7 @@
     },
     "packages/vfs": {
       "name": "@agent-assistant/vfs",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -5627,7 +5627,7 @@
     },
     "packages/webhook-runtime": {
       "name": "@agent-assistant/webhook-runtime",
-      "version": "0.4.28",
+      "version": "0.4.31",
       "dependencies": {
         "@agent-assistant/specialists": "^0.3.5",
         "@agent-assistant/surfaces": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "npm run build --workspaces --if-present",
     "build:sdk": "npm run build -w @agent-assistant/sdk",
     "pretest": "npm run build",
-    "test": "npm run test --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present -- --passWithNoTests",
     "agent": "RELAY_AUTO_SPAWN=false RELAY_CHANNEL=specialists RELAY_WORKER=specialist-worker RELAY_CLI=claude RELAY_MODEL=claude-sonnet-4-6 npm run cli -w @agent-assistant/webhook-runtime",
     "worker": "npm run worker -w @agent-assistant/webhook-runtime --"
   },

--- a/packages/proactive/src/index.ts
+++ b/packages/proactive/src/index.ts
@@ -27,6 +27,11 @@ export {
 } from './types.js';
 
 export { createProactiveEngine, InMemorySchedulerBinding } from './proactive.js';
+export { fromContext } from './runtime-interop.js';
+export type {
+  RuntimeInteropContext,
+  RuntimeInteropSession,
+} from './runtime-interop.js';
 
 // ── Notify-channel resolution ───────────────────────────────────────────────
 // Dynamic channel picking for proactive Slack posts: discover bot-member

--- a/packages/proactive/src/index.ts
+++ b/packages/proactive/src/index.ts
@@ -27,9 +27,14 @@ export {
 } from './types.js';
 
 export { createProactiveEngine, InMemorySchedulerBinding } from './proactive.js';
-export { fromContext } from './runtime-interop.js';
+export {
+  ContextSchedulerBinding,
+  RuntimeSchedulerBinding,
+  fromContext,
+} from './runtime-interop.js';
 export type {
   RuntimeInteropContext,
+  RuntimeScheduleContext,
   RuntimeInteropSession,
 } from './runtime-interop.js';
 

--- a/packages/proactive/src/runtime-interop.test.ts
+++ b/packages/proactive/src/runtime-interop.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { fromContext } from './runtime-interop.js';
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionStore, ctxFilesToRuntimeSessionStoreAdapterOptions, RuntimeSessionStoreAdapter } from '../../sessions/src/index.js';
+import { createProactiveEngine } from './proactive.js';
+import { ContextSchedulerBinding, fromContext } from './runtime-interop.js';
 import { ProactiveError } from './types.js';
 
 describe('fromContext', () => {
@@ -56,6 +58,23 @@ describe('fromContext', () => {
     });
   });
 
+  it('trims ids before deriving the session key', () => {
+    expect(
+      fromContext({
+        workspaceId: '  ws-epsilon  ',
+        agentId: '  sage  ',
+      }),
+    ).toMatchObject({
+      id: 'ws-epsilon:sage',
+      userId: 'agent:ws-epsilon:sage',
+      workspaceId: 'ws-epsilon',
+      metadata: {
+        agentId: 'sage',
+        sessionKey: 'ws-epsilon:sage',
+      },
+    });
+  });
+
   it('throws when workspace identity is missing', () => {
     expect(() =>
       fromContext({
@@ -70,5 +89,161 @@ describe('fromContext', () => {
         workspaceId: 'ws-gamma',
       }),
     ).toThrow(ProactiveError);
+  });
+});
+
+describe('ContextSchedulerBinding', () => {
+  it('uses ctx.scheduler when present', async () => {
+    const requestWakeUp = vi.fn().mockResolvedValue({ bindingId: 'binding-123' });
+    const cancelWakeUp = vi.fn().mockResolvedValue(undefined);
+    const binding = new ContextSchedulerBinding({
+      scheduler: {
+        requestWakeUp,
+        cancelWakeUp,
+      },
+    });
+
+    await expect(
+      binding.requestWakeUp(new Date('2026-05-12T12:00:00.000Z'), {
+        sessionId: 'ws-alpha:sage',
+        scheduledAt: '2026-05-12T12:00:00.000Z',
+      }),
+    ).resolves.toBe('binding-123');
+
+    await binding.cancelWakeUp('binding-123');
+
+    expect(requestWakeUp).toHaveBeenCalledTimes(1);
+    expect(cancelWakeUp).toHaveBeenCalledWith('binding-123');
+  });
+
+  it('falls back to scheduleWakeUp and cancelWakeUp functions', async () => {
+    const scheduleWakeUp = vi.fn().mockResolvedValue('binding-456');
+    const cancelWakeUp = vi.fn().mockResolvedValue(undefined);
+    const binding = new ContextSchedulerBinding({
+      scheduleWakeUp,
+      cancelWakeUp,
+    });
+
+    await expect(
+      binding.requestWakeUp(new Date('2026-05-12T13:00:00.000Z'), {
+        sessionId: 'ws-beta:night-cto',
+        ruleId: 'rule-1',
+        scheduledAt: '2026-05-12T13:00:00.000Z',
+      }),
+    ).resolves.toBe('binding-456');
+
+    await binding.cancelWakeUp('binding-456');
+
+    expect(scheduleWakeUp).toHaveBeenCalledTimes(1);
+    expect(cancelWakeUp).toHaveBeenCalledWith('binding-456');
+  });
+
+  it('throws when scheduling support is unavailable', async () => {
+    const binding = new ContextSchedulerBinding({});
+
+    await expect(
+      binding.requestWakeUp(new Date('2026-05-12T14:00:00.000Z'), {
+        sessionId: 'ws-gamma:sage',
+        scheduledAt: '2026-05-12T14:00:00.000Z',
+      }),
+    ).rejects.toMatchObject({
+      name: 'ProactiveError',
+      code: 'RUNTIME_SCHEDULER_UNAVAILABLE',
+    });
+  });
+
+  it('throws when cancel support is unavailable', async () => {
+    const binding = new ContextSchedulerBinding({
+      scheduleWakeUp: vi.fn().mockResolvedValue('binding-789'),
+    });
+
+    await expect(binding.cancelWakeUp('binding-789')).rejects.toMatchObject({
+      name: 'ProactiveError',
+      code: 'RUNTIME_SCHEDULER_UNAVAILABLE',
+    });
+  });
+});
+
+describe('runtime interop chain', () => {
+  it('bridges fromContext through durable sessions into follow-up scheduling', async () => {
+    const files = new Map<string, string>();
+    const ctx = {
+      workspace: 'support',
+      agentId: 'sage',
+      signal: new AbortController().signal,
+      files: {
+        read: async (path: string) =>
+          files.has(path) ? { path, body: files.get(path) ?? null } : null,
+        write: async (path: string, body: string) => {
+          files.set(path, body);
+        },
+        delete: async (path: string) => {
+          files.delete(path);
+        },
+        list: async (glob: string) => {
+          const prefix = glob.replace(/\/\*\*$/, '');
+          return [...files.keys()]
+            .filter((path) => path.startsWith(prefix))
+            .map((path) => ({ path }));
+        },
+      },
+      scheduler: {
+        requestWakeUp: vi.fn().mockResolvedValue({ bindingId: 'binding-chain-1' }),
+        cancelWakeUp: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    const sessions = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter(
+        ctxFilesToRuntimeSessionStoreAdapterOptions(ctx.files, {
+          signal: ctx.signal,
+        }),
+      ),
+    });
+    const engine = createProactiveEngine({
+      schedulerBinding: new ContextSchedulerBinding(ctx),
+    });
+    engine.registerFollowUpRule({
+      id: 'idle-follow-up',
+      condition: () => true,
+      messageTemplate: 'Checking back in.',
+      routingHint: 'cheap',
+    });
+
+    const runtimeSession = fromContext(ctx);
+    const created = await sessions.create({
+      id: runtimeSession.id,
+      userId: runtimeSession.userId,
+      workspaceId: runtimeSession.workspaceId,
+      initialSurfaceId: runtimeSession.initialSurfaceId,
+      metadata: runtimeSession.metadata,
+    });
+    const reloaded = await sessions.get(runtimeSession.id);
+    const decisions = await engine.evaluateFollowUp({
+      sessionId: created.id,
+      scheduledAt: '2026-05-12T12:00:00.000Z',
+      lastActivityAt: created.lastActivityAt,
+    });
+    expect(reloaded?.id).toBe('support:sage');
+    expect(reloaded?.metadata).toMatchObject({
+      source: 'proactive-runtime',
+      sessionKey: 'support:sage',
+    });
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      ruleId: 'idle-follow-up',
+      action: 'fire',
+    });
+
+    const scheduledBindingId = await new ContextSchedulerBinding(ctx).requestWakeUp(
+      new Date('2026-05-12T12:05:00.000Z'),
+      {
+        sessionId: created.id,
+        ruleId: 'idle-follow-up',
+        scheduledAt: '2026-05-12T12:05:00.000Z',
+      },
+    );
+    expect(scheduledBindingId).toBe('binding-chain-1');
+    expect(ctx.scheduler.requestWakeUp).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/proactive/src/runtime-interop.test.ts
+++ b/packages/proactive/src/runtime-interop.test.ts
@@ -219,9 +219,12 @@ describe('runtime interop chain', () => {
       metadata: runtimeSession.metadata,
     });
     const reloaded = await sessions.get(runtimeSession.id);
+    const scheduledAt = new Date(
+      new Date(created.lastActivityAt).getTime() + 5 * 60 * 1000,
+    ).toISOString();
     const decisions = await engine.evaluateFollowUp({
       sessionId: created.id,
-      scheduledAt: '2026-05-12T12:00:00.000Z',
+      scheduledAt,
       lastActivityAt: created.lastActivityAt,
     });
     expect(reloaded?.id).toBe('support:sage');
@@ -236,11 +239,11 @@ describe('runtime interop chain', () => {
     });
 
     const scheduledBindingId = await new ContextSchedulerBinding(ctx).requestWakeUp(
-      new Date('2026-05-12T12:05:00.000Z'),
+      new Date(scheduledAt),
       {
         sessionId: created.id,
         ruleId: 'idle-follow-up',
-        scheduledAt: '2026-05-12T12:05:00.000Z',
+        scheduledAt,
       },
     );
     expect(scheduledBindingId).toBe('binding-chain-1');

--- a/packages/proactive/src/runtime-interop.test.ts
+++ b/packages/proactive/src/runtime-interop.test.ts
@@ -58,6 +58,25 @@ describe('fromContext', () => {
     });
   });
 
+  it('falls back to nested ids when flat ids are blank', () => {
+    expect(
+      fromContext({
+        workspaceId: '   ',
+        workspace: { id: 'ws-zeta' },
+        agentId: '',
+        agent: { id: 'sage' },
+      }),
+    ).toMatchObject({
+      id: 'ws-zeta:sage',
+      userId: 'agent:ws-zeta:sage',
+      workspaceId: 'ws-zeta',
+      metadata: {
+        agentId: 'sage',
+        workspaceId: 'ws-zeta',
+      },
+    });
+  });
+
   it('trims ids before deriving the session key', () => {
     expect(
       fromContext({

--- a/packages/proactive/src/runtime-interop.test.ts
+++ b/packages/proactive/src/runtime-interop.test.ts
@@ -171,6 +171,22 @@ describe('ContextSchedulerBinding', () => {
     });
   });
 
+  it('throws when scheduler returns a blank binding id', async () => {
+    const binding = new ContextSchedulerBinding({
+      scheduleWakeUp: vi.fn().mockResolvedValue('   '),
+    });
+
+    await expect(
+      binding.requestWakeUp(new Date('2026-05-12T14:30:00.000Z'), {
+        sessionId: 'ws-delta:sage',
+        scheduledAt: '2026-05-12T14:30:00.000Z',
+      }),
+    ).rejects.toMatchObject({
+      name: 'ProactiveError',
+      code: 'RUNTIME_SCHEDULER_UNAVAILABLE',
+    });
+  });
+
   it('throws when cancel support is unavailable', async () => {
     const binding = new ContextSchedulerBinding({
       scheduleWakeUp: vi.fn().mockResolvedValue('binding-789'),

--- a/packages/proactive/src/runtime-interop.test.ts
+++ b/packages/proactive/src/runtime-interop.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { fromContext } from './runtime-interop.js';
+import { ProactiveError } from './types.js';
+
+describe('fromContext', () => {
+  it('builds a stable assistant session descriptor from flat ids', () => {
+    expect(
+      fromContext({
+        workspaceId: 'ws-alpha',
+        agentId: 'sage',
+      }),
+    ).toEqual({
+      id: 'ws-alpha:sage',
+      userId: 'agent:ws-alpha:sage',
+      workspaceId: 'ws-alpha',
+      surfaceId: 'proactive-runtime:ws-alpha:sage',
+      initialSurfaceId: 'proactive-runtime:ws-alpha:sage',
+      metadata: {
+        agentId: 'sage',
+        workspaceId: 'ws-alpha',
+        sessionKey: 'ws-alpha:sage',
+        source: 'proactive-runtime',
+      },
+    });
+  });
+
+  it('reads nested runtime ids', () => {
+    expect(
+      fromContext({
+        workspace: { id: 'ws-beta' },
+        agent: { id: 'night-cto' },
+      }),
+    ).toMatchObject({
+      id: 'ws-beta:night-cto',
+      userId: 'agent:ws-beta:night-cto',
+      workspaceId: 'ws-beta',
+      metadata: {
+        agentId: 'night-cto',
+        workspaceId: 'ws-beta',
+      },
+    });
+  });
+
+  it('accepts string aliases for nested runtime handles', () => {
+    expect(
+      fromContext({
+        workspace: 'ws-delta',
+        agent: 'sage',
+      }),
+    ).toMatchObject({
+      id: 'ws-delta:sage',
+      userId: 'agent:ws-delta:sage',
+      metadata: {
+        sessionKey: 'ws-delta:sage',
+      },
+    });
+  });
+
+  it('throws when workspace identity is missing', () => {
+    expect(() =>
+      fromContext({
+        agentId: 'sage',
+      }),
+    ).toThrow(ProactiveError);
+  });
+
+  it('throws when agent identity is missing', () => {
+    expect(() =>
+      fromContext({
+        workspaceId: 'ws-gamma',
+      }),
+    ).toThrow(ProactiveError);
+  });
+});

--- a/packages/proactive/src/runtime-interop.ts
+++ b/packages/proactive/src/runtime-interop.ts
@@ -1,4 +1,4 @@
-import { ProactiveError } from './types.js';
+import { ProactiveError, type SchedulerBinding, type WakeUpContext } from './types.js';
 
 const RUNTIME_INTEROP_SOURCE = 'proactive-runtime';
 
@@ -35,6 +35,63 @@ export interface RuntimeInteropSession {
     source: typeof RUNTIME_INTEROP_SOURCE;
   };
 }
+
+type ScheduleWakeUpResult = string | { bindingId: string };
+
+type RuntimeWakeScheduler = {
+  requestWakeUp(at: Date, context: WakeUpContext): Promise<ScheduleWakeUpResult>;
+  cancelWakeUp(bindingId: string): Promise<void>;
+};
+
+export interface RuntimeScheduleContext {
+  scheduleWakeUp?: (at: Date, context: WakeUpContext) => Promise<ScheduleWakeUpResult>;
+  cancelWakeUp?: (bindingId: string) => Promise<void>;
+  scheduler?: RuntimeWakeScheduler | null;
+}
+
+export class ContextSchedulerBinding implements SchedulerBinding {
+  readonly #ctx: RuntimeScheduleContext;
+
+  constructor(ctx: RuntimeScheduleContext) {
+    this.#ctx = ctx;
+  }
+
+  async requestWakeUp(at: Date, context: WakeUpContext): Promise<string> {
+    const scheduler = this.#ctx.scheduler;
+    const result = scheduler
+      ? await scheduler.requestWakeUp(at, context)
+      : await this.#ctx.scheduleWakeUp?.(at, context);
+
+    if (!result) {
+      throw new ProactiveError(
+        'Runtime context does not provide scheduleWakeUp support',
+        'RUNTIME_SCHEDULER_UNAVAILABLE',
+      );
+    }
+
+    return typeof result === 'string' ? result : result.bindingId;
+  }
+
+  async cancelWakeUp(bindingId: string): Promise<void> {
+    const scheduler = this.#ctx.scheduler;
+    if (scheduler) {
+      await scheduler.cancelWakeUp(bindingId);
+      return;
+    }
+
+    const cancelWakeUp = this.#ctx.cancelWakeUp;
+    if (!cancelWakeUp) {
+      throw new ProactiveError(
+        'Runtime context does not provide cancelWakeUp support',
+        'RUNTIME_SCHEDULER_UNAVAILABLE',
+      );
+    }
+
+    await cancelWakeUp(bindingId);
+  }
+}
+
+export { ContextSchedulerBinding as RuntimeSchedulerBinding };
 
 /**
  * Construct a stable agent-assistant session descriptor from a hosted runtime

--- a/packages/proactive/src/runtime-interop.ts
+++ b/packages/proactive/src/runtime-interop.ts
@@ -36,6 +36,11 @@ export interface RuntimeInteropSession {
   };
 }
 
+/**
+ * Construct a stable agent-assistant session descriptor from a hosted runtime
+ * context. The mapping is intentionally structural so cloud runtimes can pass
+ * plain objects without importing any OSS session types.
+ */
 export function fromContext(ctx: RuntimeInteropContext): RuntimeInteropSession {
   const workspaceId = readId(ctx.workspaceId ?? ctx.workspace);
   if (!workspaceId) {

--- a/packages/proactive/src/runtime-interop.ts
+++ b/packages/proactive/src/runtime-interop.ts
@@ -1,0 +1,72 @@
+import { ProactiveError } from './types.js';
+
+const RUNTIME_INTEROP_SOURCE = 'proactive-runtime';
+
+function readId(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (value && typeof value === 'object' && 'id' in value) {
+    return readId((value as { id?: unknown }).id);
+  }
+
+  return null;
+}
+
+export interface RuntimeInteropContext {
+  workspaceId?: string | null;
+  workspace?: string | { id?: string | null } | null;
+  agentId?: string | null;
+  agent?: string | { id?: string | null } | null;
+}
+
+export interface RuntimeInteropSession {
+  id: string;
+  userId: string;
+  workspaceId: string;
+  surfaceId: string;
+  initialSurfaceId: string;
+  metadata: {
+    agentId: string;
+    workspaceId: string;
+    sessionKey: string;
+    source: typeof RUNTIME_INTEROP_SOURCE;
+  };
+}
+
+export function fromContext(ctx: RuntimeInteropContext): RuntimeInteropSession {
+  const workspaceId = readId(ctx.workspaceId ?? ctx.workspace);
+  if (!workspaceId) {
+    throw new ProactiveError(
+      'fromContext requires ctx.workspaceId or ctx.workspace.id',
+      'RUNTIME_INTEROP_CONTEXT_INVALID',
+    );
+  }
+
+  const agentId = readId(ctx.agentId ?? ctx.agent);
+  if (!agentId) {
+    throw new ProactiveError(
+      'fromContext requires ctx.agentId or ctx.agent.id',
+      'RUNTIME_INTEROP_CONTEXT_INVALID',
+    );
+  }
+
+  const sessionKey = `${workspaceId}:${agentId}`;
+  const surfaceId = `${RUNTIME_INTEROP_SOURCE}:${sessionKey}`;
+
+  return {
+    id: sessionKey,
+    userId: `agent:${sessionKey}`,
+    workspaceId,
+    surfaceId,
+    initialSurfaceId: surfaceId,
+    metadata: {
+      agentId,
+      workspaceId,
+      sessionKey,
+      source: RUNTIME_INTEROP_SOURCE,
+    },
+  };
+}

--- a/packages/proactive/src/runtime-interop.ts
+++ b/packages/proactive/src/runtime-interop.ts
@@ -62,14 +62,21 @@ export class ContextSchedulerBinding implements SchedulerBinding {
       ? await scheduler.requestWakeUp(at, context)
       : await this.#ctx.scheduleWakeUp?.(at, context);
 
-    if (!result) {
+    const bindingId =
+      typeof result === 'string'
+        ? result.trim()
+        : typeof result?.bindingId === 'string'
+          ? result.bindingId.trim()
+          : '';
+
+    if (!bindingId) {
       throw new ProactiveError(
         'Runtime context does not provide scheduleWakeUp support',
         'RUNTIME_SCHEDULER_UNAVAILABLE',
       );
     }
 
-    return typeof result === 'string' ? result : result.bindingId;
+    return bindingId;
   }
 
   async cancelWakeUp(bindingId: string): Promise<void> {

--- a/packages/proactive/src/runtime-interop.ts
+++ b/packages/proactive/src/runtime-interop.ts
@@ -99,7 +99,7 @@ export { ContextSchedulerBinding as RuntimeSchedulerBinding };
  * plain objects without importing any OSS session types.
  */
 export function fromContext(ctx: RuntimeInteropContext): RuntimeInteropSession {
-  const workspaceId = readId(ctx.workspaceId ?? ctx.workspace);
+  const workspaceId = readId(ctx.workspaceId) ?? readId(ctx.workspace);
   if (!workspaceId) {
     throw new ProactiveError(
       'fromContext requires ctx.workspaceId or ctx.workspace.id',
@@ -107,7 +107,7 @@ export function fromContext(ctx: RuntimeInteropContext): RuntimeInteropSession {
     );
   }
 
-  const agentId = readId(ctx.agentId ?? ctx.agent);
+  const agentId = readId(ctx.agentId) ?? readId(ctx.agent);
   if (!agentId) {
     throw new ProactiveError(
       'fromContext requires ctx.agentId or ctx.agent.id',

--- a/packages/proactive/vitest.config.ts
+++ b/packages/proactive/vitest.config.ts
@@ -1,3 +1,8 @@
-import baseConfig from '../../vitest.package.config';
+import { defineConfig } from "vitest/config";
 
-export default baseConfig;
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/proactive/vitest.config.ts
+++ b/packages/proactive/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../vitest.package.config';
+
+export default baseConfig;

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -1,5 +1,6 @@
 export {
   createSessionStore,
+  ctxFilesToRuntimeSessionStoreAdapterOptions,
   defaultAffinityResolver,
   InMemorySessionStoreAdapter,
   RuntimeSessionStoreAdapter,
@@ -14,7 +15,10 @@ export {
 
 export type {
   AffinityResolver,
+  CtxFilesToRuntimeSessionStoreAdapterOptions,
   CreateSessionInput,
+  RuntimeCtxFileRecord,
+  RuntimeCtxFiles,
   Session,
   SessionQuery,
   SessionResolvableMessage,

--- a/packages/sessions/src/index.ts
+++ b/packages/sessions/src/index.ts
@@ -2,6 +2,7 @@ export {
   createSessionStore,
   defaultAffinityResolver,
   InMemorySessionStoreAdapter,
+  RuntimeSessionStoreAdapter,
   resolveSession,
 } from './sessions.js';
 
@@ -21,4 +22,5 @@ export type {
   SessionStore,
   SessionStoreAdapter,
   SessionStoreConfig,
+  RuntimeSessionStoreAdapterOptions,
 } from './types.js';

--- a/packages/sessions/src/sessions.test.ts
+++ b/packages/sessions/src/sessions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createSessionStore,
+  ctxFilesToRuntimeSessionStoreAdapterOptions,
   defaultAffinityResolver,
   InMemorySessionStoreAdapter,
   RuntimeSessionStoreAdapter,
@@ -179,6 +180,53 @@ describe('session retrieval', () => {
       attachedSurfaces: ['surface-runtime'],
       metadata: { source: 'ctx.files' },
     });
+  });
+
+  it('bridges ctx.files into runtime adapter options', async () => {
+    const files = new Map<string, string>();
+    const signal = new AbortController().signal;
+    const listCalls: string[] = [];
+    const store = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter(
+        ctxFilesToRuntimeSessionStoreAdapterOptions(
+          {
+            async read(path) {
+              return files.has(path) ? { path, body: files.get(path) ?? null } : null;
+            },
+            async write(path, body) {
+              files.set(path, body);
+            },
+            async delete(path) {
+              files.delete(path);
+            },
+            async list(glob) {
+              listCalls.push(glob);
+              const prefix = glob.replace(/\/\*\*$/, '');
+              return [...files.keys()]
+                .filter((path) => path.startsWith(prefix))
+                .map((path) => ({ path }));
+            },
+          },
+          { signal },
+        ),
+      ),
+    });
+
+    await store.create({
+      id: 'session-ctx',
+      userId: 'user-ctx',
+      metadata: { source: 'ctx.files' },
+    });
+
+    const session = await store.get('session-ctx');
+    const listed = await store.find({ limit: 10 });
+
+    expect(session).toMatchObject({
+      id: 'session-ctx',
+      metadata: { source: 'ctx.files' },
+    });
+    expect(listed).toHaveLength(1);
+    expect(listCalls).toEqual(['/agent-assistant/sessions/**']);
   });
 });
 

--- a/packages/sessions/src/sessions.test.ts
+++ b/packages/sessions/src/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   createSessionStore,
   defaultAffinityResolver,
   InMemorySessionStoreAdapter,
+  RuntimeSessionStoreAdapter,
   resolveSession,
 } from './index.js';
 import {
@@ -141,6 +142,43 @@ describe('session retrieval', () => {
     expect(sessions[0]?.userId).toBe('user-1');
     expect(sessions[0]?.state).toBe('active');
     vi.useRealTimers();
+  });
+
+  it('persists sessions through a runtime-backed adapter', async () => {
+    const files = new Map<string, string>();
+    const store = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter({
+        async read(path) {
+          return files.get(path) ?? null;
+        },
+        async write(path, body) {
+          files.set(path, body);
+        },
+        async delete(path) {
+          files.delete(path);
+        },
+        async list(prefix) {
+          return [...files.keys()].filter((path) => path.startsWith(prefix));
+        },
+      }),
+    });
+
+    await store.create({
+      id: 'session-runtime',
+      userId: 'user-runtime',
+      workspaceId: 'ws-runtime',
+      initialSurfaceId: 'surface-runtime',
+      metadata: { source: 'ctx.files' },
+    });
+
+    const session = await store.get('session-runtime');
+    expect(session).toMatchObject({
+      id: 'session-runtime',
+      userId: 'user-runtime',
+      workspaceId: 'ws-runtime',
+      attachedSurfaces: ['surface-runtime'],
+      metadata: { source: 'ctx.files' },
+    });
   });
 });
 

--- a/packages/sessions/src/sessions.test.ts
+++ b/packages/sessions/src/sessions.test.ts
@@ -182,6 +182,66 @@ describe('session retrieval', () => {
     });
   });
 
+  it('returns null for corrupt runtime-backed session records', async () => {
+    const path = '/agent-assistant/sessions/session-bad.json';
+    const files = new Map<string, string>([[path, '{not json']]);
+    const onCorruptRecord = vi.fn();
+    const store = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter({
+        async read(readPath) {
+          return files.get(readPath) ?? null;
+        },
+        async write(writePath, body) {
+          files.set(writePath, body);
+        },
+        async delete(deletePath) {
+          files.delete(deletePath);
+        },
+        async list(prefix) {
+          return [...files.keys()].filter((entry) => entry.startsWith(prefix));
+        },
+        onCorruptRecord,
+      }),
+    });
+
+    await expect(store.get('session-bad')).resolves.toBeNull();
+    await expect(store.find({ limit: 10 })).resolves.toEqual([]);
+    expect(onCorruptRecord).toHaveBeenCalled();
+  });
+
+  it('uses insert-only writes when the runtime backend supports them', async () => {
+    const files = new Map<string, string>();
+    const store = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter({
+        async read(path) {
+          return files.get(path) ?? null;
+        },
+        async write(path, body) {
+          files.set(path, body);
+        },
+        async insert(path, body) {
+          if (files.has(path)) {
+            const error = new Error('already exists');
+            (error as Error & { code?: string }).code = 'EEXIST';
+            throw error;
+          }
+          files.set(path, body);
+        },
+        async delete(path) {
+          files.delete(path);
+        },
+        async list(prefix) {
+          return [...files.keys()].filter((entry) => entry.startsWith(prefix));
+        },
+      }),
+    });
+
+    await store.create({ id: 'session-runtime-insert', userId: 'user-1' });
+    await expect(store.create({ id: 'session-runtime-insert', userId: 'user-2' })).rejects.toThrow(
+      SessionConflictError,
+    );
+  });
+
   it('bridges ctx.files into runtime adapter options', async () => {
     const files = new Map<string, string>();
     const signal = new AbortController().signal;

--- a/packages/sessions/src/sessions.test.ts
+++ b/packages/sessions/src/sessions.test.ts
@@ -147,24 +147,25 @@ describe('session retrieval', () => {
 
   it('persists sessions through a runtime-backed adapter', async () => {
     const files = new Map<string, string>();
-    const store = createSessionStore({
-      adapter: new RuntimeSessionStoreAdapter({
-        async read(path) {
-          return files.get(path) ?? null;
-        },
-        async write(path, body) {
-          files.set(path, body);
-        },
-        async delete(path) {
-          files.delete(path);
-        },
-        async list(prefix) {
-          return [...files.keys()].filter((path) => path.startsWith(prefix));
-        },
-      }),
+    const adapterOptions = {
+      async read(path: string) {
+        return files.get(path) ?? null;
+      },
+      async write(path: string, body: string) {
+        files.set(path, body);
+      },
+      async delete(path: string) {
+        files.delete(path);
+      },
+      async list(prefix: string) {
+        return [...files.keys()].filter((path) => path.startsWith(prefix));
+      },
+    };
+    const writerStore = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter(adapterOptions),
     });
 
-    await store.create({
+    await writerStore.create({
       id: 'session-runtime',
       userId: 'user-runtime',
       workspaceId: 'ws-runtime',
@@ -172,7 +173,10 @@ describe('session retrieval', () => {
       metadata: { source: 'ctx.files' },
     });
 
-    const session = await store.get('session-runtime');
+    const readerStore = createSessionStore({
+      adapter: new RuntimeSessionStoreAdapter(adapterOptions),
+    });
+    const session = await readerStore.get('session-runtime');
     expect(session).toMatchObject({
       id: 'session-runtime',
       userId: 'user-runtime',

--- a/packages/sessions/src/sessions.ts
+++ b/packages/sessions/src/sessions.ts
@@ -5,7 +5,9 @@ import {
 } from './types.js';
 import type {
   AffinityResolver,
+  CtxFilesToRuntimeSessionStoreAdapterOptions,
   CreateSessionInput,
+  RuntimeCtxFiles,
   RuntimeSessionStoreAdapterOptions,
   Session,
   SessionQuery,
@@ -30,6 +32,24 @@ function nowIso(): string {
 
 function normalizeLimit(limit?: number): number {
   return limit ?? DEFAULT_FIND_LIMIT;
+}
+
+function normalizeCtxReadResult(
+  value: string | { body?: string | null; content?: string | null } | null,
+): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (!value) {
+    return null;
+  }
+  if (typeof value.body === 'string') {
+    return value.body;
+  }
+  if (typeof value.content === 'string') {
+    return value.content;
+  }
+  return null;
 }
 
 function normalizeStateFilter(
@@ -343,6 +363,32 @@ export class RuntimeSessionStoreAdapter implements SessionStoreAdapter {
   private async writeSession(session: Session): Promise<void> {
     await this.options.write(this.pathFor(session.id), JSON.stringify(session));
   }
+}
+
+export function ctxFilesToRuntimeSessionStoreAdapterOptions(
+  files: RuntimeCtxFiles,
+  options: CtxFilesToRuntimeSessionStoreAdapterOptions = {},
+): RuntimeSessionStoreAdapterOptions {
+  const signal = options.signal;
+  return {
+    prefix: options.prefix,
+    async read(path) {
+      const result = await files.read(path, { signal });
+      return normalizeCtxReadResult(result);
+    },
+    async write(path, body) {
+      await files.write(path, body, { signal });
+    },
+    async delete(path) {
+      await files.delete(path, { signal });
+    },
+    async list(prefix) {
+      const entries = await files.list(`${prefix}/**`, { signal });
+      return entries
+        .map((entry) => (typeof entry === 'string' ? entry : entry.path))
+        .filter((path): path is string => typeof path === 'string' && path.length > 0);
+    },
+  };
 }
 
 export async function resolveSession(

--- a/packages/sessions/src/sessions.ts
+++ b/packages/sessions/src/sessions.ts
@@ -6,6 +6,7 @@ import {
 import type {
   AffinityResolver,
   CreateSessionInput,
+  RuntimeSessionStoreAdapterOptions,
   Session,
   SessionQuery,
   SessionResolvableMessage,
@@ -17,6 +18,7 @@ import type {
 
 const DEFAULT_TTL_MS = 3_600_000;
 const DEFAULT_FIND_LIMIT = 50;
+const DEFAULT_RUNTIME_PREFIX = '/agent-assistant/sessions';
 
 function cloneSession<T>(value: T): T {
   return structuredClone(value);
@@ -258,6 +260,91 @@ export class InMemorySessionStoreAdapter implements SessionStoreAdapter {
   }
 }
 
+export class RuntimeSessionStoreAdapter implements SessionStoreAdapter {
+  private readonly prefix: string;
+
+  constructor(private readonly options: RuntimeSessionStoreAdapterOptions) {
+    this.prefix = normalizePrefix(options.prefix);
+  }
+
+  async insert(session: Session): Promise<void> {
+    const existing = await this.fetchById(session.id);
+    if (existing) {
+      throw new SessionConflictError(session.id);
+    }
+    await this.writeSession(session);
+  }
+
+  async fetchById(sessionId: string): Promise<Session | null> {
+    return this.readSession(this.pathFor(sessionId));
+  }
+
+  async fetchMany(query: SessionQuery): Promise<Session[]> {
+    const states = normalizeStateFilter(query.state);
+    const limit = normalizeLimit(query.limit);
+    const paths = await this.options.list(this.prefix);
+    const sessions = await Promise.all(paths.map((path) => this.readSession(path)));
+    const matches = sessions
+      .filter((session): session is Session => Boolean(session))
+      .filter((session) => {
+        if (query.userId && session.userId !== query.userId) {
+          return false;
+        }
+        if (query.workspaceId && session.workspaceId !== query.workspaceId) {
+          return false;
+        }
+        if (states && !states.includes(session.state)) {
+          return false;
+        }
+        if (query.surfaceId && !session.attachedSurfaces.includes(query.surfaceId)) {
+          return false;
+        }
+        if (query.activeAfter && Date.parse(session.lastActivityAt) <= Date.parse(query.activeAfter)) {
+          return false;
+        }
+        return true;
+      });
+
+    return sortByRecentActivity(matches).slice(0, limit).map((session) => cloneSession(session));
+  }
+
+  async update(sessionId: string, patch: Partial<Session>): Promise<Session> {
+    const existing = await this.fetchById(sessionId);
+    if (!existing) {
+      throw new SessionNotFoundError(sessionId);
+    }
+
+    const next = cloneSession({
+      ...existing,
+      ...patch,
+    });
+    await this.writeSession(next);
+    return cloneSession(next);
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    await this.options.delete(this.pathFor(sessionId));
+  }
+
+  private pathFor(sessionId: string): string {
+    return `${this.prefix}/${encodeURIComponent(sessionId)}.json`;
+  }
+
+  private async readSession(path: string): Promise<Session | null> {
+    const body = await this.options.read(path);
+    if (!body) {
+      return null;
+    }
+
+    const session = JSON.parse(body) as Session;
+    return cloneSession(session);
+  }
+
+  private async writeSession(session: Session): Promise<void> {
+    await this.options.write(this.pathFor(session.id), JSON.stringify(session));
+  }
+}
+
 export async function resolveSession(
   message: SessionResolvableMessage,
   store: SessionStore,
@@ -297,4 +384,12 @@ export function defaultAffinityResolver(store: SessionStore): AffinityResolver {
       return sessions[0] ?? null;
     },
   };
+}
+
+function normalizePrefix(prefix: string | undefined): string {
+  const trimmed = prefix?.trim();
+  if (!trimmed) {
+    return DEFAULT_RUNTIME_PREFIX;
+  }
+  return trimmed.replace(/\/+$/, '');
 }

--- a/packages/sessions/src/sessions.ts
+++ b/packages/sessions/src/sessions.ts
@@ -288,11 +288,23 @@ export class RuntimeSessionStoreAdapter implements SessionStoreAdapter {
   }
 
   async insert(session: Session): Promise<void> {
-    const existing = await this.fetchById(session.id);
-    if (existing) {
-      throw new SessionConflictError(session.id);
+    try {
+      if (this.options.insert) {
+        await this.options.insert(this.pathFor(session.id), JSON.stringify(session));
+        return;
+      }
+
+      const existing = await this.fetchById(session.id);
+      if (existing) {
+        throw new SessionConflictError(session.id);
+      }
+      await this.writeSession(session);
+    } catch (error) {
+      if (error instanceof SessionConflictError || isAlreadyExistsError(error)) {
+        throw new SessionConflictError(session.id);
+      }
+      throw error;
     }
-    await this.writeSession(session);
   }
 
   async fetchById(sessionId: string): Promise<Session | null> {
@@ -356,8 +368,13 @@ export class RuntimeSessionStoreAdapter implements SessionStoreAdapter {
       return null;
     }
 
-    const session = JSON.parse(body) as Session;
-    return cloneSession(session);
+    try {
+      const session = JSON.parse(body) as Session;
+      return cloneSession(session);
+    } catch (error) {
+      await this.options.onCorruptRecord?.({ path, body, error });
+      return null;
+    }
   }
 
   private async writeSession(session: Session): Promise<void> {
@@ -430,6 +447,23 @@ export function defaultAffinityResolver(store: SessionStore): AffinityResolver {
       return sessions[0] ?? null;
     },
   };
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const maybeCode = 'code' in error ? (error as { code?: unknown }).code : undefined;
+  if (typeof maybeCode === 'string') {
+    const normalized = maybeCode.toLowerCase();
+    if (normalized === 'already_exists' || normalized === 'alreadyexists' || normalized === 'eexist') {
+      return true;
+    }
+  }
+
+  const maybeMessage = 'message' in error ? (error as { message?: unknown }).message : undefined;
+  return typeof maybeMessage === 'string' && /already exists|eexist/i.test(maybeMessage);
 }
 
 function normalizePrefix(prefix: string | undefined): string {

--- a/packages/sessions/src/types.ts
+++ b/packages/sessions/src/types.ts
@@ -57,6 +57,37 @@ export interface RuntimeSessionStoreAdapterOptions {
   prefix?: string;
 }
 
+export interface RuntimeCtxFileRecord {
+  path: string;
+  body?: string | null;
+  content?: string | null;
+}
+
+export interface RuntimeCtxFiles {
+  read(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<string | RuntimeCtxFileRecord | null>;
+  write(
+    path: string,
+    body: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void>;
+  delete(
+    path: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<void>;
+  list(
+    glob: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<Array<string | { path: string }>>;
+}
+
+export interface CtxFilesToRuntimeSessionStoreAdapterOptions {
+  signal?: AbortSignal;
+  prefix?: string;
+}
+
 export interface AffinityResolver {
   resolve(userId: string, surfaceId?: string): Promise<Session | null>;
 }

--- a/packages/sessions/src/types.ts
+++ b/packages/sessions/src/types.ts
@@ -54,6 +54,8 @@ export interface RuntimeSessionStoreAdapterOptions {
   write(path: string, body: string): Promise<void>;
   delete(path: string): Promise<void>;
   list(prefix: string): Promise<string[]>;
+  insert?(path: string, body: string): Promise<void>;
+  onCorruptRecord?(record: { path: string; body: string; error: unknown }): void | Promise<void>;
   prefix?: string;
 }
 

--- a/packages/sessions/src/types.ts
+++ b/packages/sessions/src/types.ts
@@ -49,6 +49,14 @@ export interface SessionStoreAdapter {
   delete(sessionId: string): Promise<void>;
 }
 
+export interface RuntimeSessionStoreAdapterOptions {
+  read(path: string): Promise<string | null>;
+  write(path: string, body: string): Promise<void>;
+  delete(path: string): Promise<void>;
+  list(prefix: string): Promise<string[]>;
+  prefix?: string;
+}
+
 export interface AffinityResolver {
   resolve(userId: string, surfaceId?: string): Promise<Session | null>;
 }


### PR DESCRIPTION
## Summary

Part of the Proactive Agent Runtime spec (#513 in cloud). M1 (interop doc + helper) + M4 (RuntimeSessionStoreAdapter + ctx.files bridge).

## In this PR

- **M1** — `@agent-assistant/proactive` runtime-interop helper (`fromContext`) + `docs/proactive-runtime-interop.md`
- **M4** — `RuntimeSessionStoreAdapter` for the proactive runtime; ctx.files bridged into session-store adapter

## Test plan

- [ ] Run: `npm test -w packages/proactive`
- [ ] Reviewer: confirm `fromContext` output shape is consumed correctly by `@agent-assistant/sessions` `createSessionStore`

## Notes

- Branch shared across 7 repos.
- M5 migrates Sage + Ricky to consume `@agent-relay/agent`; that work lands separately on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)