### PR TITLE
Add synthesis spec: superior assistant architecture from OpenClaw + Hermes comparison

### DIFF
--- a/docs/architecture/openkaren-spec.md
+++ b/docs/architecture/openkaren-spec.md
@@ -1,6 +1,6 @@
 # Spec: OpenKaren — Token-Conscious Proactive Agent Assistant
 
-**Date:** 2026-05-16  
+**Date:** 2026-05-17  
 **Status:** Proposal  
 **Governing rule:** Every token costs money. Every action should be necessary. Identity is portable. Learning is gated.
 
@@ -58,15 +58,31 @@ OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SD
 │                      │       └─────────────────────────────────────────┘
 │  relaycron           │
 │  (scheduling)        │
-└──────────────────────┘
+└──────────┬───────────┘
+           │  ↕ bidirectional bridge
+┌──────────▼──────────────────────────────────────────────────────────┐
+│              RELAY ↔ N8N AUTOMATION BRIDGE                           │
+│                                                                      │
+│  n8n-nodes-relayfile   ← relayfile events → n8n workflow triggers   │
+│  (Trigger + Action nodes; polls VFS; fires on create/update/delete) │
+│                                                                      │
+│  relaycast-n8n-bridge  ← relaycast channel msgs → n8n webhooks      │
+│  (glob pattern routing; agent findings → Slack/Jira/PagerDuty)      │
+└──────────┬───────────────────────────────────────────────────────────┘
            │
 ┌──────────▼──────────────────────────────────────────────────────────┐
-│                  COORDINATION & WORKFLOWS                            │
+│                  N8N AUTOMATION LAYER (self-hosted)                  │
+│                                                                      │
+│  n8n    ← receives from bridge; sends back to Karen's inbox          │
+│  workflows: Stripe alerts, calendar prep, GA4 summaries, etc.        │
+└──────────┬───────────────────────────────────────────────────────────┘
+           │
+┌──────────▼──────────────────────────────────────────────────────────┐
+│                  COORDINATION & SPECIALISTS                          │
 │                                                                      │
 │  Sage    ← planning assistant (deep research, architecture)          │
 │  Ricky   ← workflow reliability (debug, repair, restart)             │
 │  Agent Relay ← multi-agent fabric                                    │
-│  n8n     ← automation workflows (self-hosted)                        │
 │  workforce personas ← Karen + specialist persona definitions         │
 └─────────────────────────────────────────────────────────────────────┘
            │
@@ -76,7 +92,6 @@ OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SD
 │  Nango      ← OAuth management (hosted; no local option)            │
 │  Composio   ← tool/integration platform (hosted)                    │
 │  Pipedream  ← workflow automation (hosted)                           │
