### PR TITLE
fix(ci): harden publish workflow package matrix validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,6 +135,17 @@ jobs:
           echo "Publishing Agent Assistant package group: ${{ github.event.inputs.package_group }}"
           echo "Packages: ${{ needs.resolve-packages.outputs.package_list }}"
 
+      - name: Validate publish matrix packages exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          for pkg in $(echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -r '.[]'); do
+            if [ ! -f "packages/$pkg/package.json" ]; then
+              echo "ERROR: publish matrix references missing package directory packages/$pkg" >&2
+              exit 1
+            fi
+          done
+
       # Tests import from @agent-assistant/* siblings whose package.json
       # exports point at dist/. dist/ is not committed, so every dep that
       # any test in the matrix imports must be built before vitest runs.
@@ -186,6 +197,12 @@ jobs:
           # Topological build order. dist/ is no longer committed, so each
           # package's tsc needs its workspace deps' dist on disk first.
           ORDER=(traits persona dispatch connectivity memory vfs core coordination surfaces sessions policy harness turn-context proactive inbox continuation telemetry specialists sdk webhook-runtime cloudflare-runtime)
+          for pkg in $(echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -r '.[]'); do
+            if ! printf '%s\n' "${ORDER[@]}" | grep -qx "$pkg"; then
+              echo "ERROR: package '$pkg' is in publish matrix but missing from dependency-aware build order" >&2
+              exit 1
+            fi
+          done
           for pkg in "${ORDER[@]}"; do
             if echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -e --arg pkg "$pkg" '.[] | select(. == $pkg)' >/dev/null; then
               echo "==> Building $pkg"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,6 +297,17 @@ jobs:
           set -euo pipefail
           mkdir -p /tmp/publish-artifacts
           for pkg in $(echo '${{ needs.resolve-packages.outputs.matrix }}' | jq -r '.[]'); do
+            if [ ! -f "packages/$pkg/package.json" ]; then
+              echo "ERROR: packages/$pkg/package.json is missing" >&2
+              exit 1
+            fi
+
+            if [ ! -d "packages/$pkg/dist" ]; then
+              echo "ERROR: packages/$pkg/dist is missing after build. The publish matrix includes a package that did not produce build artifacts." >&2
+              echo "Package: $pkg" >&2
+              exit 1
+            fi
+
             cp -R "packages/$pkg/dist" "/tmp/publish-artifacts/dist-$pkg"
             cp "packages/$pkg/package.json" "/tmp/publish-artifacts/manifest-$pkg.json"
           done


### PR DESCRIPTION
## Summary

Fix the `publish.yml` failure mode behind the failed publish run:
- old workflow matrix included packages that no longer existed or were not present in the dependency-aware build order
- artifact upload then failed later with opaque `cp: cannot stat .../dist`

This PR hardens the workflow in two ways:

1. fail clearly when a matrix package does not produce build artifacts
2. fail early when the publish matrix references:
   - a missing package directory, or
   - a package omitted from the dependency-aware build order

## Root cause from the failed run

The failed run on `main` (`26327788454`) used a workflow revision where:
- the publish matrix still included `persona` and `dispatch`
- the dependency-aware `ORDER=(...)` build list did **not** include `dispatch`
- `packages/dispatch/dist` was never produced
- `Upload build artifacts` then failed with:
  - `cp: cannot stat 'packages/dispatch/dist'`

## Changes

- add explicit checks in `Upload build artifacts` for:
  - `packages/$pkg/package.json`
  - `packages/$pkg/dist`
- add a `Validate publish matrix packages exist` step before build/test loops
- validate that every package in the publish matrix is present in the dependency-aware build order before running the build loop

## Why this helps

Instead of a late opaque artifact-copy failure, the workflow now fails with a precise, actionable error when the matrix and repo/build order drift apart.

## Commits

- `6dc68f6` fix(ci): fail clearly when publish artifacts are missing
- `9c3906e` fix(ci): validate publish matrix against repo and build order
