### PR TITLE
fix: add cloudflare runtime license metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3674,6 +3674,7 @@
     "packages/cloudflare-runtime": {
       "name": "@agent-assistant/cloudflare-runtime",
       "version": "0.4.35",
+      "license": "MIT",
       "dependencies": {
         "@agent-assistant/continuation": "^0.3.4",
         "@agent-assistant/surfaces": "^0.3.0",

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -32,6 +32,7 @@
     "type": "git",
     "url": "https://github.com/AgentWorkforce/agent-assistant"
   },
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary
- Adds `license: "MIT"` to `@agent-assistant/cloudflare-runtime` package metadata.
- Mirrors the repository root MIT license in `package-lock.json` for the workspace package.
- Leaves runtime code, exports, dependencies, versioning, and Cloudflare behavior unchanged.

## Validation
- `node` metadata assertion for package.json + package-lock
- `cd packages/cloudflare-runtime && npm pack --dry-run --json`
- `git diff --check`

## Executor revalidation — 2026-06-14
- PR remains current against upstream `main` (`upstream/main...HEAD` = `0 1`).
- Rechecked the diff is metadata-only: `package-lock.json` + `packages/cloudflare-runtime/package.json`, 2 insertions.
- Validation passed: package metadata assertion, `cd packages/cloudflare-runtime && npm pack --dry-run --json`, and `git diff --check upstream/main...HEAD`.
- Scope remains no runtime/source-code changes; this only mirrors the repository MIT license into the published package metadata.
