### PR TITLE
feat(surfaces): add Slack progress stream helpers

### DIFF
--- a/packages/surfaces/src/index.ts
+++ b/packages/surfaces/src/index.ts
@@ -58,3 +58,23 @@ export type {
 
 export { listBotChannels } from "./slack-bot-channels.js";
 export type { BotChannel } from "./slack-bot-channels.js";
+
+export {
+  appendSlackProgressStream,
+  createSlackTaskUpdate,
+  finishSlackProgressStream,
+  startSlackProgressStream,
+} from "./slack-progress-stream.js";
+export type {
+  SlackProgressAppendInput,
+  SlackProgressChunk,
+  SlackProgressFinishFallback,
+  SlackProgressFinishInput,
+  SlackProgressFinishResult,
+  SlackProgressResult,
+  SlackProgressStartInput,
+  SlackProgressStreamEgress,
+  SlackProgressTaskDisplayMode,
+  SlackProgressTaskStatus,
+  SlackProgressTaskUpdate,
+} from "./slack-progress-stream.js";

--- a/packages/surfaces/src/slack-progress-stream.test.ts
+++ b/packages/surfaces/src/slack-progress-stream.test.ts
@@ -16,6 +16,13 @@ describe("createSlackTaskUpdate", () => {
         title: "Sync",
         status: "complete",
         details: "2 skills",
+        sources: [
+          {
+            type: "url",
+            text: "Run log",
+            url: "https://example.com/run",
+          },
+        ],
       }),
     ).toEqual({
       type: "task_update",
@@ -23,6 +30,13 @@ describe("createSlackTaskUpdate", () => {
       title: "Sync",
       status: "complete",
       details: "2 skills",
+      sources: [
+        {
+          type: "url",
+          text: "Run log",
+          url: "https://example.com/run",
+        },
+      ],
     });
   });
 
@@ -50,7 +64,10 @@ describe("startSlackProgressStream", () => {
       recipientUserId: "U123",
       recipientTeamId: "T123",
       taskDisplayMode: "timeline",
-      chunks: [createSlackTaskUpdate({ id: "prepare", title: "Prepare", status: "in_progress" })],
+      chunks: [
+        { type: "markdown_text", text: "Preparing the run." },
+        createSlackTaskUpdate({ id: "prepare", title: "Prepare", status: "in_progress" }),
+      ],
     });
 
     expect(result).toEqual({ ok: true, ts: "1710000000.000100" });