-│  n8n        ← self-hosted automation alternative                    │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -318,7 +333,9 @@ const delegation = await coordination.delegate({
 | tilth | Yes | Rust binary + MCP server |
 | tokensave | Yes | MCP server + libSQL |
 | workshop (raindrop) | Yes | TypeScript daemon + Vite UI, localhost:5899 |
-| n8n | Yes | Self-hosted automation |
+| n8n | Yes | Self-hosted automation, port 5678 |
+| n8n-nodes-relayfile | Yes | npm package installed in n8n instance |
+| relaycast-n8n-bridge | Yes | TypeScript daemon; Docker or bare Node |
 | Telegram (polling mode) | Yes | No webhook required locally |
 | workforce personas | Yes | JSON config files |
 
@@ -484,32 +501,133 @@ Marketing angle: *"Karen doesn't just cost $75/month. She pays for part of herse
 
 ```
 - relayfile workspace (pre-provisioned)
-- relaycast channels (karen-main, karen-proactive, karen-coordination)
+- relaycast channels (karen-main, karen-proactive, karen-coordination, karen-findings/*)
 - relaycron schedules (daily standup, weekly review)
 - burn stamping (automatic for all sessions)
 - rtk bash hook (automatic in harness tool wrapper)
 - tilth MCP server (auto-started with Karen runtime)
 - tokensave semantic index (auto-built on first integration sync)
 - workflow personas (sage, ricky pre-registered in relaycast)
+- n8n-nodes-relayfile installed in n8n instance
+- relaycast-n8n-bridge running as daemon with default glob routes
+- n8n base workflows (severity router, inbox forwarder, Notion writeback)
 ```
 
 ---
 
-## 9. n8n Integration
+## 9. n8n Integration — Bidirectional Automation Mesh
 
-n8n runs self-hosted on the Mac mini. It bridges Karen with automations that don't have native relayfile/relaycast support:
+The relay ↔ n8n integration is fully bidirectional through two dedicated bridge packages. This is not a simple "n8n can call Karen" setup — it is an automation mesh where relayfile events and relaycast agent messages both flow into n8n, and n8n flows back into Karen.
+
+### 9.1 relayfile → n8n: `n8n-nodes-relayfile`
+
+[`AgentWorkforce/n8n-nodes-relayfile`] is a community n8n node package with three node types:
+
+**Relayfile Trigger Node** — polls a relayfile workspace for new filesystem events and emits them as n8n workflow triggers:
 
 ```
-n8n workflow examples:
-  - "When Stripe payment > $1000 → notify Karen → Karen surfaces to user"
-  - "When AWS billing alert fires → Karen investigates and reports"
-  - "When calendar event in 1 hour → Karen sends prep brief via Telegram"
-  - "Daily: fetch analytics from GA4 → Karen summarizes trends"
+Config:
+  Workspace ID: rw_karen_main
+  Event Types:  created, updated, deleted
+  Provider:     linear, github, notion
+  Poll Interval: 30s
+
+Output per event:
+  eventId, type, path, revision, provider, correlationId, timestamp, nextCursor
 ```
 
-n8n's webhook nodes POST to Karen's `@agent-assistant/inbox`:
+This means n8n workflows can fire directly from relayfile events — without Karen needing to be in the loop for every event. Routine notifications (issue assigned → Slack DM, PR merged → update project tracker) run entirely in n8n automation.
+
+**Relayfile Action Node** — seven operations Karen (or n8n) can invoke against the VFS:
+- `Read File`, `Write File`, `Query Files`, `List Tree`
+- `Bulk Write` — batch writeback for multiple integration updates
+- `Get Events` — retrieve event history for a path
+- `Export Workspace` — full workspace snapshot
+
+**Relayfile Ops Node** — monitors the writeback pipeline:
+- `List Operations`, `Get Operation`, `Replay Operation`
+- Useful for n8n error-handling flows when writeback to Linear/GitHub fails
+
+Example n8n workflow using the trigger:
+```
+[Relayfile Trigger: /github/repos/*/pulls CREATED]
+  → [IF: pr.assignee == context.userId]
+    → [HTTP: POST to Karen's inbox → Karen investigates]
+  → [ELSE]
+    → [Slack: notify team channel directly]
+```
+
+This offloads high-volume routing decisions from Karen to n8n, preserving Karen's token budget for decisions that actually need intelligence.
+
+### 9.2 relaycast → n8n: `relaycast-n8n-bridge`
+
+[`AgentWorkforce/relaycast-n8n-bridge`] runs as a lightweight daemon that subscribes to relaycast channels and forwards agent messages to n8n webhook URLs with exponential backoff retry.
+
+**How it works:**
+
+```
+Karen/Sage/Ricky post a finding to a relaycast channel
+  → bridge subscribes via glob pattern (e.g., "karen-findings/*")
+  → 100ms queue batching to prevent webhook floods
+  → HTTP POST to matched n8n webhook URL
+  → retry on failure: 3 attempts, exponential backoff
+```
+
+**Message shape forwarded to n8n:**
+
+```json
+{
+  "channel": "karen-findings/ricky-debug",
+  "messageId": "msg_abc123",
+  "sender": "ricky",
+  "timestamp": "2026-05-17T09:14:00Z",
+  "content": "...",
+  "metadata": {
+    "prNumber": 42,
+    "filePaths": ["src/policy/index.ts"],
+    "severity": "high",
+    "agentRole": "workflow-debugger",
+    "agentId": "ricky-v1"
+  },
+  "bridge": {
+    "bridgeId": "openkaren-bridge",
+    "routeRef": "ricky-findings",
+    "processedAt": "2026-05-17T09:14:00Z"
+  }
+}
+```
+
+**n8n routing by severity:**
+
+```
+[Webhook Trigger: relaycast-bridge POST]
+  → [Switch on $json.metadata.severity]
+    → "critical" → [PagerDuty: open incident]
+    → "high"     → [Slack: #incidents DM + Telegram to user]
+    → "medium"   → [Jira: create ticket]
+    → "low"      → [Slack: #general summary]
+```
+
+**Health endpoint:** `GET /health` exposes message counters, retry metrics, and per-route stats — feeds into the burn dashboard for operational visibility.
+
+**Glob pattern routing config:**
+
+```json
+{
+  "routes": [
+    { "pattern": "karen-findings/*",    "webhook": "http://n8n:5678/webhook/karen-findings" },
+    { "pattern": "ricky-debug/*",       "webhook": "http://n8n:5678/webhook/ricky-findings" },
+    { "pattern": "sage-plans/*",        "webhook": "http://n8n:5678/webhook/sage-output" },
+    { "pattern": "karen-proactive/*",   "webhook": "http://n8n:5678/webhook/proactive-surface" }
+  ]
+}
+```
+
+### 9.3 n8n → Karen: Inbox Surface
+
+n8n's outbound flows POST back to Karen's `@agent-assistant/inbox` for anything that needs intelligence, not just routing:
+
 ```typescript
-// Karen's inbox handler for n8n events
 inbox.register({
   source: 'n8n',
   handler: async (event) => {
@@ -521,6 +639,48 @@ inbox.register({
     await karen.proactiveReply(projection);
   },
 });
+```
+
+Example flows that need Karen's intelligence (not just n8n routing):
+- `"AWS billing alert fired → Karen investigates root cause, not just notifies"`
+- `"Calendar event in 1 hour → Karen assembles context-aware prep brief"`
+- `"GA4 daily summary → Karen synthesizes trends and flags anomalies"`
+
+### 9.4 Full Event Flow Examples
+
+**Scenario A: Linear issue assigned (routine — Karen not involved)**
+```
+Linear webhook → Nango → relayfile VFS update (/linear/issues/AGE-42)
+  → n8n-nodes-relayfile Trigger fires
+  → n8n IF: not assigned to user → Slack #team notification
+  (Karen's budget untouched)
+```
+
+**Scenario B: GitHub PR opened on critical path (Karen involved)**
+```
+GitHub webhook → Nango → relayfile VFS update (/github/pulls/99)
+  → n8n-nodes-relayfile Trigger fires
+  → n8n IF: pr.base == 'main' && labels include 'critical'
+  → POST to Karen's inbox
+  → Karen reviews PR, surfaces blockers to user via Telegram
+```
+
+**Scenario C: Ricky finds a bug overnight (agent finding → downstream)**
+```
+Ricky posts finding to relaycast: "karen-findings/ricky-debug"
+  → relaycast-n8n-bridge picks up (glob match)
+  → metadata.severity == "high"
+  → n8n: Slack #incidents + Telegram DM to user + Jira ticket created
+  (Karen wakes up to a morning summary, Jira already filed)
+```
+
+**Scenario D: Sage completes a plan (structured output → downstream)**
+```
+Sage posts plan to relaycast: "sage-plans/architecture-review"
+  → relaycast-n8n-bridge picks up
+  → n8n: writes plan to Notion via relayfile Action Node
+  → n8n: Slack notification to team
+  → n8n: POSTs summary to Karen's inbox → Karen surfaces to user
 ```
 
 ---
@@ -546,7 +706,7 @@ inbox.register({
 | **Policy governance** | Yes — @agent-assistant/policy | Ad hoc config | No |
 | **Voice integration** | No (v1) | Yes (macOS/iOS) | No |
 | **Canvas** | No (v1) | Yes (A2UI) | No |
-| **n8n integration** | Yes | No | No |
+| **n8n bidirectional mesh** | Yes — relayfile→n8n + relaycast→n8n + n8n→Karen | No | No |
 | **Nango OAuth** | Yes | Manual channel config | No |
 | **Fully local option** | Yes (Mac mini) | Yes | Yes |
 | **Self-hosted** | Yes | Yes | Yes |
@@ -640,13 +800,19 @@ Combined with proactive behavior (Karen watches your integrations and surfaces w
 - [ ] Wire Ricky's workflow monitoring to relaycron health-check schedule
 - [ ] Integration test: complex planning request → delegation to Sage → synthesis → delivery
 
-### Phase 4: Integration Plane (Week 5–6)
+### Phase 4: Relay ↔ n8n Automation Mesh (Week 5–6)
 
+- [ ] Install `n8n-nodes-relayfile` package in self-hosted n8n instance
+- [ ] Configure Relayfile Trigger Node: watch `/linear/issues`, `/github/repos/*/pulls`, `/notion/pages`
+- [ ] Build n8n routing workflows: severity-based Switch → Slack / Jira / Karen inbox
+- [ ] Stand up `relaycast-n8n-bridge` daemon with glob routes for `karen-findings/*`, `ricky-debug/*`, `sage-plans/*`
 - [ ] Configure Nango for OAuth management (Linear, GitHub, Notion, Slack)
 - [ ] Wire Composio tools through `@agent-assistant/inbox`
 - [ ] Wire Pipedream webhooks through `@agent-assistant/inbox`
-- [ ] Install n8n self-hosted + configure webhook delivery to Karen's inbox
-- [ ] Integration test: n8n calendar trigger → Karen prep brief → Telegram delivery
+- [ ] Integration test A: Linear issue created → relayfile event → n8n trigger → Slack (Karen budget untouched)
+- [ ] Integration test B: Ricky finding → relaycast → bridge → n8n → PagerDuty + Jira + Telegram
+- [ ] Integration test C: n8n calendar trigger → Karen inbox → prep brief → Telegram delivery
+- [ ] Integration test D: Sage plan → relaycast → bridge → n8n → Notion write via Relayfile Action Node
 
 ### Phase 5: BYOK + Subscription (Week 6–7)
 
@@ -667,6 +833,7 @@ Combined with proactive behavior (Karen watches your integrations and surfaces w
 | relaycast local | 7528 | Agent messaging daemon |
 | workshop | 5899 | Trace dashboard UI |
 | n8n | 5678 | Automation UI |
+| relaycast-n8n-bridge | 3721 | Bridge daemon + /health endpoint |
 | tokensave MCP | stdio | MCP server via subprocess |
 | tilth MCP | stdio | MCP server via subprocess |
 | Cloudflare Tunnel | — | Routes external webhooks to localhost |

--- a/docs/architecture/openkaren-spec.md
+++ b/docs/architecture/openkaren-spec.md
@@ -15,7 +15,13 @@ OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SD
 3. **Multi-surface with session bridging** — Karen is reachable on Telegram and Slack simultaneously; conversations bridge seamlessly across surfaces so context is never lost when the user switches channels
 4. **Durable, consistent state** — all state (Nango OAuth connections, sessions, messages, workflow state, budget, memory) lives in Cloudflare Durable Objects — strongly consistent, survives restarts, accessible from both the Mac mini runtime and any Cloudflare edge worker
 
-**Pricing:** $75/month hosted. Primary compute on a Mac mini. State in Cloudflare Durable Objects. Reachable via Telegram and Slack.
+**Pricing:** $75/month hosted. Reachable via Telegram and Slack.
+
+**Two deployment modes:**
+- **Mac mini mode** — compute on your Mac mini; state in Cloudflare DOs. Local-first for users who want code tooling (rtk, tilth, tokensave) and self-hosted automation (n8n).
+- **Cloud-only mode** — compute in Cloudflare Workers; state in Cloudflare DOs. No Mac mini required. Suitable for productivity-focused use (conversation, integration watches, delegation) without local tooling.
+
+Both modes share the same DO state layer. Graduating from Mac mini to cloud-only requires no data migration.
 
 **Tagline:** *"Your assistant that watches your integrations, surfaces what matters, never burns your budget, and follows you wherever you work."*
 
@@ -821,6 +827,113 @@ Single Slack connection → surfaces for conversation + VFS for data + bridge fo
 | Sage (cloud mode) | Yes | If using hosted Sage |
 | Agent Relay (cloud) | Yes | If using hosted multi-agent fabric |
 
+### Cloud-Only Mode (Cloudflare Workers + DO)
+
+When the Mac mini isn't needed or wanted, OpenKaren runs entirely in Cloudflare. Because all authoritative state was always in Durable Objects, this is purely a compute migration — zero data movement.
+
+**What changes in cloud-only mode:**
+
+| Component | Mac Mini Mode | Cloud-Only Mode |
+|---|---|---|
+| Karen runtime | Mac mini process | Cloudflare Worker |
+| Telegram | Polling (`getUpdates`) | Webhook (Worker has native public URL) |
+| Slack events | Cloudflare Tunnel → localhost | Native webhook URL (no tunnel) |
+| relayfile | Self-hosted docker-compose, port 9090 | Hosted SaaS |
+| relaycast | Local daemon, 127.0.0.1:7528 | Hosted api.relaycast.dev |
+| relaycron | Local Node.js + SQLite, port 4007 | DO Alarms (already the scheduling authority) |
+| n8n | Self-hosted, port 5678 | Hosted n8n Cloud or Pipedream |
+| relaycast-n8n-bridge | Local daemon, port 3721 | Cloudflare Worker or Pipedream step |
+| burn attribution | `~/.agentworkforce/burn/` SQLite | DO `budget` table (already authoritative) |
+| rtk | Local Rust binary (bash hook) | Not applicable — no shell execution in Workers |
+| tilth | Local Rust MCP server | Not applicable — no local filesystem to navigate |
+| tokensave | Local MCP server + index | Not applicable — no local codebase index |
+| workshop dashboard | localhost:5899 | Not applicable — removed or replaced with DO-native observability |
+| Cloudflare Tunnel | Required for external webhooks | Not needed — Worker URL is public |
+
+**What stays identical in cloud-only mode:**
+
+| Component | Notes |
+|---|---|
+| KarenUserDO | Unchanged — was always the authoritative state |
+| DO Alarms | Primary scheduler in cloud-only; was secondary to relaycron in Mac mini mode |
+| R2, KV | Unchanged |
+| Nango OAuth | Unchanged — tokens stored in DO, webhook updates DO |
+| Composio, Pipedream | Unchanged — already hosted |
+| Cross-surface session bridging | Unchanged — `bridge_session_id` in DO |
+| Budget gate enforcement | Unchanged — DO single-writer, no race conditions |
+| Multi-agent coordination | Unchanged — relaycast channels, same delegation model |
+| Karen persona JSON | Unchanged — `karen.persona.json` from workforce repo |
+
+**Token consciousness in cloud-only mode:**
+
+rtk, tilth, and tokensave depend on local bash execution and filesystem access. In Cloudflare Workers neither is available:
+
+- **rtk**: Removed — Workers don't execute shell commands
+- **tilth**: Removed — no local codebase to navigate
+- **tokensave**: Removed — no local index to maintain
+
+This means cloud-only OpenKaren trades the local compression stack for zero-ops hosting. The tradeoff is appropriate for users running Karen as a productivity assistant (conversation, integration watches, delegation to Sage/Ricky) rather than a coding assistant.
+
+Budget gating, routing tier downgrade (opus → sonnet → haiku), and spend reporting via `/spend`/`/forecast` remain fully intact — those are DO-based and don't depend on local tools.
+
+**Karen Worker deployment:**
+
+```typescript
+// workers/karen/src/index.ts
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const router = createKarenRouter(env);
+
+    // Telegram webhook (replaces Mac mini polling)
+    if (request.url.includes('/webhook/telegram')) {
+      return router.handleTelegram(request);
+    }
+
+    // Slack events (no tunnel needed — Worker URL is public)
+    if (request.url.includes('/webhook/slack')) {
+      return router.handleSlack(request);
+    }
+
+    // Nango webhook → upsert DO connection
+    if (request.url.includes('/webhook/nango')) {
+      return router.handleNango(request);
+    }
+
+    // n8n / Pipedream → Karen inbox
+    if (request.url.includes('/inbox')) {
+      return router.handleInbox(request);
+    }
+
+    return new Response('Not Found', { status: 404 });
+  },
+};
+
+function createKarenRouter(env: Env) {
+  // KarenDOClient still the same — Worker calls DO directly, no HTTP proxy needed
+  const doId = env.KAREN_DO.idFromName(env.USER_ID);
+  const doStub = env.KAREN_DO.get(doId);
+
+  return createAssistant({
+    id: 'karen',
+    traits: karenTraits,
+    stateStore: new KarenDOClient({ stub: doStub }),
+    surfaces: [
+      createTelegramSurface({
+        token: env.TELEGRAM_TOKEN,
+        mode: 'webhook',  // cloud-only: webhook, not polling
+      }),
+      createSlackSurface({
+        token: await doStub.getNangoConnection('slack'),
+        signingSecret: env.SLACK_SIGNING_SECRET,
+        replyMode: 'thread',
+      }),
+    ],
+    // Token consciousness tools removed — no shell/filesystem in Workers
+    // Budget gating, routing, spend reporting: unchanged
+  });
+}
+```
+
 ### Relaycast Webhook Decision
 
 The user correctly noted: *"Relaycast? No, not if want webhooks."*
@@ -838,6 +951,37 @@ cloudflared tunnel create openkaren
 cloudflared tunnel route dns openkaren karen.yourdomain.com
 cloudflared tunnel run --url http://localhost:7528 openkaren
 ```
+
+### Graduation Path: Mac Mini → Cloud-Only
+
+Because DO was the authoritative state store from day one, graduating from Mac mini to cloud-only is a compute swap, not a migration:
+
+```
+1. Deploy Karen Worker to Cloudflare
+   wrangler deploy workers/karen
+
+2. Switch Telegram from polling → webhook
+   POST https://api.telegram.org/bot<token>/setWebhook
+     {"url": "https://karen.yourdomain.workers.dev/webhook/telegram"}
+
+3. Update Slack app: change Event Subscriptions URL
+   https://karen.yourdomain.workers.dev/webhook/slack
+   (remove Cloudflare Tunnel from Mac mini)
+
+4. Switch relayfile to hosted SaaS
+   Update RELAYFILE_URL in Worker env
+
+5. Switch relaycast to hosted
+   Update RELAYCAST_URL to api.relaycast.dev
+
+6. Switch n8n to hosted n8n Cloud or Pipedream
+   Update webhook destinations in existing n8n workflows
+
+7. Decommission Mac mini processes
+   (relaycron, relaycast daemon, workshop, rtk hook, n8n local instance)
+```
+
+State after graduation: **unchanged**. KarenUserDO has the complete history — sessions, messages, memory, proactive workflow state, Nango connections, and full budget history. Nothing is lost.
 
 ---
 
@@ -1199,8 +1343,9 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 | **Durable state / crash recovery** | Yes — Cloudflare DO; 30-day PITR | File re-read | suspend_session |
 | **Budget gate consistency** | Yes — DO single-writer; no race conditions | None | None |
 | **Cross-session search** | Yes — FTS5 in DO | None | FTS5 local SQLite |
-| **Fully local option** | Yes (Mac mini) | Yes | Yes |
-| **Self-hosted** | Yes | Yes | Yes |
+| **Fully local option** | Yes (Mac mini mode) | Yes | Yes |
+| **Fully cloud option** | Yes (Workers + DO; no Mac mini required) | No | No |
+| **Self-hosted** | Yes (Mac mini mode) | Yes | Yes |
 | **Telegram** | Yes | Yes | Yes |
 | **Trace dashboard** | Yes — workshop | No | No |
 | **Spend dashboard** | Yes — burn + rtk + tilth | No | No |
@@ -1326,6 +1471,25 @@ Combined with proactive behavior (Karen watches your integrations and surfaces w
 - [ ] Add subscription check to session start policy gate
 - [ ] Build spend summary dashboard (burn + rtk + tilth metrics combined)
 - [ ] Integration test: full monthly budget cycle with spend reporting
+
+### Phase 6: Cloud-Only Mode (Optional Graduation)
+
+*Can be done at any point after Phase 0. No data migration required.*
+
+- [ ] Create `workers/karen` Cloudflare Worker project
+- [ ] Wire Telegram webhook handler (replace Mac mini polling)
+- [ ] Wire Slack events webhook handler (replace Cloudflare Tunnel)
+- [ ] Wire Nango webhook handler (already handled in Phase 0 DO upsert)
+- [ ] Wire Karen inbox handler for Pipedream / hosted n8n
+- [ ] Remove rtk, tilth, tokensave from cloud persona config (not applicable in Workers)
+- [ ] Switch relayfile from docker-compose to hosted SaaS URL
+- [ ] Switch relaycast from local daemon to `api.relaycast.dev`
+- [ ] Configure hosted n8n Cloud or Pipedream to replace local n8n + relaycast-n8n-bridge
+- [ ] Deploy `relaycast-n8n-bridge` as a Cloudflare Worker (if not using Pipedream)
+- [ ] Integration test: full turn from Telegram webhook → Karen Worker → DO → response delivery
+- [ ] Integration test: DO Alarm fires proactive workflow → Telegram delivery (relaycron removed)
+- [ ] Integration test: cross-surface session bridge still intact after Mac mini removed
+- [ ] Verify `/spend` and `/forecast` still accurate (DO budget table only; burn.sqlite gone)
 
 ---
 

--- a/docs/architecture/openkaren-spec.md
+++ b/docs/architecture/openkaren-spec.md
@@ -8,14 +8,15 @@
 
 ## 1. What OpenKaren Is
 
-OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SDK, designed specifically around two properties that neither OpenClaw nor Hermes Agent has:
+OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SDK, designed around three properties that neither OpenClaw nor Hermes Agent has:
 
 1. **Token consciousness** — the assistant knows exactly what it costs to run, surfaces that cost to the user, and actively minimizes unnecessary spend through compression, smart routing, and budget-gated policy
 2. **Proactive by default** — the assistant acts ahead of the user via scheduled triggers (relaycron), integration watches (relayfile), and multi-agent delegation — not just in response to messages
+3. **Multi-surface with session bridging** — Karen is reachable on Telegram and Slack simultaneously; conversations bridge seamlessly across surfaces so context is never lost when the user switches channels
 
-**Pricing:** $75/month hosted. Runs on a Mac mini. Reachable primarily via Telegram.
+**Pricing:** $75/month hosted. Runs on a Mac mini. Reachable via Telegram and Slack.
 
-**Tagline:** *"Your assistant that watches your integrations, surfaces what matters, and never burns your budget."*
+**Tagline:** *"Your assistant that watches your integrations, surfaces what matters, never burns your budget, and follows you wherever you work."*
 
 ---
 
@@ -25,8 +26,13 @@ OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SD
 ┌─────────────────────────────────────────────────────────────────────┐
 │                        USER LAYER                                    │
 │                                                                      │
-│   Telegram ─────────────────────────────────────────────────────    │
-│   (primary surface; polling mode for local; webhook for hosted)     │
+│   Telegram ──────────────────────────────────────────────────────   │
+│   (polling mode local; webhook hosted)                              │
+│                                                                      │
+│   Slack ─────────────────────────────────────────────────────────   │
+│   (OAuth via Nango; bot token; thread-native replies)               │
+│                                                                      │
+│   ← sessions package bridges conversations across both surfaces →   │
 └──────────────────────────────┬──────────────────────────────────────┘
                                │
 ┌──────────────────────────────▼──────────────────────────────────────┐
@@ -34,7 +40,7 @@ OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SD
 │                                                                      │
 │  @agent-assistant/core          ← OpenKaren assistant definition     │
 │  @agent-assistant/sessions      ← cross-surface session continuity   │
-│  @agent-assistant/surfaces      ← Telegram + relaycast surfaces      │
+│  @agent-assistant/surfaces      ← Telegram + Slack + relaycast       │
 │  @agent-assistant/traits        ← OpenKaren identity floor           │
 │  @agent-assistant/turn-context  ← token-aware context assembly       │
 │  @agent-assistant/policy        ← BYOK budget gates + approvals      │
@@ -318,7 +324,120 @@ const delegation = await coordination.delegate({
 
 ---
 
-## 5. Local vs Hosted Breakdown
+## 5. Multi-Surface Support and Session Bridging
+
+### 5.1 Surfaces: Telegram + Slack
+
+Karen runs two surfaces simultaneously via `@agent-assistant/surfaces`. Slack is already partially implemented in the SDK (Slack progress stream helpers, Slack thread gate tests pass in CI). Nango manages the Slack OAuth token — no manual bot configuration required during onboarding.
+
+```typescript
+const runtime = createAssistant({
+  id: 'karen',
+  traits: karenTraits,
+  surfaces: [
+    createTelegramSurface({
+      token: relay.byok('telegram'),
+      mode: 'polling',          // local Mac mini; no webhook needed
+    }),
+    createSlackSurface({
+      token: nango.getToken('slack-bot'),   // Nango manages OAuth lifecycle
+      signingSecret: relay.byok('slack-signing'),
+      replyMode: 'thread',      // always reply in-thread, not channel
+      allowChannels: ['#karen', '#general'],
+      dmPolicy: 'open',         // DMs always accepted
+    }),
+  ],
+});
+```
+
+**What Nango handles for Slack:**
+- Initial OAuth flow (user authorizes Karen's Slack app)
+- Bot token storage and refresh
+- Workspace-level token isolation per user
+- Token rotation without Karen's runtime restarting
+
+### 5.2 Cross-Surface Session Bridging
+
+`@agent-assistant/sessions` provides cross-surface session continuity — the same session can be active on multiple surfaces simultaneously. Karen uses this to bridge conversations:
+
+```
+User messages Karen on Telegram at 9am → session S1 starts
+User DMs Karen on Slack at 11am → sessions package attaches to S1
+  - Karen recognizes the same user
+  - Full conversation context from Telegram is available
+  - Reply goes to Slack; future Telegram messages still reference same session
+```
+
+Session affinity rules in Karen's persona:
+```typescript
+const sessionConfig = {
+  // Same user on different surfaces → same session
+  crossSurfaceAffinity: 'user-identity',
+
+  // How long before surfaces lose affinity and start fresh sessions
+  surfaceAffinityTtl: '4h',
+
+  // Which surface gets proactive messages when multiple are active
+  proactiveSurfacePreference: 'most-recent-active',
+};
+```
+
+### 5.3 Surface Routing Rules
+
+Not every message goes to every surface. Karen applies routing rules at delivery time:
+
+| Message Type | Telegram | Slack | Logic |
+|---|---|---|---|
+| User-initiated reply | ✓ | ✓ | Reply on the surface where the message arrived |
+| Proactive (low urgency) | ✓ | — | Primary surface only (default: Telegram) |
+| Proactive (high urgency) | ✓ | ✓ | Both surfaces — don't miss it |
+| `/spend` report | ✓ | ✓ | Both, so user sees it wherever they are |
+| Ricky finding (critical) | ✓ | ✓ | Both + Slack #incidents channel |
+| Sage plan complete | — | ✓ | Slack preferred for long-form structured output |
+| Daily standup | ✓ | — | Telegram only — personal, not team-facing |
+
+```typescript
+// In proactive engine delivery config
+const deliveryRules: SurfaceDeliveryRule[] = [
+  { when: { urgency: 'critical' },            surfaces: ['telegram', 'slack'] },
+  { when: { type: 'spend-report' },           surfaces: ['telegram', 'slack'] },
+  { when: { type: 'structured-plan' },        surfaces: ['slack'] },
+  { when: { type: 'daily-standup' },          surfaces: ['telegram'] },
+  { when: { urgency: 'low' },                 surfaces: ['most-recent-active'] },
+];
+```
+
+### 5.4 Slack Thread Context as Turn Enrichment
+
+Slack threads carry rich context Karen can read. When a user invokes Karen inside a Slack thread (e.g., `@Karen can you summarize this?`), the surfaces package captures the thread history and feeds it into `@agent-assistant/turn-context` as enrichment — Karen responds with full awareness of the thread without the user having to re-explain.
+
+```typescript
+// Surfaces package thread enrichment (already implemented for Slack progress streams)
+createSlackSurface({
+  threadContextDepth: 20,      // include up to 20 prior thread messages
+  threadContextAsEnrichment: true,  // fed into turn-context, not system prompt
+});
+```
+
+This is the integration point where Nango's Slack token and relayfile's Slack provider converge: relayfile can watch Slack channels for new messages that reference specific topics (e.g., `mention:incident`), while the surfaces package handles direct Karen interactions inside threads.
+
+### 5.5 Nango as the OAuth Foundation for All Surfaces
+
+Nango manages OAuth for both Slack (surface) and relayfile's Slack provider (VFS integration). This avoids two separate auth flows for the same workspace:
+
+```
+User connects Slack once (Nango OAuth flow)
+  → Nango stores bot token + user token
+  → Karen's Slack surface reads bot token from Nango
+  → relayfile's Slack adapter reads user token from Nango
+  → relaycast-n8n-bridge posts to Slack via the same token
+```
+
+Single Slack connection → surfaces for conversation + VFS for data + bridge for agent findings.
+
+---
+
+## 6. Local vs Hosted Breakdown
 
 ### What Runs on the Mac Mini (Fully Local)
 
@@ -337,6 +456,7 @@ const delegation = await coordination.delegate({
 | n8n-nodes-relayfile | Yes | npm package installed in n8n instance |
 | relaycast-n8n-bridge | Yes | TypeScript daemon; Docker or bare Node |
 | Telegram (polling mode) | Yes | No webhook required locally |
+| Slack surface | Partial | Bot runs locally; Slack events require public URL (Cloudflare Tunnel) |
 | workforce personas | Yes | JSON config files |
 
 ### What Requires Cloud (Cannot Run Fully Local)
@@ -370,7 +490,7 @@ cloudflared tunnel run --url http://localhost:7528 openkaren
 
 ---
 
-## 6. Workforce Persona: Karen
+## 7. Workforce Persona: Karen
 
 [`AgentWorkforce/workforce`] defines Karen as a deployable persona JSON:
 
@@ -446,7 +566,13 @@ cloudflared tunnel run --url http://localhost:7528 openkaren
     "tokensave": { "enabled": true, "mcpServer": true }
   },
 
-  "surfaces": ["telegram"],
+  "surfaces": ["telegram", "slack"],
+  "surfaceBridging": {
+    "crossSurfaceAffinity": "user-identity",
+    "surfaceAffinityTtl": "4h",
+    "proactiveSurfacePreference": "most-recent-active",
+    "urgentDelivery": "all-surfaces"
+  },
   "sandbox": { "mode": "none" },
   "subscription": { "tier": "byok", "billing": "relay-byok" }
 }
@@ -454,7 +580,7 @@ cloudflared tunnel run --url http://localhost:7528 openkaren
 
 ---
 
-## 7. BYOK Subscription Model
+## 8. BYOK Subscription Model
 
 Users bring their own API keys (Anthropic, OpenAI, etc.) via Relay's BYOK infrastructure. OpenKaren charges $75/month for the platform, not for model tokens.
 
@@ -479,22 +605,31 @@ Marketing angle: *"Karen doesn't just cost $75/month. She pays for part of herse
 
 ---
 
-## 8. Integration Setup (What Gets Configured)
+## 9. Integration Setup (What Gets Configured)
 
 ### What the User Sets Up (Guided Onboarding)
 
 ```
-1. Nango → OAuth for Linear, GitHub, Notion, Slack, HubSpot, Salesforce
-   (Nango manages OAuth tokens; relayfile uses them for VFS sync)
+1. Nango → Slack OAuth (single flow; covers all three Slack uses)
+   - Karen's Slack surface bot token (for conversation surface)
+   - relayfile's Slack provider token (for VFS sync of Slack messages)
+   - relaycast-n8n-bridge posting token (for agent findings → Slack)
+   One connection. Three consumers. Nango handles refresh.
 
-2. Composio → additional tool integrations
+2. Nango → OAuth for remaining integrations: Linear, GitHub, Notion,
+   HubSpot, Salesforce
+   (relayfile uses these for VFS sync; n8n-nodes-relayfile Trigger reads
+   the same workspace)
+
+3. Composio → additional tool integrations
    (composio tools surface through @agent-assistant/inbox)
 
-3. Pipedream → automation workflows that trigger Karen
+4. Pipedream → automation workflows that trigger Karen
    (webhook delivery to Karen's inbox surface)
 
-4. n8n → self-hosted automations connecting internal tools
-   (HTTP webhooks to Karen's inbox)
+5. n8n → self-hosted automations connecting internal tools
+   (HTTP webhooks to Karen's inbox; relayfile Trigger Node already
+   wired; relaycast-n8n-bridge already wired)
 ```
 
 ### What the Platform Pre-Wires (No User Config)
@@ -515,7 +650,7 @@ Marketing angle: *"Karen doesn't just cost $75/month. She pays for part of herse
 
 ---
 
-## 9. n8n Integration — Bidirectional Automation Mesh
+## 10. n8n Integration — Bidirectional Automation Mesh
 
 The relay ↔ n8n integration is fully bidirectional through two dedicated bridge packages. This is not a simple "n8n can call Karen" setup — it is an automation mesh where relayfile events and relaycast agent messages both flow into n8n, and n8n flows back into Karen.
 
@@ -685,7 +820,7 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 
 ---
 
-## 10. Comparison: OpenKaren vs OpenClaw vs Hermes Agent
+## 11. Comparison: OpenKaren vs OpenClaw vs Hermes Agent
 
 ### Feature Matrix
 
@@ -707,7 +842,9 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 | **Voice integration** | No (v1) | Yes (macOS/iOS) | No |
 | **Canvas** | No (v1) | Yes (A2UI) | No |
 | **n8n bidirectional mesh** | Yes — relayfile→n8n + relaycast→n8n + n8n→Karen | No | No |
-| **Nango OAuth** | Yes | Manual channel config | No |
+| **Slack surface** | Yes — native via agent-assistant/surfaces + Nango | Yes (daemon) | Yes (gateway) |
+| **Cross-surface session bridge** | Yes — sessions package; Telegram ↔ Slack continuity | No | No |
+| **Nango OAuth** | Yes — single flow covers surface + VFS + bridge | Manual channel config | No |
 | **Fully local option** | Yes (Mac mini) | Yes | Yes |
 | **Self-hosted** | Yes | Yes | Yes |
 | **Telegram** | Yes | Yes | Yes |
@@ -722,7 +859,8 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 - relayfile SaaS VFS — OpenClaw has no structured integration filesystem
 - Multi-agent delegation via relaycast — OpenClaw has session spawning but no specialist fabric
 - TypeScript SDK — OpenClaw is a daemon, not an embeddable library
-- n8n and Nango integration — OpenClaw handles channels manually
+- Cross-surface session bridging — OpenClaw routes channels to agents but doesn't bridge session context across surfaces
+- Nango single OAuth covers surface + VFS + bridge — OpenClaw requires manual channel configuration per platform
 
 **vs Hermes Agent:**
 - Token consciousness — Hermes has no burn, rtk, tilth, or tokensave equivalent
@@ -746,7 +884,7 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 
 ---
 
-## 11. What Makes OpenKaren the Right Product
+## 12. What Makes OpenKaren the Right Product
 
 Neither OpenClaw nor Hermes tries to own the cost conversation. Both assume tokens are essentially free — OpenClaw because it's local-first and focused on privacy, Hermes because it's research-focused and optimizing for capability.
 
@@ -761,7 +899,7 @@ Combined with proactive behavior (Karen watches your integrations and surfaces w
 
 ---
 
-## 12. Implementation Roadmap
+## 13. Implementation Roadmap
 
 ### Phase 0: Mac Mini Runtime (Week 1–2)
 
@@ -773,7 +911,10 @@ Combined with proactive behavior (Karen watches your integrations and surfaces w
 - [ ] Install tokensave MCP server + index relayfile workspace
 - [ ] Install workshop for local trace dashboard
 - [ ] Configure Telegram surface (polling mode, no webhook required)
-- [ ] Cloudflare Tunnel for external webhook reception (n8n, Pipedream, Nango)
+- [ ] Cloudflare Tunnel for external webhook reception (Slack events, Nango, Pipedream)
+- [ ] Configure Nango Slack OAuth flow (single flow covers surface + relayfile + bridge)
+- [ ] Configure Slack surface with thread-reply mode and channel allowlist
+- [ ] Verify cross-surface session bridging: message on Telegram, continue on Slack
 
 ### Phase 1: Karen Persona + Token Consciousness (Week 2–3)
 

--- a/docs/architecture/openkaren-spec.md
+++ b/docs/architecture/openkaren-spec.md
@@ -1,0 +1,699 @@
+# Spec: OpenKaren — Token-Conscious Proactive Agent Assistant
+
+**Date:** 2026-05-16  
+**Status:** Proposal  
+**Governing rule:** Every token costs money. Every action should be necessary. Identity is portable. Learning is gated.
+
+---
+
+## 1. What OpenKaren Is
+
+OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SDK, designed specifically around two properties that neither OpenClaw nor Hermes Agent has:
+
+1. **Token consciousness** — the assistant knows exactly what it costs to run, surfaces that cost to the user, and actively minimizes unnecessary spend through compression, smart routing, and budget-gated policy
+2. **Proactive by default** — the assistant acts ahead of the user via scheduled triggers (relaycron), integration watches (relayfile), and multi-agent delegation — not just in response to messages
+
+**Pricing:** $75/month hosted. Runs on a Mac mini. Reachable primarily via Telegram.
+
+**Tagline:** *"Your assistant that watches your integrations, surfaces what matters, and never burns your budget."*
+
+---
+
+## 2. The Full Component Stack
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        USER LAYER                                    │
+│                                                                      │
+│   Telegram ─────────────────────────────────────────────────────    │
+│   (primary surface; polling mode for local; webhook for hosted)     │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │
+┌──────────────────────────────▼──────────────────────────────────────┐
+│                    OPENKAREN RUNTIME (agent-assistant SDK)           │
+│                                                                      │
+│  @agent-assistant/core          ← OpenKaren assistant definition     │
+│  @agent-assistant/sessions      ← cross-surface session continuity   │
+│  @agent-assistant/surfaces      ← Telegram + relaycast surfaces      │
+│  @agent-assistant/traits        ← OpenKaren identity floor           │
+│  @agent-assistant/turn-context  ← token-aware context assembly       │
+│  @agent-assistant/policy        ← BYOK budget gates + approvals      │
+│  @agent-assistant/routing       ← budget-aware model selection       │
+│  @agent-assistant/harness       ← bounded turn execution             │
+│  @agent-assistant/memory        ← session history + user modeling    │
+│  @agent-assistant/proactive     ← watch rules + scheduled follow-ups │
+│  @agent-assistant/inbox         ← Nango/Composio/Pipedream ingress   │
+│  @agent-assistant/continuation  ← resumable unfinished turns         │
+│  @agent-assistant/coordination  ← delegation to Sage, Ricky         │
+└──────────┬─────────────────────────────────┬────────────────────────┘
+           │                                 │
+┌──────────▼──────────┐       ┌─────────────▼──────────────────────────┐
+│   RELAY FABRIC       │       │       TOKEN CONSCIOUSNESS LAYER         │
+│                      │       │                                         │
+│  relayfile           │       │  burn    ← spend attribution + budget  │
+│  (SaaS VFS)          │       │  rtk     ← command output compression  │
+│                      │       │  tilth   ← structural code navigation  │
+│  relaycast           │       │  tokensave ← semantic graph queries    │
+│  (agent messaging)   │       │  workshop  ← trace viewer + evals      │
+│                      │       └─────────────────────────────────────────┘
+│  relaycron           │
+│  (scheduling)        │
+└──────────────────────┘
+           │
+┌──────────▼──────────────────────────────────────────────────────────┐
+│                  COORDINATION & WORKFLOWS                            │
+│                                                                      │
+│  Sage    ← planning assistant (deep research, architecture)          │
+│  Ricky   ← workflow reliability (debug, repair, restart)             │
+│  Agent Relay ← multi-agent fabric                                    │
+│  n8n     ← automation workflows (self-hosted)                        │
+│  workforce personas ← Karen + specialist persona definitions         │
+└─────────────────────────────────────────────────────────────────────┘
+           │
+┌──────────▼──────────────────────────────────────────────────────────┐
+│                  INTEGRATION PLANE                                   │
+│                                                                      │
+│  Nango      ← OAuth management (hosted; no local option)            │
+│  Composio   ← tool/integration platform (hosted)                    │
+│  Pipedream  ← workflow automation (hosted)                           │
+│  n8n        ← self-hosted automation alternative                    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Token Consciousness — The Core Differentiator
+
+This is what neither OpenClaw nor Hermes has. OpenKaren is the only assistant that treats token spend as a first-class runtime concern.
+
+### 3.1 The Four Token-Saving Layers
+
+**Layer 1: Burn — Attribution and Budget Gates**
+
+[`AgentWorkforce/burn`] is the financial ledger for all token activity. Every OpenKaren session is stamped at launch:
+
+```typescript
+// Burn stamping in session start hook
+await burn.stamp(sessionId, {
+  persona: 'karen',
+  userId: context.userId,
+  workflowId: context.workflowId,
+  tier: 'hosted-$75',
+});
+```
+
+Budget gate in `@agent-assistant/policy`:
+```typescript
+// Pre-turn policy check
+const monthlySpend = await burn.getMonthlySpend(userId);
+const budget = 75.00; // USD
+const remainingRatio = (budget - monthlySpend) / budget;
+
+if (remainingRatio < 0.1) {
+  return { outcome: 'deny', reason: 'monthly-budget-exhausted' };
+}
+if (remainingRatio < 0.25) {
+  return { outcome: 'route-downgrade', targetTier: 'economy' };
+}
+```
+
+Budget-aware routing in `@agent-assistant/routing`:
+```typescript
+// If >75% of budget spent, route to cheaper model
+const tier = policy.getRoutingTier(userId);  // 'premium' | 'standard' | 'economy'
+const model = {
+  premium:  'claude-opus-4-7',    // deep planning, complex reasoning
+  standard: 'claude-sonnet-4-6',  // most turns
+  economy:  'claude-haiku-4-5',   // budget-near-exhausted turns
+}[tier];
+```
+
+Burn metrics surfaced to user via Telegram on demand:
+```
+/spend → "This month: $31.42 / $75. Top cost: workflow debugging (42%), Linear watches (28%)"
+/forecast → "At current rate you'll reach budget in 18 days."
+```
+
+**Layer 2: RTK — Command Output Compression (60–90% reduction)**
+
+[`rtk-ai/rtk`] is a Rust binary that intercepts shell commands and compresses output before it enters the context window. Used by OpenKaren for all tool-bearing turns:
+
+- `git status` → compressed diff summary (not full output)
+- `npm test` → failures only, not full test runner output  
+- `docker ps` → filtered container listing
+- `ls -la` → grouped file listing
+
+RTK integrates as a bash hook — no code changes required. All tool-bearing harness turns go through the RTK proxy:
+
+```typescript
+// In OpenKaren's harness configuration
+const harness = createHarness({
+  toolWrapper: rtkProxy,  // wrap all tool executions through rtk
+  ...harnessConfig,
+});
+```
+
+Expected savings: 60–90% reduction on bash/tool outputs.
+
+**Layer 3: Tilth — Structural Code Navigation (40% reduction)**
+
+[`jahala/tilth`] is a Rust MCP server using tree-sitter for AST-based code navigation. Instead of reading full files, Karen navigates code structurally:
+
+- `tilth src/policy/index.ts` → structural outline (not full file content)
+- `tilth createAssistant --scope src/` → symbol definition + context (not grep over all files)
+- Line-range drill-down only on the specific section needed
+
+Integrated as an MCP server in Karen's harness tool surface:
+```json
+{
+  "mcpServers": {
+    "tilth": { "command": "tilth", "args": ["--mcp"] }
+  }
+}
+```
+
+Expected savings: ~40% average across file navigation operations. Accuracy improves from 76% → 86% (less irrelevant context confusing reasoning).
+
+**Layer 4: TokenSave — Semantic Graph Queries (93% reduction on retrieval)**
+
+[`aovestdipaperino/tokensave`] builds a pre-indexed semantic knowledge graph of connected codebases. Instead of scanning files for symbol lookups:
+
+- `tokensave.callers("createAssistant")` → instant caller list, no file scan
+- `tokensave.impact("@agent-assistant/policy")` → dependency impact graph
+- `tokensave.search("budget gate")` → FTS5 semantic search returning only matching symbols
+
+Expected savings: 93% mean retrieval savings across codebase queries. A 15,475-token raw query drops to 460 tokens.
+
+Integrated as an MCP server alongside tilth:
+```json
+{
+  "mcpServers": {
+    "tokensave": { "command": "tokensave-server", "args": ["--workspace", "/workspace"] }
+  }
+}
+```
+
+### 3.2 Token Budget Dashboard
+
+**Workshop** [`raindrop-ai/workshop`] provides real-time trace visualization — every token, tool call, and span as Karen executes. Runs locally on `localhost:5899` against `~/.raindrop/raindrop_workshop.db`.
+
+**RTK gain** shows command-level savings: per-command reduction percentages, 30-day savings, adoption rates.
+
+**Burn dashboard** surfaces: spend by persona, spend by workflow, spend by session, cache hit rates, overhead attribution.
+
+**Tilth + TokenSave** report per-call token metrics showing exact savings per invocation — this feeds into burn's overhead attribution model.
+
+Together these form the token consciousness dashboard: a unified view of where every dollar is going, which workflows are expensive, and what the model forecast is for the rest of the month.
+
+---
+
+## 4. Proactive Architecture
+
+OpenKaren is proactive by default, not reactive. The three trigger mechanisms:
+
+### 4.1 Scheduled Triggers (relaycron)
+
+[`AgentWorkforce/relaycron`] — Node.js + SQLite scheduler, fully local, WebSocket delivery.
+
+```typescript
+// Karen's default proactive schedule
+await relaycron.schedule({
+  name: 'daily-standup',
+  cron: '0 9 * * 1-5',  // 9am weekdays
+  tz: 'America/New_York',
+  deliver: { via: 'websocket', channel: 'karen-proactive' },
+});
+
+await relaycron.schedule({
+  name: 'weekly-spend-review',
+  cron: '0 17 * * 5',   // Friday 5pm
+  tz: 'America/New_York',
+  deliver: { via: 'websocket', channel: 'karen-proactive' },
+});
+```
+
+Each scheduled event fires the proactive engine in `@agent-assistant/proactive`, which:
+1. Assembles turn-context from current memory + relayfile state
+2. Routes through budget-aware model selection
+3. Delivers to Telegram surface
+
+### 4.2 Integration Watches (relayfile)
+
+[`AgentWorkforce/relayfile`] exposes SaaS integrations as a VFS. Karen watches for changes:
+
+```typescript
+// Watch rules in @agent-assistant/proactive
+const watches = [
+  {
+    path: '/linear/issues',
+    event: 'created',
+    trigger: async (file) => await karen.proactiveReply({
+      text: `New issue assigned: ${file.title}. Want me to investigate?`,
+    }),
+  },
+  {
+    path: '/github/repos/*/pulls',
+    event: 'opened',
+    trigger: async (file) => await karen.proactiveReply({
+      text: `PR opened: ${file.title}. Checking for blocking issues...`,
+    }),
+  },
+  {
+    path: '/notion/pages',
+    event: 'updated',
+    filter: (file) => file.assignee === context.userId,
+    trigger: async (file) => await karen.proactiveReply({
+      text: `Page updated: ${file.title}`,
+    }),
+  },
+];
+```
+
+relayfile write-through invalidation means Karen sees integration changes within ~500ms.
+
+### 4.3 Multi-Agent Coordination (relaycast + Agent Relay)
+
+[`AgentWorkforce/relaycast`] is "Headless Slack for AI agents" — Karen delegates to specialists via relaycast channels:
+
+```
+User asks Karen complex architecture question
+  → Karen routes to Sage via relaycast (planning + deep research)
+  → Sage responds with structured plan
+  → Karen synthesizes and delivers to user via Telegram
+
+Workflow breaks overnight
+  → relaycron fires Karen's monitoring tick
+  → Karen detects failure via relayfile (GitHub Actions watch)
+  → Karen delegates to Ricky via relaycast
+  → Ricky debugs, repairs, restarts
+  → Karen reports outcome to user next morning
+```
+
+Delegation uses `@agent-assistant/coordination` specialist model:
+```typescript
+// Karen delegates to Sage for planning tasks
+const delegation = await coordination.delegate({
+  to: 'sage',
+  via: relaycast,
+  input: { type: 'planning', userRequest: turn.message },
+  timeout: 120_000,
+  onResult: (memo) => karen.synthesize(memo),
+});
+```
+
+---
+
+## 5. Local vs Hosted Breakdown
+
+### What Runs on the Mac Mini (Fully Local)
+
+| Component | Local? | Notes |
+|---|---|---|
+| `agent-assistant` SDK | Yes | TypeScript runtime |
+| relayfile server | Yes | Go server + docker-compose |
+| relaycron | Yes | Node.js + SQLite, port 4007 |
+| relaycast local daemon | Yes | Rust daemon, 127.0.0.1:7528 |
+| burn | Yes | SQLite at `~/.agentworkforce/burn/` |
+| rtk | Yes | Single Rust binary, bash hook |
+| tilth | Yes | Rust binary + MCP server |
+| tokensave | Yes | MCP server + libSQL |
+| workshop (raindrop) | Yes | TypeScript daemon + Vite UI, localhost:5899 |
+| n8n | Yes | Self-hosted automation |
+| Telegram (polling mode) | Yes | No webhook required locally |
+| workforce personas | Yes | JSON config files |
+
+### What Requires Cloud (Cannot Run Fully Local)
+
+| Component | Cloud Required? | Why |
+|---|---|---|
+| relaycast (webhooks) | Partial | External webhook triggers require public URL; local daemon works for agent-to-agent messaging; Telegram inbound works via polling |
+| Nango | Yes | OAuth management is their hosted service |
+| Composio | Yes | Integration platform is hosted |
+| Pipedream | Yes | Workflow automation is hosted |
+| Sage (cloud mode) | Yes | If using hosted Sage |
+| Agent Relay (cloud) | Yes | If using hosted multi-agent fabric |
+
+### Relaycast Webhook Decision
+
+The user correctly noted: *"Relaycast? No, not if want webhooks."*
+
+For OpenKaren on a Mac mini:
+- **Agent-to-agent messaging** (Karen ↔ Sage ↔ Ricky): relaycast local daemon — fully local, no webhooks needed
+- **Telegram inbound**: use polling mode (`getUpdates`) — no webhook required
+- **External webhooks** (Nango, Composio, Pipedream, n8n): require hosted relaycast or a tunnel (ngrok/Cloudflare Tunnel) for the Mac mini to receive external HTTP
+
+**Recommended local webhook solution:** Cloudflare Tunnel (free tier) pointing at the Mac mini's relaycast port. This keeps the Mac mini running fully locally while receiving external webhook deliveries without port-forwarding or static IP.
+
+```bash
+# One-time setup
+cloudflared tunnel create openkaren
+cloudflared tunnel route dns openkaren karen.yourdomain.com
+cloudflared tunnel run --url http://localhost:7528 openkaren
+```
+
+---
+
+## 6. Workforce Persona: Karen
+
+[`AgentWorkforce/workforce`] defines Karen as a deployable persona JSON:
+
+```json
+{
+  "id": "karen",
+  "name": "OpenKaren",
+  "version": "1.0.0",
+  "description": "Token-conscious proactive personal assistant",
+  "intent": "Proactively surface what matters, minimize token spend, delegate complexity",
+
+  "traits": {
+    "voice": "direct",
+    "formality": "casual-professional",
+    "proactivity": "high",
+    "riskPosture": "moderate",
+    "domain": "general"
+  },
+
+  "executionTiers": [
+    {
+      "name": "premium",
+      "harness": "built-in",
+      "model": "claude-opus-4-7",
+      "condition": "budget.remainingRatio > 0.75 && task.complexity == 'high'"
+    },
+    {
+      "name": "standard",
+      "harness": "built-in",
+      "model": "claude-sonnet-4-6",
+      "condition": "budget.remainingRatio > 0.25"
+    },
+    {
+      "name": "economy",
+      "harness": "built-in",
+      "model": "claude-haiku-4-5",
+      "condition": "budget.remainingRatio <= 0.25"
+    }
+  ],
+
+  "integrations": {
+    "relayfile": {
+      "providers": ["linear", "github", "notion", "slack"],
+      "watches": ["issues/created", "pulls/opened", "pages/updated"]
+    },
+    "relaycast": {
+      "specialists": ["sage", "ricky"]
+    },
+    "relaycron": {
+      "schedules": ["daily-standup", "weekly-spend-review", "workflow-health-check"]
+    },
+    "inbox": {
+      "sources": ["nango", "composio", "pipedream", "n8n"]
+    }
+  },
+
+  "permissions": {
+    "allow": ["read", "write", "bash", "relayfile/*", "relaycast/send"],
+    "requireApproval": ["delete", "deploy", "spend > 5.00"],
+    "deny": ["admin", "billing-modify"]
+  },
+
+  "memory": {
+    "scope": "user",
+    "ttl": "90d",
+    "include": ["preferences", "workflow-history", "spend-patterns"]
+  },
+
+  "tokenConsciousness": {
+    "burn": { "enabled": true, "budgetUSD": 75.00 },
+    "rtk": { "enabled": true, "wrapAllBashTools": true },
+    "tilth": { "enabled": true, "mcpServer": true },
+    "tokensave": { "enabled": true, "mcpServer": true }
+  },
+
+  "surfaces": ["telegram"],
+  "sandbox": { "mode": "none" },
+  "subscription": { "tier": "byok", "billing": "relay-byok" }
+}
+```
+
+---
+
+## 7. BYOK Subscription Model
+
+Users bring their own API keys (Anthropic, OpenAI, etc.) via Relay's BYOK infrastructure. OpenKaren charges $75/month for the platform, not for model tokens.
+
+```
+$75/month covers:
+  - Karen runtime (agent-assistant SDK hosting)
+  - relayfile SaaS VFS (integration syncs)
+  - relaycast (agent messaging fabric)
+  - relaycron (scheduling)
+  - burn dashboard
+  - Setup assistance for Nango, Composio, Pipedream
+
+User pays separately:
+  - Anthropic API tokens (BYOK via Relay)
+  - Nango subscription (if needed)
+  - Composio plan (if needed)
+```
+
+Token consciousness tooling (rtk, tilth, tokensave) directly reduces the user's Anthropic API bill — this is a concrete selling point. A user spending $50/month on raw Claude API calls might save $20–40/month through Karen's compression layers.
+
+Marketing angle: *"Karen doesn't just cost $75/month. She pays for part of herself through token savings."*
+
+---
+
+## 8. Integration Setup (What Gets Configured)
+
+### What the User Sets Up (Guided Onboarding)
+
+```
+1. Nango → OAuth for Linear, GitHub, Notion, Slack, HubSpot, Salesforce
+   (Nango manages OAuth tokens; relayfile uses them for VFS sync)
+
+2. Composio → additional tool integrations
+   (composio tools surface through @agent-assistant/inbox)
+
+3. Pipedream → automation workflows that trigger Karen
+   (webhook delivery to Karen's inbox surface)
+
+4. n8n → self-hosted automations connecting internal tools
+   (HTTP webhooks to Karen's inbox)
+```
+
+### What the Platform Pre-Wires (No User Config)
+
+```
+- relayfile workspace (pre-provisioned)
+- relaycast channels (karen-main, karen-proactive, karen-coordination)
+- relaycron schedules (daily standup, weekly review)
+- burn stamping (automatic for all sessions)
+- rtk bash hook (automatic in harness tool wrapper)
+- tilth MCP server (auto-started with Karen runtime)
+- tokensave semantic index (auto-built on first integration sync)
+- workflow personas (sage, ricky pre-registered in relaycast)
+```
+
+---
+
+## 9. n8n Integration
+
+n8n runs self-hosted on the Mac mini. It bridges Karen with automations that don't have native relayfile/relaycast support:
+
+```
+n8n workflow examples:
+  - "When Stripe payment > $1000 → notify Karen → Karen surfaces to user"
+  - "When AWS billing alert fires → Karen investigates and reports"
+  - "When calendar event in 1 hour → Karen sends prep brief via Telegram"
+  - "Daily: fetch analytics from GA4 → Karen summarizes trends"
+```
+
+n8n's webhook nodes POST to Karen's `@agent-assistant/inbox`:
+```typescript
+// Karen's inbox handler for n8n events
+inbox.register({
+  source: 'n8n',
+  handler: async (event) => {
+    const projection = await inbox.project({
+      type: 'external-trigger',
+      payload: event,
+      surfaceId: 'telegram-primary',
+    });
+    await karen.proactiveReply(projection);
+  },
+});
+```
+
+---
+
+## 10. Comparison: OpenKaren vs OpenClaw vs Hermes Agent
+
+### Feature Matrix
+
+| Property | OpenKaren | OpenClaw | Hermes Agent |
+|---|---|---|---|
+| **Token spend tracking** | Yes — burn attribution, budget gates, model downgrade | No | No |
+| **Command compression** | Yes — rtk (60–90%) | No | No |
+| **Structural code nav** | Yes — tilth (-40%) | No | No |
+| **Semantic graph queries** | Yes — tokensave (93%) | No | No |
+| **Budget-aware routing** | Yes — policy → routing tier | No | No |
+| **Proactive scheduling** | Yes — relaycron | Partial — cron tool | No |
+| **SaaS integration VFS** | Yes — relayfile | No | No |
+| **Multi-agent delegation** | Yes — Sage, Ricky via relaycast | No | Subagent RPC |
+| **Persistent learning** | Planned — skills package | Static SKILL.md | Yes (ungated) |
+| **BYOH execution** | Yes — execution-adapter | No | Yes (7 backends) |
+| **TypeScript SDK** | Yes | Partial | No (Python) |
+| **Formal capability negotiation** | Yes — negotiate() | No | No |
+| **Policy governance** | Yes — @agent-assistant/policy | Ad hoc config | No |
+| **Voice integration** | No (v1) | Yes (macOS/iOS) | No |
+| **Canvas** | No (v1) | Yes (A2UI) | No |
+| **n8n integration** | Yes | No | No |
+| **Nango OAuth** | Yes | Manual channel config | No |
+| **Fully local option** | Yes (Mac mini) | Yes | Yes |
+| **Self-hosted** | Yes | Yes | Yes |
+| **Telegram** | Yes | Yes | Yes |
+| **Trace dashboard** | Yes — workshop | No | No |
+| **Spend dashboard** | Yes — burn + rtk + tilth | No | No |
+
+### Where OpenKaren Wins
+
+**vs OpenClaw:**
+- Token consciousness end-to-end (burn + rtk + tilth + tokensave) — OpenClaw has no awareness of spend
+- Budget-gated routing — OpenClaw can't downgrade model based on budget
+- relayfile SaaS VFS — OpenClaw has no structured integration filesystem
+- Multi-agent delegation via relaycast — OpenClaw has session spawning but no specialist fabric
+- TypeScript SDK — OpenClaw is a daemon, not an embeddable library
+- n8n and Nango integration — OpenClaw handles channels manually
+
+**vs Hermes Agent:**
+- Token consciousness — Hermes has no burn, rtk, tilth, or tokensave equivalent
+- Policy-gated budget enforcement — Hermes has no policy layer
+- relayfile integration VFS — Hermes has tools, not a filesystem abstraction
+- TypeScript purity — Hermes is 88% Python; Karen is TypeScript-native
+- Formal capability negotiation — Hermes picks backends but doesn't negotiate capabilities
+- Identity portable across execution backends — Hermes has no identity primitive above the harness
+
+### Where OpenKaren Doesn't Win (Yet)
+
+**vs OpenClaw:**
+- Voice wake words — OpenClaw has native macOS/iOS voice; Karen v1 is text-only
+- Canvas — OpenClaw has A2UI visual workspace; Karen v1 has none
+- 20+ platform channels — OpenClaw integrates Discord, Signal, iMessage; Karen v1 is Telegram only
+
+**vs Hermes:**
+- Persistent learning loop — Hermes has autonomous skill creation; Karen's skills package is v2
+- More execution backends — Hermes has 7 backends; Karen v1 ships BuiltIn + Claude API adapters
+- Research infrastructure — Hermes has `trajectory_compressor.py` for training; Karen's trajectory → skill pipeline is v2
+
+---
+
+## 11. What Makes OpenKaren the Right Product
+
+Neither OpenClaw nor Hermes tries to own the cost conversation. Both assume tokens are essentially free — OpenClaw because it's local-first and focused on privacy, Hermes because it's research-focused and optimizing for capability.
+
+OpenKaren's bet is different: **the user paying $75/month cares deeply about what that $75 gets them.** They want to know their burn rate. They want to know Karen is not wasting tokens on bloated command output. They want the model to downgrade gracefully rather than surprise them with a $200 API bill.
+
+Token consciousness is not a feature. It is the product philosophy.
+
+Combined with proactive behavior (Karen watches your integrations and surfaces what matters before you ask), this creates an assistant that is:
+- **Cheaper to run** than an unoptimized Claude API setup
+- **More useful** than a reactive assistant
+- **More trustworthy** than an autonomous agent with no budget governance
+
+---
+
+## 12. Implementation Roadmap
+
+### Phase 0: Mac Mini Runtime (Week 1–2)
+
+- [ ] Bootstrap `agent-assistant` SDK on Mac mini
+- [ ] Stand up relayfile with docker-compose (Linear + GitHub providers)
+- [ ] Configure relaycron with daily standup + weekly review schedules
+- [ ] Install rtk Rust binary + configure bash hook
+- [ ] Install tilth Rust binary + configure MCP server
+- [ ] Install tokensave MCP server + index relayfile workspace
+- [ ] Install workshop for local trace dashboard
+- [ ] Configure Telegram surface (polling mode, no webhook required)
+- [ ] Cloudflare Tunnel for external webhook reception (n8n, Pipedream, Nango)
+
+### Phase 1: Karen Persona + Token Consciousness (Week 2–3)
+
+- [ ] Define `karen.persona.json` in workforce repo
+- [ ] Wire burn stamping into Karen session start
+- [ ] Add budget gate to `@agent-assistant/policy` (deny at 100%, downgrade at 75%)
+- [ ] Add budget-aware routing tiers (opus → sonnet → haiku) to `@agent-assistant/routing`
+- [ ] Wire rtk as tool wrapper in harness configuration
+- [ ] Add `/spend` and `/forecast` Telegram commands
+- [ ] Integration test: full turn with burn attribution + rtk compression
+
+### Phase 2: Proactive Watches (Week 3–4)
+
+- [ ] Wire relayfile watches for Linear issues, GitHub PRs, Notion pages
+- [ ] Connect relaycron ticks to proactive engine in `@agent-assistant/proactive`
+- [ ] Configure Telegram delivery for proactive messages
+- [ ] Integration test: Linear issue created → Karen proactive message on Telegram
+
+### Phase 3: Multi-Agent Delegation (Week 4–5)
+
+- [ ] Configure relaycast channels (local daemon)
+- [ ] Register Sage as specialist in `@agent-assistant/coordination`
+- [ ] Register Ricky as specialist in `@agent-assistant/coordination`
+- [ ] Wire Ricky's workflow monitoring to relaycron health-check schedule
+- [ ] Integration test: complex planning request → delegation to Sage → synthesis → delivery
+
+### Phase 4: Integration Plane (Week 5–6)
+
+- [ ] Configure Nango for OAuth management (Linear, GitHub, Notion, Slack)
+- [ ] Wire Composio tools through `@agent-assistant/inbox`
+- [ ] Wire Pipedream webhooks through `@agent-assistant/inbox`
+- [ ] Install n8n self-hosted + configure webhook delivery to Karen's inbox
+- [ ] Integration test: n8n calendar trigger → Karen prep brief → Telegram delivery
+
+### Phase 5: BYOK + Subscription (Week 6–7)
+
+- [ ] Wire Relay BYOK key management for Anthropic API
+- [ ] Add subscription check to session start policy gate
+- [ ] Build spend summary dashboard (burn + rtk + tilth metrics combined)
+- [ ] Integration test: full monthly budget cycle with spend reporting
+
+---
+
+## Appendix A: Local Port Map (Mac Mini)
+
+| Service | Port | Notes |
+|---|---|---|
+| relayfile server | 9090 | Go VFS API |
+| relayauth (dev) | 9091 | Dev token issuer |
+| relaycron | 4007 | Scheduler API |
+| relaycast local | 7528 | Agent messaging daemon |
+| workshop | 5899 | Trace dashboard UI |
+| n8n | 5678 | Automation UI |
+| tokensave MCP | stdio | MCP server via subprocess |
+| tilth MCP | stdio | MCP server via subprocess |
+| Cloudflare Tunnel | — | Routes external webhooks to localhost |
+
+---
+
+## Appendix B: Token Savings Projection
+
+For a user running Karen 8 hours/day on active tasks:
+
+| Layer | Mechanism | Expected Savings |
+|---|---|---|
+| RTK | Command output compression | 60–90% on bash/tool outputs |
+| Tilth | Structural code navigation | ~40% on file reads |
+| TokenSave | Semantic graph queries | ~93% on codebase retrieval |
+| Budget routing | Haiku for simple turns | ~80% cost reduction on downgraded turns |
+| Proactive filtering | Only surface relevant info | Fewer reactive deep turns |
+
+A user paying $50/month in raw Anthropic API costs without Karen might pay $20–30/month with Karen's token consciousness stack active — while getting better coverage through proactive triggers.
+
+---
+
+## Appendix C: Governing Principles
+
+1. **Product identity is canonical.** Karen is Karen regardless of which execution backend is selected.
+2. **Execution harnesses are replaceable.** Opus today, Haiku tomorrow when budget tightens.
+3. **Learning is policy-gated.** No skill promotes without explicit approval.
+4. **Token spend is visible and bounded.** No surprises. Every dollar attributed.
+5. **Proactive beats reactive.** Karen surfaces what matters before being asked.
+6. **Platform reach is surface adapters.** No separate daemon. Telegram is a surfaces implementation.

--- a/docs/architecture/openkaren-spec.md
+++ b/docs/architecture/openkaren-spec.md
@@ -8,13 +8,14 @@
 
 ## 1. What OpenKaren Is
 
-OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SDK, designed around three properties that neither OpenClaw nor Hermes Agent has:
+OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SDK, designed around four properties that neither OpenClaw nor Hermes Agent has:
 
 1. **Token consciousness** — the assistant knows exactly what it costs to run, surfaces that cost to the user, and actively minimizes unnecessary spend through compression, smart routing, and budget-gated policy
-2. **Proactive by default** — the assistant acts ahead of the user via scheduled triggers (relaycron), integration watches (relayfile), and multi-agent delegation — not just in response to messages
+2. **Proactive by default** — the assistant acts ahead of the user via scheduled triggers, integration watches (relayfile), and multi-agent delegation — not just in response to messages
 3. **Multi-surface with session bridging** — Karen is reachable on Telegram and Slack simultaneously; conversations bridge seamlessly across surfaces so context is never lost when the user switches channels
+4. **Durable, consistent state** — all state (Nango OAuth connections, sessions, messages, workflow state, budget, memory) lives in Cloudflare Durable Objects — strongly consistent, survives restarts, accessible from both the Mac mini runtime and any Cloudflare edge worker
 
-**Pricing:** $75/month hosted. Runs on a Mac mini. Reachable via Telegram and Slack.
+**Pricing:** $75/month hosted. Primary compute on a Mac mini. State in Cloudflare Durable Objects. Reachable via Telegram and Slack.
 
 **Tagline:** *"Your assistant that watches your integrations, surfaces what matters, never burns your budget, and follows you wherever you work."*
 
@@ -51,19 +52,36 @@ OpenKaren is a hosted personal agent assistant built on the `agent-assistant` SD
 │  @agent-assistant/inbox         ← Nango/Composio/Pipedream ingress   │
 │  @agent-assistant/continuation  ← resumable unfinished turns         │
 │  @agent-assistant/coordination  ← delegation to Sage, Ricky         │
-└──────────┬─────────────────────────────────┬────────────────────────┘
-           │                                 │
+└──────────┬─────────────────────────────────┴────────────────────────┘
+           │
+┌──────────▼──────────────────────────────────────────────────────────┐
+│          STATE LAYER — Cloudflare Durable Objects                    │
+│                                                                      │
+│  KarenUserDO  (one per user; strongly consistent SQLite per user)   │
+│    nango_connections  ← OAuth tokens, refresh tokens, scopes        │
+│    sessions           ← cross-surface session continuity            │
+│    messages + FTS5    ← full transcript + cross-session recall       │
+│    workflow_state     ← proactive watches, scheduled jobs           │
+│    budget             ← monthly token spend, alert thresholds       │
+│    memory + FTS5      ← persistent facts, preferences, patterns     │
+│                                                                      │
+│  DO Alarms  ← per-user scheduling (hosted; replaces relaycron)     │
+│  R2         ← trajectory files, skill artifacts, large blobs       │
+│  KV         ← routing config, feature flags                        │
+└──────────┬───────────────────────────────────────────────────────────┘
+           │
 ┌──────────▼──────────┐       ┌─────────────▼──────────────────────────┐
 │   RELAY FABRIC       │       │       TOKEN CONSCIOUSNESS LAYER         │
 │                      │       │                                         │
-│  relayfile           │       │  burn    ← spend attribution + budget  │
+│  relayfile           │       │  burn    ← local session attribution   │
 │  (SaaS VFS)          │       │  rtk     ← command output compression  │
 │                      │       │  tilth   ← structural code navigation  │
 │  relaycast           │       │  tokensave ← semantic graph queries    │
 │  (agent messaging)   │       │  workshop  ← trace viewer + evals      │
 │                      │       └─────────────────────────────────────────┘
 │  relaycron           │
-│  (scheduling)        │
+│  (local scheduling;  │
+│   DO Alarms hosted)  │
 └──────────┬───────────┘
            │  ↕ bidirectional bridge
 ┌──────────▼──────────────────────────────────────────────────────────┐
@@ -324,7 +342,337 @@ const delegation = await coordination.delegate({
 
 ---
 
-## 5. Multi-Surface Support and Session Bridging
+## 5. State Layer — Cloudflare Durable Objects
+
+### 5.1 Why Durable Objects
+
+Neither OpenClaw nor Hermes solves the durable state problem correctly for a hosted, multi-surface proactive assistant:
+
+- **OpenClaw**: files on local disk. Survives as long as the Mac mini does. No cross-process consistency. No query capability.
+- **Hermes**: SQLite on local disk. WAL mode for concurrency within one process. Same durability problem — disk failure or restart loses state.
+
+OpenKaren has state concerns that genuinely cannot live on local disk:
+
+| Concern | Why local disk fails |
+|---|---|
+| Nango OAuth tokens | Security risk; lost on disk failure; inaccessible if compute moves |
+| Cross-surface session bridge | Telegram and Slack surface handlers may run in different processes |
+| Proactive workflow state | A scheduled workflow must survive a Mac mini restart |
+| Budget enforcement | Must be authoritative — two concurrent turns must not both pass a gate that should deny one |
+| Memory across sessions | Must be queryable, not just injected wholesale |
+
+Cloudflare Durable Objects solve all of these:
+- **Strongly consistent**: reads always see the latest write — critical for budget gates where two simultaneous turns must not both pass a $75 ceiling
+- **Durable**: state survives compute restarts; the Mac mini is just a compute client
+- **Per-user isolation**: one DO per user means no cross-user contention
+- **SQLite with FTS5**: full-text search across messages and memory, matching Hermes's capability
+- **Alarm API**: per-user scheduling without relaycron in the hosted path
+- **PITR**: 30-day point-in-time recovery — important for debugging workflow failures
+
+### 5.2 KarenUserDO — One Per User
+
+Each user gets one Durable Object. The DO holds the complete per-user SQLite database.
+
+```typescript
+export class KarenUserDO implements DurableObject {
+  private sql: SqlStorage;
+
+  constructor(private ctx: DurableObjectState, private env: Env) {
+    this.sql = ctx.storage.sql;
+    this.ctx.blockConcurrencyWhile(() => this.migrate());
+  }
+
+  private async migrate() {
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS nango_connections (
+        integration_id     TEXT PRIMARY KEY,
+        connection_id      TEXT NOT NULL,
+        provider_config_key TEXT NOT NULL,
+        expires_at         INTEGER,
+        scopes             TEXT,          -- JSON array
+        metadata           TEXT,          -- JSON blob from Nango
+        last_refresh_at    INTEGER,
+        created_at         INTEGER NOT NULL,
+        updated_at         INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS sessions (
+        id                 TEXT PRIMARY KEY,
+        surface            TEXT NOT NULL,  -- 'telegram' | 'slack' | 'relaycast'
+        surface_channel_id TEXT,
+        bridge_session_id  TEXT,           -- links sessions across surfaces
+        status             TEXT DEFAULT 'active',
+        model              TEXT,
+        routing_tier       TEXT,           -- 'premium' | 'standard' | 'economy'
+        started_at         INTEGER NOT NULL,
+        last_active_at     INTEGER NOT NULL,
+        ended_at           INTEGER,
+        message_count      INTEGER DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS messages (
+        id                 TEXT PRIMARY KEY,
+        session_id         TEXT NOT NULL REFERENCES sessions(id),
+        role               TEXT NOT NULL,  -- 'user' | 'assistant' | 'tool'
+        content            TEXT,
+        tool_calls         TEXT,           -- JSON
+        tool_name          TEXT,
+        input_tokens       INTEGER DEFAULT 0,
+        output_tokens      INTEGER DEFAULT 0,
+        cache_read_tokens  INTEGER DEFAULT 0,
+        timestamp          INTEGER NOT NULL
+      );
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+        content,
+        session_id  UNINDEXED,
+        timestamp   UNINDEXED,
+        tokenize    = 'unicode61'
+      );
+
+      CREATE TABLE IF NOT EXISTS budget (
+        period             TEXT PRIMARY KEY,  -- 'YYYY-MM'
+        input_tokens       INTEGER DEFAULT 0,
+        output_tokens      INTEGER DEFAULT 0,
+        cache_read_tokens  INTEGER DEFAULT 0,
+        estimated_cost_usd REAL DEFAULT 0,
+        budget_usd         REAL DEFAULT 75.0,
+        alert_sent_75_at   INTEGER,
+        alert_sent_90_at   INTEGER,
+        updated_at         INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workflow_state (
+        id           TEXT PRIMARY KEY,
+        type         TEXT NOT NULL,     -- 'watch' | 'scheduled' | 'delegation' | 'continuation'
+        trigger      TEXT,              -- 'relayfile-event' | 'alarm' | 'user-request'
+        status       TEXT DEFAULT 'pending',
+        payload      TEXT,              -- JSON
+        result       TEXT,              -- JSON
+        scheduled_at INTEGER,
+        started_at   INTEGER,
+        completed_at INTEGER,
+        error        TEXT,
+        created_at   INTEGER NOT NULL,
+        updated_at   INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS memory (
+        id                TEXT PRIMARY KEY,
+        type              TEXT NOT NULL,  -- 'preference' | 'fact' | 'workflow-pattern'
+        content           TEXT NOT NULL,
+        source_session_id TEXT,
+        confidence        REAL DEFAULT 1.0,
+        access_count      INTEGER DEFAULT 0,
+        created_at        INTEGER NOT NULL,
+        last_accessed_at  INTEGER
+      );
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+        content,
+        type       UNINDEXED,
+        id         UNINDEXED,
+        tokenize   = 'unicode61'
+      );
+    `);
+  }
+```
+
+### 5.3 DO Alarms for Proactive Scheduling
+
+The DO's alarm API replaces relaycron in the hosted deployment. Each user's proactive schedule is stored in `workflow_state` and the alarm fires at the next due time:
+
+```typescript
+  async alarm() {
+    const now = Date.now();
+
+    // Find all scheduled workflows due now
+    const due = this.sql.exec(`
+      SELECT * FROM workflow_state
+      WHERE status = 'pending'
+        AND type = 'scheduled'
+        AND scheduled_at <= ?
+      ORDER BY scheduled_at ASC
+    `, now).toArray();
+
+    for (const workflow of due) {
+      await this.executeWorkflow(workflow);
+    }
+
+    // Reschedule alarm for next pending workflow
+    const next = this.sql.exec(`
+      SELECT MIN(scheduled_at) as next_at FROM workflow_state
+      WHERE status = 'pending' AND type IN ('scheduled', 'watch')
+    `).one();
+
+    if (next?.next_at) {
+      await this.ctx.storage.setAlarm(next.next_at);
+    }
+  }
+```
+
+Daily standup, weekly spend review, workflow health checks — all stored as `workflow_state` rows, alarm-driven. No separate relaycron process needed in the hosted path.
+
+### 5.4 Budget Gate — Strong Consistency Matters
+
+The budget gate in `@agent-assistant/policy` must be strongly consistent. If two Telegram messages arrive simultaneously and both query `estimated_cost_usd` from a local SQLite, they can both see $74.50 and both pass a $75 gate — resulting in overrun.
+
+With DO, all budget reads and writes are serialized within the DO's single-writer model:
+
+```typescript
+  async checkAndRecordSpend(tokens: TokenUsage): Promise<BudgetDecision> {
+    // DO guarantees this read-modify-write is atomic — no race possible
+    const period = new Date().toISOString().slice(0, 7); // 'YYYY-MM'
+
+    const row = this.sql.exec(`
+      SELECT estimated_cost_usd, budget_usd FROM budget WHERE period = ?
+    `, period).one();
+
+    const current = row?.estimated_cost_usd ?? 0;
+    const limit = row?.budget_usd ?? 75.0;
+    const cost = estimateCost(tokens);
+    const projected = current + cost;
+
+    if (projected > limit) {
+      return { outcome: 'deny', reason: 'budget-exhausted', current, limit };
+    }
+
+    this.sql.exec(`
+      INSERT INTO budget (period, estimated_cost_usd, input_tokens, output_tokens, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(period) DO UPDATE SET
+        estimated_cost_usd = estimated_cost_usd + excluded.estimated_cost_usd,
+        input_tokens = input_tokens + excluded.input_tokens,
+        output_tokens = output_tokens + excluded.output_tokens,
+        updated_at = excluded.updated_at
+    `, period, cost, tokens.input, tokens.output, Date.now());
+
+    const ratio = projected / limit;
+    if (ratio > 0.90) return { outcome: 'allow', tier: 'economy', projected, limit };
+    if (ratio > 0.75) return { outcome: 'allow', tier: 'standard', projected, limit };
+    return { outcome: 'allow', tier: 'premium', projected, limit };
+  }
+```
+
+### 5.5 Nango Connection Storage
+
+Nango OAuth tokens live in the DO, not in environment variables or local files. Karen's runtime fetches them from the DO on each turn that needs a specific integration:
+
+```typescript
+  async getNangoConnection(integrationId: string): Promise<NangoConnection | null> {
+    return this.sql.exec(`
+      SELECT * FROM nango_connections WHERE integration_id = ?
+    `, integrationId).one() ?? null;
+  }
+
+  async upsertNangoConnection(conn: NangoConnection) {
+    this.sql.exec(`
+      INSERT INTO nango_connections
+        (integration_id, connection_id, provider_config_key, expires_at, scopes, metadata, updated_at, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(integration_id) DO UPDATE SET
+        connection_id = excluded.connection_id,
+        expires_at    = excluded.expires_at,
+        metadata      = excluded.metadata,
+        updated_at    = excluded.updated_at
+    `, conn.integrationId, conn.connectionId, conn.providerConfigKey,
+       conn.expiresAt, JSON.stringify(conn.scopes), JSON.stringify(conn.metadata),
+       Date.now(), Date.now());
+  }
+```
+
+When Nango fires a token-refresh webhook, the DO is updated. Karen's runtime never holds a token in memory longer than a single turn.
+
+### 5.6 Cross-Surface Session Bridge
+
+Session bridging across Telegram and Slack requires shared, strongly consistent session state. The DO provides this:
+
+```typescript
+  async getOrCreateBridgeSession(
+    surface: 'telegram' | 'slack',
+    channelId: string,
+    existingBridgeId?: string
+  ): Promise<Session> {
+    // If a bridge ID is provided, find the existing session on this surface
+    if (existingBridgeId) {
+      const existing = this.sql.exec(`
+        SELECT * FROM sessions
+        WHERE bridge_session_id = ? AND surface = ? AND status = 'active'
+      `, existingBridgeId, surface).one();
+      if (existing) return existing;
+    }
+
+    // Create new session, linking to bridge if provided
+    const id = crypto.randomUUID();
+    this.sql.exec(`
+      INSERT INTO sessions (id, surface, surface_channel_id, bridge_session_id,
+        status, started_at, last_active_at)
+      VALUES (?, ?, ?, ?, 'active', ?, ?)
+    `, id, surface, channelId, existingBridgeId ?? id, Date.now(), Date.now());
+
+    return this.sql.exec(`SELECT * FROM sessions WHERE id = ?`, id).one();
+  }
+```
+
+When the user messages Karen on Slack after a Telegram session, the Slack surface handler passes the known `bridge_session_id`, and both surfaces see the same message history.
+
+### 5.7 How the Mac Mini Runtime Connects to DOs
+
+The Mac mini Karen runtime accesses the DO via a thin Cloudflare Worker proxy:
+
+```typescript
+// Karen runtime on Mac mini
+const karenDO = new KarenDOClient({
+  workerUrl: 'https://karen-state.yourdomain.workers.dev',
+  userId: context.userId,
+  authToken: relay.byok('karen-state-token'),
+});
+
+// Used in @agent-assistant/policy budget gate
+const decision = await karenDO.checkAndRecordSpend(tokens);
+
+// Used in @agent-assistant/sessions
+const session = await karenDO.getOrCreateBridgeSession('telegram', chatId);
+
+// Used in @agent-assistant/memory
+const memories = await karenDO.searchMemory(query);
+
+// Used in @agent-assistant/inbox (Nango token fetch)
+const slackToken = await karenDO.getNangoConnection('slack');
+```
+
+The DO worker is a thin HTTP→DO proxy. The Mac mini never stores anything persistent locally except burn.sqlite (which is local attribution for rtk/tilth/workshop tooling only — the authoritative spend record is in the DO).
+
+### 5.8 SDK Package Mapping to DO Implementations
+
+| agent-assistant package | DO implementation |
+|---|---|
+| `@agent-assistant/sessions` | `KarenDOSessionStore` — reads/writes `sessions` + `messages` |
+| `@agent-assistant/memory` | `KarenDOMemoryStore` — reads/writes `memory` + `memory_fts` |
+| `@agent-assistant/policy` (budget gate) | `KarenDOBudgetPolicy` — atomic read-modify-write on `budget` |
+| `@agent-assistant/proactive` (scheduler) | `KarenDOWorkflowStore` — reads/writes `workflow_state`; alarm-driven |
+| `@agent-assistant/inbox` (Nango) | `KarenDONangoAdapter` — reads `nango_connections` |
+| `@agent-assistant/continuation` | Stored in `workflow_state` with `type: 'continuation'` |
+
+### 5.9 Comparison: DO vs Hermes SQLite vs OpenClaw Files
+
+| Concern | Hermes (local SQLite) | OpenClaw (files) | OpenKaren (DO) |
+|---|---|---|---|
+| Transcript storage | SQLite on local disk | JSONL files | DO SQLite |
+| Cross-session search | FTS5 (local) | None | FTS5 (DO) |
+| Nango token storage | N/A | N/A | DO (secure, durable) |
+| Budget gate consistency | Not applicable | Not applicable | Strongly consistent (DO single-writer) |
+| Proactive workflow state | In-memory (lost on restart) | Not applicable | DO workflow_state table |
+| Cross-surface session | Not applicable | Not applicable | DO bridge_session_id |
+| Crash recovery | suspend + mark_resume | Re-read files | DO always consistent |
+| Memory scale ceiling | FTS5, limited to local disk | Context window | FTS5 in DO, Cloudflare-replicated |
+| PITR | None | None | 30-day rollback |
+
+---
+
+## 6. Multi-Surface Support and Session Bridging
+
+> *Session bridging state lives in KarenUserDO (see §5.6). The surfaces layer reads and writes session rows through the DO client; it does not hold session state in memory.*
 
 ### 5.1 Surfaces: Telegram + Slack
 
@@ -437,17 +785,17 @@ Single Slack connection → surfaces for conversation + VFS for data + bridge fo
 
 ---
 
-## 6. Local vs Hosted Breakdown
+## 7. Local vs Hosted Breakdown
 
-### What Runs on the Mac Mini (Fully Local)
+### Compute: Mac Mini (Fully Local)
 
 | Component | Local? | Notes |
 |---|---|---|
 | `agent-assistant` SDK | Yes | TypeScript runtime |
 | relayfile server | Yes | Go server + docker-compose |
-| relaycron | Yes | Node.js + SQLite, port 4007 |
+| relaycron | Yes | Node.js + SQLite, port 4007 (local scheduling; DO Alarms used when hosted) |
 | relaycast local daemon | Yes | Rust daemon, 127.0.0.1:7528 |
-| burn | Yes | SQLite at `~/.agentworkforce/burn/` |
+| burn | Yes | Local attribution only — `~/.agentworkforce/burn/`; authoritative spend in DO |
 | rtk | Yes | Single Rust binary, bash hook |
 | tilth | Yes | Rust binary + MCP server |
 | tokensave | Yes | MCP server + libSQL |
@@ -456,17 +804,20 @@ Single Slack connection → surfaces for conversation + VFS for data + bridge fo
 | n8n-nodes-relayfile | Yes | npm package installed in n8n instance |
 | relaycast-n8n-bridge | Yes | TypeScript daemon; Docker or bare Node |
 | Telegram (polling mode) | Yes | No webhook required locally |
-| Slack surface | Partial | Bot runs locally; Slack events require public URL (Cloudflare Tunnel) |
+| Slack surface | Partial | Bot runs locally; Slack events require Cloudflare Tunnel |
 | workforce personas | Yes | JSON config files |
 
-### What Requires Cloud (Cannot Run Fully Local)
+### State: Cloudflare Durable Objects (Always Cloud)
 
-| Component | Cloud Required? | Why |
+| Component | Cloud Required? | Notes |
 |---|---|---|
-| relaycast (webhooks) | Partial | External webhook triggers require public URL; local daemon works for agent-to-agent messaging; Telegram inbound works via polling |
-| Nango | Yes | OAuth management is their hosted service |
-| Composio | Yes | Integration platform is hosted |
-| Pipedream | Yes | Workflow automation is hosted |
+| **KarenUserDO** | Yes | Nango connections, sessions, messages+FTS5, workflow state, budget, memory+FTS5 |
+| **DO Alarms** | Yes | Per-user proactive scheduling in hosted mode |
+| **R2** | Yes | Trajectory files, skill artifacts, large blobs |
+| **KV** | Yes | Routing config, feature flags |
+| Nango | Yes | OAuth management — token writes trigger DO upsert |
+| Composio | Yes | Integration platform |
+| Pipedream | Yes | Workflow automation |
 | Sage (cloud mode) | Yes | If using hosted Sage |
 | Agent Relay (cloud) | Yes | If using hosted multi-agent fabric |
 
@@ -490,7 +841,7 @@ cloudflared tunnel run --url http://localhost:7528 openkaren
 
 ---
 
-## 7. Workforce Persona: Karen
+## 8. Workforce Persona: Karen
 
 [`AgentWorkforce/workforce`] defines Karen as a deployable persona JSON:
 
@@ -580,7 +931,7 @@ cloudflared tunnel run --url http://localhost:7528 openkaren
 
 ---
 
-## 8. BYOK Subscription Model
+## 9. BYOK Subscription Model
 
 Users bring their own API keys (Anthropic, OpenAI, etc.) via Relay's BYOK infrastructure. OpenKaren charges $75/month for the platform, not for model tokens.
 
@@ -605,7 +956,7 @@ Marketing angle: *"Karen doesn't just cost $75/month. She pays for part of herse
 
 ---
 
-## 9. Integration Setup (What Gets Configured)
+## 10. Integration Setup (What Gets Configured)
 
 ### What the User Sets Up (Guided Onboarding)
 
@@ -650,7 +1001,7 @@ Marketing angle: *"Karen doesn't just cost $75/month. She pays for part of herse
 
 ---
 
-## 10. n8n Integration — Bidirectional Automation Mesh
+## 11. n8n Integration — Bidirectional Automation Mesh
 
 The relay ↔ n8n integration is fully bidirectional through two dedicated bridge packages. This is not a simple "n8n can call Karen" setup — it is an automation mesh where relayfile events and relaycast agent messages both flow into n8n, and n8n flows back into Karen.
 
@@ -820,7 +1171,7 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 
 ---
 
-## 11. Comparison: OpenKaren vs OpenClaw vs Hermes Agent
+## 12. Comparison: OpenKaren vs OpenClaw vs Hermes Agent
 
 ### Feature Matrix
 
@@ -843,8 +1194,11 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 | **Canvas** | No (v1) | Yes (A2UI) | No |
 | **n8n bidirectional mesh** | Yes — relayfile→n8n + relaycast→n8n + n8n→Karen | No | No |
 | **Slack surface** | Yes — native via agent-assistant/surfaces + Nango | Yes (daemon) | Yes (gateway) |
-| **Cross-surface session bridge** | Yes — sessions package; Telegram ↔ Slack continuity | No | No |
-| **Nango OAuth** | Yes — single flow covers surface + VFS + bridge | Manual channel config | No |
+| **Cross-surface session bridge** | Yes — DO bridge_session_id; strongly consistent | No | No |
+| **Nango OAuth** | Yes — stored in DO; single flow covers surface + VFS + bridge | Manual config | No |
+| **Durable state / crash recovery** | Yes — Cloudflare DO; 30-day PITR | File re-read | suspend_session |
+| **Budget gate consistency** | Yes — DO single-writer; no race conditions | None | None |
+| **Cross-session search** | Yes — FTS5 in DO | None | FTS5 local SQLite |
 | **Fully local option** | Yes (Mac mini) | Yes | Yes |
 | **Self-hosted** | Yes | Yes | Yes |
 | **Telegram** | Yes | Yes | Yes |
@@ -884,7 +1238,7 @@ Sage posts plan to relaycast: "sage-plans/architecture-review"
 
 ---
 
-## 12. What Makes OpenKaren the Right Product
+## 13. What Makes OpenKaren the Right Product
 
 Neither OpenClaw nor Hermes tries to own the cost conversation. Both assume tokens are essentially free — OpenClaw because it's local-first and focused on privacy, Hermes because it's research-focused and optimizing for capability.
 
@@ -899,9 +1253,20 @@ Combined with proactive behavior (Karen watches your integrations and surfaces w
 
 ---
 
-## 13. Implementation Roadmap
+## 14. Implementation Roadmap
 
-### Phase 0: Mac Mini Runtime (Week 1–2)
+### Phase 0: Durable State Foundation (Week 1)
+
+- [ ] Create `KarenUserDO` Cloudflare Worker project
+- [ ] Implement full SQLite schema with migrations (`blockConcurrencyWhile`)
+- [ ] Implement HTTP API: `POST /nango-connection`, `GET /nango-connection/:id`, `POST /budget/check-and-record`, `POST /sessions`, `GET /sessions/:bridgeId`, `POST /messages`, `GET /search/messages`, `POST /memory`, `GET /search/memory`, `POST /workflow`, `GET /workflow/due`
+- [ ] Implement DO Alarm handler: query `workflow_state` due items, execute, reschedule
+- [ ] Deploy to Cloudflare Workers with per-user DO routing: `env.KAREN_DO.idFromName(userId)`
+- [ ] Write `KarenDOClient` TypeScript SDK for Mac mini → DO calls
+- [ ] Integration test: concurrent budget check proves no overrun (two simultaneous requests at $74.50)
+- [ ] Wire Nango webhook → DO `upsert_nango_connection`
+
+### Phase 1: Mac Mini Runtime (Week 2–3)
 
 - [ ] Bootstrap `agent-assistant` SDK on Mac mini
 - [ ] Stand up relayfile with docker-compose (Linear + GitHub providers)

--- a/docs/architecture/synthesis-superior-assistant-spec.md
+++ b/docs/architecture/synthesis-superior-assistant-spec.md
@@ -1,0 +1,492 @@
+# Spec: Synthesis Architecture — A Superior Assistant Built on agent-assistant
+
+**Date:** 2026-05-16  
+**Status:** Proposal  
+**Governing rule:** Product identity is canonical. Execution harnesses are replaceable. Learning is policy-gated.
+
+---
+
+## 1. Purpose and Scope
+
+This document synthesizes a deep comparison of three agent frameworks — this repo (`agent-assistant`), OpenClaw (`openclaw/openclaw`), and Hermes Agent (`NousResearch/hermes-agent`) — into a concrete architectural proposal for building a better assistant than any of the three individually.
+
+The proposal is additive. The existing `agent-assistant` primitive decomposition is the correct foundation. No primitives need to be removed or restructured. What is needed is:
+
+1. Completion of the already-specced execution-adapter seam
+2. A new `@agent-assistant/skills` package for policy-gated learning
+3. Dynamic trait overlays in `@agent-assistant/traits`
+4. Surface-adapter implementations for multi-platform gateway (not a daemon)
+5. Unblocking the memory package
+
+---
+
+## 2. Reference Framework Analysis
+
+### 2.1 OpenClaw
+
+**Core model:** Local-first daemon. Single gateway process manages sessions, channels, tools, and events across 20+ messaging platforms.
+
+**Strengths:**
+- Workspace isolation per agent (`~/.openclaw/workspace/`)
+- Multi-channel inbox unified behind one control plane
+- Sandbox security model: tool allowlists per session type (main vs non-main)
+- DM pairing policy for untrusted senders
+- Voice integration (macOS/iOS wake words, Android continuous)
+- Live canvas (A2UI framework)
+- ClawHub skill marketplace
+- Skills-as-filesystem: `~/.openclaw/workspace/skills/<skill>/SKILL.md` injected into prompt via `AGENTS.md`, `SOUL.md`, `TOOLS.md`
+
+**Gaps:**
+- No SDK story — not importable as a library
+- No formal capability negotiation — backend is fixed at runtime
+- No policy package — governance is ad hoc
+- No persistent learning — skills are static `.md` files, no promotion mechanism
+- No execution-adapter seam — permanently coupled to the host model provider
+- Skills have no versioning, approval, or pruning model
+
+**Key patterns to adopt:**
+- Workspace model as a turn-context enrichment source (not as a daemon-level concept)
+- Tool allowlist mapped to `@agent-assistant/policy` allow/deny/approve/escalate
+- Platform integrations as surface adapters, not a parallel runtime
+- Voice and canvas as surface adapters
+
+### 2.2 Hermes Agent
+
+**Core model:** Python-first autonomous agent with a closed learning loop. FTS5 session search, Honcho dialectic user modeling, autonomous skill creation, skill self-improvement during use.
+
+**Strengths:**
+- Skills-as-artifacts following the `agentskills.io` open standard — portable, self-improving, community-shareable
+- 7 execution backends: local, Docker, SSH, Singularity, Modal, Daytona, Vercel Sandbox
+- Serverless hibernation — agents wake on demand
+- `trajectory_compressor.py` — trajectory compression for training data generation
+- Subagent delegation via RPC
+- Unified gateway across Telegram, Discord, Slack, WhatsApp, Signal, Email
+- Honcho dialectic user modeling across sessions
+- FTS5 session search with LLM summarization
+
+**Gaps:**
+- No TypeScript SDK — not embeddable as a library in TypeScript products
+- No formal package contracts or primitive boundaries
+- No capability negotiation — 7 backends but no `negotiate()` contract
+- No governance layer — the learning loop runs without policy gates
+- Skills grow without a pruning, versioning, or approval model
+- No Relay-native fabric equivalent — multi-agent coordination is custom
+- Python-first makes it difficult to embed in web/edge/CF Workers deployments
+
+**Key patterns to adopt:**
+- Skills-as-evolving-artifacts as a `@agent-assistant/skills` package
+- Trajectory-to-skill promotion pipeline (`.trajectories/` already exists in this repo)
+- Honcho-style user modeling as dynamic trait overlays in `@agent-assistant/traits`
+- Multi-backend execution as `ExecutionAdapter` implementations (already specced)
+
+### 2.3 agent-assistant (this repo)
+
+**Core model:** TypeScript SDK monorepo. 16 packages, 566 tests. Explicitly decomposed runtime primitives. Relay-native. BYOH execution-adapter seam specced but not yet shipped.
+
+**Strengths:**
+- Correct primitive decomposition: shell → sessions → surfaces → harness → routing → policy → memory → traits → continuation → inbox → proactive → coordination
+- Governing principle: *"Product identity is canonical. Execution harnesses are replaceable."*
+- Formal capability negotiation specced (negotiate/describeCapabilities)
+- Policy package with allow/deny/approve/escalate classification
+- Cloudflare Workers compatible
+- Trajectory recording infrastructure already in place (`.trajectories/`)
+- BYOH seam architecturally correct and fully specced
+
+**Current gaps:**
+- `@agent-assistant/execution-adapter` not yet shipped (Phase 0–1 of SPEC.md)
+- `@agent-relay/memory` blocker not resolved
+- No skill system — no learning loop
+- No platform gateway surface adapters
+- Traits are static — no dynamic evolution from user modeling
+- No consumer-facing deployment story
+
+---
+
+## 3. What a Superior Architecture Looks Like
+
+The superior assistant combines:
+- **agent-assistant's** formal SDK primitives and governance model as the foundation
+- **OpenClaw's** platform reach and workspace-isolation patterns as surface adapter implementations
+- **Hermes's** persistent learning loop and multi-backend execution as a policy-gated skills system and execution adapters
+
+The unique property none of the three currently has: **identity-portable, policy-gated, multi-backend execution with a persistent learning loop.**
+
+### Core thesis
+
+```
+Product identity is canonical.               (agent-assistant principle — keep)
+Execution harnesses are replaceable.         (agent-assistant principle — implement fully)
+Learning is policy-gated.                    (new principle — skills don't auto-promote without approval)
+Platform reach is surface adapters.          (OpenClaw pattern — composable, not a daemon)
+Skills are turn-context enrichment inputs.   (Hermes pattern — formalized with SDK contracts)
+```
+
+---
+
+## 4. New Package: `@agent-assistant/skills`
+
+This is the primary new package. It closes the gap that neither OpenClaw nor Hermes solves cleanly.
+
+### 4.1 Design Principles
+
+- Skills are **turn-context enrichment inputs**, not filesystem prompt injections
+- Skills are **policy-gated**: no skill promotes to active without an approval decision
+- Skills are **versioned**: each promotion creates a new version, old versions are retained
+- Skills are **prunable**: deprecated skills are marked, not silently deleted
+- Skills are **provenance-tracked**: `'trajectory' | 'authored' | 'imported'`
+- Skills are **agentskills.io compatible** for interop with Hermes and ClawHub
+
+### 4.2 Core Types
+
+```typescript
+interface Skill {
+  id: string;
+  version: string;
+  name: string;
+  description: string;
+  trigger: SkillTrigger;
+  body: SkillBody;
+  provenance: 'trajectory' | 'authored' | 'imported';
+  approvalStatus: 'pending' | 'approved' | 'deprecated';
+  usageStats: SkillUsageRecord[];
+  createdAt: string;
+  lastUsedAt?: string;
+}
+
+interface SkillTrigger {
+  type: 'semantic' | 'keyword' | 'domain' | 'explicit';
+  pattern: string;
+  confidence?: number;  // minimum match confidence for semantic triggers
+}
+
+interface SkillBody {
+  enrichmentText: string;         // injected into turn-context as enrichment
+  toolHints?: string[];           // suggested tools to surface
+  voiceOverride?: Partial<AssistantTraits['voice']>;  // optional turn-scoped identity shaping
+}
+
+interface SkillRegistry {
+  query(input: TurnContextInput): Promise<Skill[]>;
+  promote(trajectoryId: string, candidate: SkillCandidate): Promise<Skill>;
+  approve(skillId: string, version: string): Promise<Skill>;
+  deprecate(skillId: string, reason: string): Promise<void>;
+  import(source: 'openclaw' | 'hermes' | 'agentskills', path: string): Promise<Skill[]>;
+  export(skillId: string, format: 'agentskills' | 'openclaw'): Promise<SkillExport>;
+}
+```
+
+### 4.3 Trajectory-to-Skill Promotion Pipeline
+
+The `.trajectories/` infrastructure already exists in this repo. The promotion pipeline is:
+
+```
+trajectory completed
+  → proactive engine fires post-task analysis
+  → SkillExtractor analyzes trajectory for reusable patterns
+  → SkillCandidate created with provenance: 'trajectory'
+  → policy.evaluate({ type: 'skill-promotion', candidate })
+  → if approved: skill.approvalStatus = 'approved', added to registry
+  → on next relevant turn: registry.query() returns skill as enrichment input
+  → turn-context assembler includes skill.body.enrichmentText
+```
+
+This is better than Hermes: the loop is policy-gated. Better than OpenClaw: skills are enrichment inputs with formal contracts, not SKILL.md files injected into a flat prompt.
+
+### 4.4 Turn-Context Integration
+
+```typescript
+// In turn-context assembler (extend TurnContextInput)
+interface TurnContextInput {
+  // ... existing fields
+  skillEnrichment?: {
+    registry: SkillRegistry;
+    maxSkills?: number;      // default 3 — avoid context bloat
+    minConfidence?: number;  // default 0.7
+  };
+}
+
+// SkillRegistry.query() runs at assembly time, not at harness time
+// Skills enrich context before execution — they do not replace identity
+```
+
+---
+
+## 5. Dynamic Traits: Honcho-Pattern User Modeling
+
+### 5.1 Problem
+
+`@agent-assistant/traits` provides a stable identity floor, but it is static. Neither OpenClaw (static SOUL.md) nor Hermes (Honcho runs outside formal primitive stack) handles this correctly.
+
+### 5.2 Design
+
+Add `DynamicTraitOverlay` to `@agent-assistant/traits`:
+
+```typescript
+interface DynamicTraitOverlay {
+  sessionId: string;
+  userId?: string;
+  proposedAt: string;
+  approvalStatus: 'pending' | 'applied' | 'rejected';
+  changes: Partial<AssistantTraits>;
+  evidence: string[];  // trajectory IDs or session summaries supporting this change
+  confidence: number;
+}
+
+interface DynamicTraitsProvider {
+  getEffectiveTraits(base: AssistantTraits, context: TurnContextInput): Promise<AssistantTraits>;
+  proposeOverlay(evidence: TraitEvidence): Promise<DynamicTraitOverlay>;
+  approveOverlay(overlayId: string): Promise<void>;
+  rejectOverlay(overlayId: string): Promise<void>;
+}
+```
+
+### 5.3 Composition at Turn-Context Assembly Time
+
+```
+stable AssistantTraits (traits package — unchanged)
+  + approved DynamicTraitOverlay (per user, per context)
+  = effectiveTraits fed into TurnContextAssembler
+```
+
+Dynamic overlays are **not** harness inputs. They compose at turn-context assembly time. This means they survive execution backend swaps — which is the property neither Hermes's Honcho nor OpenClaw's SOUL.md has.
+
+### 5.4 Proactive Engine Integration
+
+After each session, the proactive engine can propose overlay candidates based on:
+- Communication style signals from session transcript
+- Domain preference signals from trajectory
+- Explicit user feedback events
+
+These are policy-evaluated before application. A user expressing "please be more concise" does not immediately change traits — it creates a `DynamicTraitOverlay` in `pending` state.
+
+---
+
+## 6. Surface Adapters: Platform Gateway Without a Daemon
+
+### 6.1 Problem
+
+OpenClaw's gateway is a separate daemon with its own session management, lifecycle, and routing. This means it cannot be embedded as a library, tested in isolation, or composed with other SDK primitives cleanly.
+
+Hermes's gateway has the same problem.
+
+### 6.2 Design
+
+Platform integrations should be `@agent-assistant/surfaces` implementations — `InboundSurfaceAdapter` and `OutboundSurfaceAdapter` pairs:
+
+```typescript
+// Usage — not a daemon, a surfaces configuration
+const runtime = createAssistant({
+  id: 'my-assistant',
+  traits,
+  surfaces: [
+    createTelegramSurface({ token: process.env.TELEGRAM_TOKEN, dmPolicy: 'paired-only' }),
+    createSlackSurface({ token: process.env.SLACK_TOKEN, allowChannels: ['#general'] }),
+    createDiscordSurface({ token: process.env.DISCORD_TOKEN }),
+    createWebhookSurface({ path: '/webhook', secret: process.env.WEBHOOK_SECRET }),
+  ],
+});
+
+await runtime.start();
+```
+
+### 6.3 Platform Surface Priority Order
+
+| Platform | Priority | Notes |
+|---|---|---|
+| Telegram | High | Hermes's best-documented platform; large agent-user base |
+| Slack | High | OpenClaw's enterprise-facing channel; existing in surfaces package |
+| Discord | Medium | OpenClaw/Hermes both support; community use |
+| WhatsApp | Medium | OpenClaw supports; requires Business API approval |
+| Email | Low | Hermes supports via gateway; lower priority for SDK |
+| Voice (macOS) | Low | OpenClaw's differentiator; requires native companion app |
+
+### 6.4 DM Pairing Policy
+
+Adopt OpenClaw's DM pairing model as a `SurfacePairingPolicy` in the policy package:
+
+```typescript
+type DmPolicy = 'open' | 'paired-only' | 'allowlist';
+
+interface SurfacePairingPolicy {
+  defaultDmPolicy: DmPolicy;
+  allowFrom: string[];   // explicit sender allowlist
+  requireApproval: boolean;  // whether unknown senders get a pairing code flow
+}
+```
+
+This is better than OpenClaw because it is formally evaluated by the policy package — not hardcoded in the gateway daemon config.
+
+---
+
+## 7. Multi-Backend Execution Adapters
+
+The BYOH/execution-adapter architecture is already fully specced in `SPEC.md` and `docs/architecture/agent-assistant-runtime-primitive-map.md`. This section maps the Hermes 7-backend model onto execution adapters.
+
+### 7.1 Adapter Implementation Priority
+
+| Adapter | Backend | Priority | Capability Notes |
+|---|---|---|---|
+| `BuiltInHarnessAdapter` | `@agent-assistant/harness` | **Critical — ship first** | Native tool use, structured continuation, approval interrupts |
+| `ClaudeAPIAdapter` | Anthropic Claude API | High | Native tool use; continuation via opaque resume; no approval interrupts |
+| `DockerSandboxAdapter` | Docker container + harness | High | Isolated execution; maps to OpenClaw sandbox model |
+| `SSHAdapter` | Remote SSH host + harness | Medium | Hermes SSH backend pattern |
+| `ModalAdapter` | Modal serverless | Medium | Hermes serverless hibernation pattern |
+| `CodexAdapter` | OpenAI Codex | Low | Degraded continuation; no approval interrupts |
+
+### 7.2 Capability Negotiation Matrix
+
+Each adapter's `describeCapabilities()` should return honest values:
+
+| Capability | BuiltIn | ClaudeAPI | DockerSandbox | SSH | Modal |
+|---|---|---|---|---|---|
+| `toolUse` | `native-iterative` | `native-iterative` | `adapter-mediated` | `adapter-mediated` | `adapter-mediated` |
+| `continuationSupport` | `structured` | `opaque-resume` | `structured` | `structured` | `opaque-resume` |
+| `approvalInterrupts` | `native` | `none` | `adapter-mediated` | `none` | `none` |
+| `traceDepth` | `detailed` | `standard` | `detailed` | `standard` | `minimal` |
+| `attachments` | `false` | `true` | `false` | `false` | `false` |
+| `maxContextStrategy` | `large` | `large` | `large` | `medium` | `medium` |
+
+The product runtime decides how to handle each `degraded: true` case — not the adapter.
+
+---
+
+## 8. Implementation Roadmap
+
+### Phase 0: Unblock (already in SPEC.md — do first)
+
+- [ ] Resolve `@agent-relay/memory` dependency — publish or extract standalone interface
+- [ ] Fix `@agent-assistant/connectivity` package.json exports for vitest
+- [ ] Re-run coordination tests and confirm all pass
+- [ ] Rebuild and republish all wave-1 npm packages with correct dist/ artifacts
+
+### Phase 1: Execution Adapter (already in SPEC.md)
+
+- [ ] Create `@agent-assistant/execution-adapter` with types from `v1-execution-adapter-spec.md`
+- [ ] Implement `BuiltInHarnessAdapter` (~150 lines)
+- [ ] Add `toExecutionRequest()` on `@agent-assistant/turn-context`
+- [ ] Add `fromExecutionResult()` on `@agent-assistant/continuation`
+- [ ] Write conformance test suite for any future adapter
+
+### Phase 2: Skills Package (new)
+
+- [ ] Create `@agent-assistant/skills` package with `Skill`, `SkillTrigger`, `SkillBody`, `SkillRegistry` types
+- [ ] Implement filesystem-backed `SkillRegistry` (agentskills.io compatible format)
+- [ ] Add `skillEnrichment` input to `TurnContextInput` in `@agent-assistant/turn-context`
+- [ ] Add `SkillExtractor` to `@agent-assistant/proactive` — fires post-task, creates `SkillCandidate`
+- [ ] Add skill-promotion to `@agent-assistant/policy` action classification
+- [ ] Integration test: trajectory → candidate → approval → enrichment → turn execution
+- [ ] Add `import` from OpenClaw (`SKILL.md` format) and Hermes (`~/.hermes/skills/`) for migration
+
+### Phase 3: Dynamic Traits (new)
+
+- [ ] Add `DynamicTraitOverlay` and `DynamicTraitsProvider` to `@agent-assistant/traits`
+- [ ] Wire overlay composition into `TurnContextAssembler.assemble()` before harness projection
+- [ ] Add overlay proposal to `@agent-assistant/proactive` post-session analysis
+- [ ] Add overlay approval to `@agent-assistant/policy` action classification
+- [ ] Integration test: session signal → overlay proposal → policy approval → effective traits on next turn
+
+### Phase 4: Platform Surface Adapters (new)
+
+- [ ] Add `@agent-assistant/surface-telegram` — `InboundSurfaceAdapter` + `OutboundSurfaceAdapter`
+- [ ] Add `@agent-assistant/surface-slack` (may already be partially implemented in surfaces)
+- [ ] Add `@agent-assistant/surface-discord`
+- [ ] Add `SurfacePairingPolicy` to `@agent-assistant/policy` for DM pairing model
+- [ ] Integration test: inbound Telegram message → sessions → turn-context → harness → outbound reply
+
+### Phase 5: Additional Execution Adapters
+
+- [ ] Implement `ClaudeAPIAdapter` — prove degraded continuation path end-to-end
+- [ ] Implement `DockerSandboxAdapter` — maps to OpenClaw sandbox model
+- [ ] Run conformance suite against all adapters
+- [ ] Document adapter authoring guide
+
+### Phase 6: Hardening
+
+- [ ] Update all package versions to 0.2.0 (skills + dynamic traits release)
+- [ ] Full test suite target: 800+ passing, 0 blocked suites
+- [ ] Publish all packages with correct dist/ artifacts
+- [ ] Update `docs/index.md` with synthesis architecture section
+- [ ] Add reference examples: Telegram-connected assistant with skill learning loop
+
+---
+
+## 9. Competitive Differentiation Summary
+
+### vs OpenClaw
+
+| Property | OpenClaw | This |
+|---|---|---|
+| SDK — importable as library | No — daemon only | Yes |
+| Capability negotiation | No | Yes — `negotiate()` before every execution |
+| Policy governance | Ad hoc config | Formal `@agent-assistant/policy` |
+| BYOH — swap execution backend | No | Yes — identity portable across backends |
+| Learning loop | Static SKILL.md files | Policy-gated trajectory-to-skill promotion |
+| Dynamic identity | Static SOUL.md | `DynamicTraitOverlay` composing at assembly time |
+| Platform reach | 20+ platforms (daemon) | Surface adapters (composable, testable) |
+| Cloudflare Workers compatible | No | Yes |
+
+### vs Hermes Agent
+
+| Property | Hermes | This |
+|---|---|---|
+| TypeScript SDK | No — Python-first | Yes |
+| Formal package contracts | No | Yes — 16 packages with explicit boundaries |
+| Capability negotiation | No — backends picked, not negotiated | Yes |
+| Policy governance | No — learning loop runs ungated | Yes — policy gate on every skill promotion |
+| Skill versioning and pruning | Minimal | Explicit `approve`, `deprecate` lifecycle |
+| Identity portable across backends | No — no identity primitive | Yes — traits compose before harness |
+| Relay-native fabric | No | Yes |
+| Research/training infrastructure | Yes — trajectory compression | Yes — `.trajectories/` + `trail` |
+| Edge/serverless deployment | Partial (Modal, Vercel) | Yes — Workers compatible |
+
+### vs Both
+
+The unique property: **identity is provably portable across execution backends, and the learning loop is policy-gated.**
+
+Neither OpenClaw nor Hermes has both. OpenClaw has no backend portability. Hermes has backend portability but no identity primitive and no policy gate. This architecture has both by design — because the governing principle is *"product identity is canonical, execution harnesses are replaceable"* and the new principle is *"learning is policy-gated."*
+
+---
+
+## 10. What to Skip (and Why)
+
+| Pattern | Source | Reason to Skip |
+|---|---|---|
+| Daemon gateway architecture | OpenClaw, Hermes | Platform integrations must be surface adapters — testable, embeddable, not a parallel runtime |
+| Ungated autonomous skill promotion | Hermes | Skills that self-improve without approval create governance risk and skill bloat |
+| Static SOUL.md persona | OpenClaw | Identity that can't evolve is not an identity primitive — it's a config file |
+| Python-first implementation | Hermes | TypeScript SDK purity is a core differentiator for edge/Workers deployments |
+| Monolithic tool registry | OpenClaw | Tool choice belongs upstream per turn per the existing harness spec |
+| Over-abstracted middleware chains | General | The adapter is a seam, not a pipeline |
+| Consumer UX patterns | Both | This is an SDK — UX belongs in the product layer |
+
+---
+
+## Appendix A: Governing Principles (Extended)
+
+The original principle from this repo:
+> Product identity is canonical. Execution harnesses are replaceable. Relay remains the coordination fabric.
+
+Two new principles added by this synthesis:
+> Learning is policy-gated. No skill or trait overlay becomes active without an explicit approval decision.
+
+> Platform reach is surface adapters. No platform integration should require a separate daemon or runtime.
+
+These three principles together define what makes this architecture superior to both reference frameworks.
+
+---
+
+## Appendix B: Migration Paths
+
+For users of OpenClaw or Hermes who want to adopt this SDK:
+
+**From OpenClaw:**
+1. `SKILL.md` files → `SkillRegistry.import('openclaw', path)` — converted to `Skill` with `provenance: 'imported'`, `approvalStatus: 'pending'`
+2. `SOUL.md` → `AssistantTraits` base definition — one-time migration
+3. `AGENTS.md` / `TOOLS.md` → product-owned turn-context shaping (product intelligence layer)
+4. Sandbox config → `DockerSandboxAdapter` capability negotiation
+
+**From Hermes:**
+1. `~/.hermes/skills/` → `SkillRegistry.import('hermes', path)` — agentskills.io compatible
+2. Provider config → `ExecutionAdapter` selection via `@agent-assistant/routing`
+3. `trajectory_compressor.py` outputs → compatible with `.trajectories/compacted/` format
+4. Honcho user modeling → `DynamicTraitOverlay` proposals from `@agent-assistant/proactive`


### PR DESCRIPTION
Deep comparison of openclaw/openclaw and NousResearch/hermes-agent against the
agent-assistant SDK. Identifies what each does well, where each falls short, and
proposes a concrete architecture that combines all three strengths.

Key additions specified:
- @agent-assistant/skills — policy-gated trajectory-to-skill promotion pipeline
- DynamicTraitOverlay — Honcho-pattern user modeling composing at assembly time
- Platform surface adapters — Telegram, Slack, Discord as surfaces implementations (not a daemon)
- Multi-backend execution adapter matrix — maps Hermes 7-backend model to ExecutionAdapter
- Migration paths from both OpenClaw (SKILL.md) and Hermes (~/.hermes/skills/)

Governing principles extended:
  "Learning is policy-gated. Platform reach is surface adapters."

https://claude.ai/code/session_0161bPaoc8gKK3JgZZDEdt2V