@@ -63,6 +80,10 @@ describe("startSlackProgressStream", () => {
       recipientTeamId: "T123",
       taskDisplayMode: "timeline",
       chunks: [
+        {
+          type: "markdown_text",
+          text: "Preparing the run.",
+        },
         {
           type: "task_update",
           id: "prepare",

--- a/packages/surfaces/src/slack-progress-stream.test.ts
+++ b/packages/surfaces/src/slack-progress-stream.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  appendSlackProgressStream,
+  createSlackTaskUpdate,
+  finishSlackProgressStream,
+  startSlackProgressStream,
+  type SlackProgressStreamEgress,
+} from "./slack-progress-stream.js";
+
+describe("createSlackTaskUpdate", () => {
+  it("builds compact Slack task update chunks", () => {
+    expect(
+      createSlackTaskUpdate({
+        id: "sync",
+        title: "Sync",
+        status: "complete",
+        details: "2 skills",
+      }),
+    ).toEqual({
+      type: "task_update",
+      id: "sync",
+      title: "Sync",
+      status: "complete",
+      details: "2 skills",
+    });
+  });
+
+  it("omits empty optional fields", () => {
+    expect(createSlackTaskUpdate({ id: "prepare", title: "", details: "" })).toEqual({
+      type: "task_update",
+      id: "prepare",
+    });
+  });
+});
+
+describe("startSlackProgressStream", () => {
+  it("starts a Slack stream with recipients, display mode, and chunks", async () => {
+    const startStream = vi.fn<SlackProgressStreamEgress["startStream"]>().mockResolvedValue({
+      ok: true,
+      ts: "1710000000.000100",
+    });
+
+    const result = await startSlackProgressStream({
+      egress: { startStream },
+      workspaceId: "workspace-1",
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      markdownText: "Working...",
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+      taskDisplayMode: "timeline",
+      chunks: [createSlackTaskUpdate({ id: "prepare", title: "Prepare", status: "in_progress" })],
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1710000000.000100" });
+    expect(startStream).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      channel: "C123",
+      threadTs: "1700000000.000100",
+      markdownText: "Working...",
+      recipientUserId: "U123",
+      recipientTeamId: "T123",
+      taskDisplayMode: "timeline",
+      chunks: [
+        {
+          type: "task_update",
+          id: "prepare",
+          title: "Prepare",
+          status: "in_progress",
+        },
+      ],
+    });
+  });
+
+  it("converts thrown start errors into failed results", async () => {
+    const startStream = vi
+      .fn<SlackProgressStreamEgress["startStream"]>()
+      .mockRejectedValue(new Error("Slack unavailable"));
+
+    await expect(
+      startSlackProgressStream({
+        egress: { startStream },
+        channel: "C123",
+        threadTs: "1700000000.000100",
+      }),
+    ).resolves.toEqual({ ok: false, error: "Slack unavailable" });
+  });
+});
+
+describe("appendSlackProgressStream", () => {
+  it("appends markdown and chunks when appendStream is supported", async () => {
+    const appendStream = vi
+      .fn<NonNullable<SlackProgressStreamEgress["appendStream"]>>()
+      .mockResolvedValue({
+        ok: true,
+        ts: "1710000000.000100",
+      });
+
+    const result = await appendSlackProgressStream({
+      egress: { appendStream },
+      workspaceId: "workspace-1",
+      channel: "C123",
+      ts: "1710000000.000100",
+      markdownText: "Still working...",
+      chunks: [createSlackTaskUpdate({ id: "load", status: "in_progress" })],
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1710000000.000100" });
+    expect(appendStream).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      channel: "C123",
+      ts: "1710000000.000100",
+      markdownText: "Still working...",
+      chunks: [{ type: "task_update", id: "load", status: "in_progress" }],
+    });
+  });
+
+  it("reports unsupported appendStream without throwing", async () => {
+    await expect(
+      appendSlackProgressStream({
+        egress: {},
+        channel: "C123",
+        ts: "1710000000.000100",
+        markdownText: "Still working...",
+      }),
+    ).resolves.toEqual({ ok: false, error: "Slack appendStream is not available" });
+  });
+});
+
+describe("finishSlackProgressStream", () => {
+  it("stops a stream with rich final content", async () => {
+    const stopStream = vi.fn<SlackProgressStreamEgress["stopStream"]>().mockResolvedValue({
+      ok: true,
+      ts: "1710000000.000100",
+    });
+
+    const result = await finishSlackProgressStream({
+      egress: { stopStream },
+      workspaceId: "workspace-1",
+      channel: "C123",
+      ts: "1710000000.000100",
+      markdownText: "Done",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "Done" } }],
+      chunks: [createSlackTaskUpdate({ id: "done", status: "complete" })],
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1710000000.000100", fallback: "none" });
+    expect(stopStream).toHaveBeenCalledTimes(1);
+    expect(stopStream).toHaveBeenCalledWith({
+      workspaceId: "workspace-1",
+      channel: "C123",
+      ts: "1710000000.000100",
+      markdownText: "Done",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "Done" } }],
+      chunks: [{ type: "task_update", id: "done", status: "complete" }],
+    });
+  });
+
+  it("retries with a minimal stop when rich final content fails", async () => {
+    const stopStream = vi
+      .fn<SlackProgressStreamEgress["stopStream"]>()
+      .mockResolvedValueOnce({ ok: false, error: "invalid_blocks" })
+      .mockResolvedValueOnce({ ok: true, ts: "1710000000.000100" });
+
+    const result = await finishSlackProgressStream({
+      egress: { stopStream },
+      workspaceId: "workspace-1",
+      channel: "C123",
+      ts: "1710000000.000100",
+      markdownText: "Done",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "Done" } }],
+      chunks: [createSlackTaskUpdate({ id: "done", status: "complete" })],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      ts: "1710000000.000100",
+      fallback: "minimal_stop",
+    });
+    expect(stopStream).toHaveBeenNthCalledWith(2, {
+      workspaceId: "workspace-1",
+      channel: "C123",
+      ts: "1710000000.000100",
+      markdownText: "Done",
+    });
+  });
+
+  it("keeps the original rich failure when the minimal fallback also fails", async () => {
+    const stopStream = vi
+      .fn<SlackProgressStreamEgress["stopStream"]>()
+      .mockResolvedValueOnce({ ok: false, error: "invalid_blocks" })
+      .mockResolvedValueOnce({ ok: false });
+
+    await expect(
+      finishSlackProgressStream({
+        egress: { stopStream },
+        channel: "C123",
+        ts: "1710000000.000100",
+        markdownText: "Done",
+        chunks: [createSlackTaskUpdate({ id: "done", status: "complete" })],
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "invalid_blocks",
+      fallback: "minimal_stop",
+    });
+  });
+
+  it("does not retry plain stop failures", async () => {
+    const stopStream = vi.fn<SlackProgressStreamEgress["stopStream"]>().mockResolvedValue({
+      ok: false,
+      error: "not_in_progress",
+    });
+
+    await expect(
+      finishSlackProgressStream({
+        egress: { stopStream },
+        channel: "C123",
+        ts: "1710000000.000100",
+        markdownText: "Done",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "not_in_progress",
+      fallback: "none",
+    });
+    expect(stopStream).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/surfaces/src/slack-progress-stream.ts
+++ b/packages/surfaces/src/slack-progress-stream.ts
@@ -1,0 +1,213 @@
+export type SlackProgressTaskStatus = "pending" | "in_progress" | "complete" | "error";
+
+export type SlackProgressTaskUpdate = {
+  type: "task_update";
+  id: string;
+  title?: string;
+  status?: SlackProgressTaskStatus;
+  details?: string;
+  output?: string;
+};
+
+export type SlackProgressChunk =
+  | { type: "markdown_text"; markdown_text: string }
+  | SlackProgressTaskUpdate
+  | { type: "plan_update"; [key: string]: unknown }
+  | { type: "blocks"; blocks: unknown[] };
+
+export type SlackProgressTaskDisplayMode = "timeline" | "plan" | "dense";
+
+export interface SlackProgressResult {
+  ok: boolean;
+  ts?: string;
+  error?: string;
+}
+
+export interface SlackProgressStreamEgress {
+  startStream(input: {
+    workspaceId?: string;
+    channel: string;
+    threadTs: string;
+    markdownText?: string;
+    recipientUserId?: string;
+    recipientTeamId?: string;
+    taskDisplayMode?: SlackProgressTaskDisplayMode;
+    chunks?: SlackProgressChunk[];
+  }): Promise<SlackProgressResult>;
+
+  appendStream?(input: {
+    workspaceId?: string;
+    channel: string;
+    ts: string;
+    markdownText: string;
+    chunks?: SlackProgressChunk[];
+  }): Promise<SlackProgressResult>;
+
+  stopStream(input: {
+    workspaceId?: string;
+    channel: string;
+    ts: string;
+    markdownText?: string;
+    blocks?: unknown[];
+    chunks?: SlackProgressChunk[];
+  }): Promise<SlackProgressResult>;
+}
+
+export interface SlackProgressStartInput {
+  egress: Pick<SlackProgressStreamEgress, "startStream">;
+  workspaceId?: string;
+  channel: string;
+  threadTs: string;
+  markdownText?: string;
+  recipientUserId?: string;
+  recipientTeamId?: string;
+  taskDisplayMode?: SlackProgressTaskDisplayMode;
+  chunks?: SlackProgressChunk[];
+}
+
+export interface SlackProgressAppendInput {
+  egress: Pick<SlackProgressStreamEgress, "appendStream">;
+  workspaceId?: string;
+  channel: string;
+  ts: string;
+  markdownText: string;
+  chunks?: SlackProgressChunk[];
+}
+
+export type SlackProgressFinishFallback = "none" | "minimal_stop";
+
+export interface SlackProgressFinishResult extends SlackProgressResult {
+  fallback: SlackProgressFinishFallback;
+}
+
+export interface SlackProgressFinishInput {
+  egress: Pick<SlackProgressStreamEgress, "stopStream">;
+  workspaceId?: string;
+  channel: string;
+  ts: string;
+  markdownText?: string;
+  blocks?: unknown[];
+  chunks?: SlackProgressChunk[];
+}
+
+export function createSlackTaskUpdate(input: {
+  id: string;
+  title?: string;
+  status?: SlackProgressTaskStatus;
+  details?: string;
+  output?: string;
+}): SlackProgressTaskUpdate {
+  return {
+    type: "task_update",
+    id: input.id,
+    ...(input.title ? { title: input.title } : {}),
+    ...(input.status ? { status: input.status } : {}),
+    ...(input.details ? { details: input.details } : {}),
+    ...(input.output ? { output: input.output } : {}),
+  };
+}
+
+export async function startSlackProgressStream(
+  input: SlackProgressStartInput,
+): Promise<SlackProgressResult> {
+  try {
+    return await input.egress.startStream({
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+      channel: input.channel,
+      threadTs: input.threadTs,
+      ...(input.markdownText ? { markdownText: input.markdownText } : {}),
+      ...(input.recipientUserId ? { recipientUserId: input.recipientUserId } : {}),
+      ...(input.recipientTeamId ? { recipientTeamId: input.recipientTeamId } : {}),
+      ...(input.taskDisplayMode ? { taskDisplayMode: input.taskDisplayMode } : {}),
+      ...(input.chunks ? { chunks: input.chunks } : {}),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: errorMessage(error),
+    };
+  }
+}
+
+export async function appendSlackProgressStream(
+  input: SlackProgressAppendInput,
+): Promise<SlackProgressResult> {
+  if (!input.egress.appendStream) {
+    return { ok: false, error: "Slack appendStream is not available" };
+  }
+
+  try {
+    return await input.egress.appendStream({
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+      channel: input.channel,
+      ts: input.ts,
+      markdownText: input.markdownText,
+      ...(input.chunks ? { chunks: input.chunks } : {}),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: errorMessage(error),
+    };
+  }
+}
+
+export async function finishSlackProgressStream(
+  input: SlackProgressFinishInput,
+): Promise<SlackProgressFinishResult> {
+  const rich = await stopSlackProgressStream(input);
+  if (rich.ok) {
+    return { ...rich, fallback: "none" };
+  }
+
+  if (!input.blocks && !input.chunks) {
+    return { ...rich, fallback: "none" };
+  }
+
+  const minimal = await stopSlackProgressStream({
+    egress: input.egress,
+    ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+    channel: input.channel,
+    ts: input.ts,
+    ...(input.markdownText ? { markdownText: input.markdownText } : {}),
+  });
+  if (minimal.ok) {
+    return { ...minimal, fallback: "minimal_stop" };
+  }
+
+  return {
+    ...minimal,
+    error: minimal.error ?? rich.error,
+    fallback: "minimal_stop",
+  };
+}
+
+async function stopSlackProgressStream(
+  input: SlackProgressFinishInput,
+): Promise<SlackProgressResult> {
+  try {
+    return await input.egress.stopStream({
+      ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+      channel: input.channel,
+      ts: input.ts,
+      ...(input.markdownText ? { markdownText: input.markdownText } : {}),
+      ...(input.blocks ? { blocks: input.blocks } : {}),
+      ...(input.chunks ? { chunks: input.chunks } : {}),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      error: errorMessage(error),
+    };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim()) {
+    return error;
+  }
+  return "Slack progress stream request failed";
+}

--- a/packages/surfaces/src/slack-progress-stream.ts
+++ b/packages/surfaces/src/slack-progress-stream.ts
@@ -1,5 +1,16 @@
 export type SlackProgressTaskStatus = "pending" | "in_progress" | "complete" | "error";
 
+export type SlackProgressTaskSource =
+  | {
+      type: "url";
+      text: string;
+      url: string;
+    }
+  | {
+      type: string;
+      [key: string]: unknown;
+    };
+
 export type SlackProgressTaskUpdate = {
   type: "task_update";
   id: string;
@@ -7,10 +18,11 @@ export type SlackProgressTaskUpdate = {
   status?: SlackProgressTaskStatus;
   details?: string;
   output?: string;
+  sources?: SlackProgressTaskSource[];
 };
 
 export type SlackProgressChunk =
-  | { type: "markdown_text"; markdown_text: string }
+  | { type: "markdown_text"; text: string }
   | SlackProgressTaskUpdate
   | { type: "plan_update"; [key: string]: unknown }
   | { type: "blocks"; blocks: unknown[] };
@@ -96,6 +108,7 @@ export function createSlackTaskUpdate(input: {
   status?: SlackProgressTaskStatus;
   details?: string;
   output?: string;
+  sources?: SlackProgressTaskSource[];
 }): SlackProgressTaskUpdate {
   return {
     type: "task_update",
@@ -104,6 +117,7 @@ export function createSlackTaskUpdate(input: {
     ...(input.status ? { status: input.status } : {}),
     ...(input.details ? { details: input.details } : {}),
     ...(input.output ? { output: input.output } : {}),
+    ...(input.sources?.length ? { sources: input.sources } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- add shared Slack native progress stream helpers in `@agent-assistant/surfaces`
- support start, append, and rich stop with minimal stop fallback for Slack stream finalization
- export task update/chunk/result types for downstream Ricky and Sage integrations
- cover start, append, stop, fallback, and error handling behavior with Vitest

## Verification
- `npx vitest run packages/surfaces/src/slack-progress-stream.test.ts`
- `npx vitest run packages/surfaces/src`
- `npm run build -w @agent-assistant/surfaces`
- `git diff --check`

## Notes
- `npm run build` at the repo root still fails in unrelated workspaces: `@agent-assistant/harness` cannot resolve `@agent-assistant/memory` and has an existing `unknown` catch typing error; `@agent-assistant/inbox` cannot resolve `@agent-assistant/turn-context`. The surfaces package build passes.
- Cloud/Sage can switch to this helper after this package is released and their `@agent-assistant/surfaces` dependency is bumped; importing it before publication would make those PRs fail against the current registry version.